### PR TITLE
chore(governance): Add branching model enforcement

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,23 @@
+name: Enforce Branching Model
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name compliance
+        run: |
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          echo "Checking if merge comes from release/ or hotfix/..."
+          
+          # Regex checks if the branch begins with release/ or hotfix/
+          if [[ ! $SOURCE_BRANCH =~ ^(release\/|hotfix\/) ]]; then
+            echo "❌ ERROR: Merges to main are only allowed from 'release/*' or 'hotfix/*' branches."
+            echo "Your branch is named: $SOURCE_BRANCH"
+            exit 1
+          fi
+          
+          echo "✅ Branch name '$SOURCE_BRANCH' is valid for merging to main."


### PR DESCRIPTION
## Summary
governance.yml added to enforce merging to main only from release/* and hotfix/* branches

## Requirements Implemented
none

## Safety Considerations
- [n/a] Reviewed Safety Traceability Matrix
- [n/a] No new hazards introduced
- [n/a] Existing mitigations preserved
- [n/a] P1 isolation maintained (no new P2/P3 imports in core.py)

## Testing
- [n/a] Unit tests added/updated
- [n/a] Integration tests pass
- [n/a] Manual testing performed

## Documentation
- [n/a] API docs updated (if applicable)
- [n/a] README updated (if applicable)
- [n/a] Changelog entry added