### PR TITLE
docs(doc): minor formatting and workflow naming fixes in ADRs

### DIFF
--- a/docs/architecture/adr/300-DEV-documentation-as-code.md
+++ b/docs/architecture/adr/300-DEV-documentation-as-code.md
@@ -3,7 +3,7 @@
 * **Status:** Accepted
 * **Date:** 2026-02-20
 
-## Context:
+## Context
 
 In complex, safety-critical projects like AeroDash, the "Why" behind architectural decisions is often lost over time. This leads to architectural drift, where original safety guarantees or structural choices are accidentally bypassed. Furthermore, new contributors lack a historical record to learn from, resulting in a steeper onboarding curve and repeated discussions. We need a way to ensure all architectural decisions—both for the product and the development process—are transparent, traceable, and persistent.
 

--- a/docs/architecture/adr/303-DEV-ticket-workflow.md
+++ b/docs/architecture/adr/303-DEV-ticket-workflow.md
@@ -18,7 +18,7 @@ As AeroDash grows, managing the backlog, tracking in-progress work, and correlat
 We will use a canonical GitHub Project Board ("AeroDash Backlog") driven by specific, rule-based transitions.
 
 1.  **Tagging:** All issues must be categorized by Type (`Bug`, `Feature`, `Task`) and by safety impact (`safety-critical`).
-2.  **Board Columns:** The board must use specific columns mapping to the development lifecycle (`Backlog/Accepted`, `In Progress`, `In Verification`, `Ready for Release`, `Done`).
+2.  **Board Columns:** The board must use specific columns mapping to the development lifecycle (`Backlog`, `Accepted`, `In Progress`, `In Verification`, `Ready for Release`, `Done`).
 3.  **Parent/Sub-Task Rules:** 
     *   `Task` tickets (sub-tasks) can be closed as soon as their specific PR is merged to `develop`.
     *   Parent tickets (`Feature` or `Bug`) **cannot** advance to `Ready for Release` until **all** corresponding sub-tasks are closed. 


### PR DESCRIPTION
### Summary
This PR commits two minor unpublished changes discovered during previous documentation work:
1. Removed trailing colon from the `Context` header in `300-DEV-documentation-as-code.md` to perfectly match the ADR template.
2. Updated the column names list from `(Backlog/Accepted, ...)` to `(Backlog, Accepted, ...)` in `303-DEV-ticket-workflow.md` to reflect the current GitHub Project Board structure.

### Related Issues
N/A

### Issue State Management (Post-Merge)
<!-- Delete the following lines if not applicable: -->
- [x] If merging to `develop`: Changed Issue Label to `ready` & Project Status to `Ready for Release`

### Affected Items
- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates
- [X] **Requirements:** N/A
- [X] **Architecture:** Updated `300-DEV-documentation-as-code.md`, `303-DEV-ticket-workflow.md`
- [X] **Risk Management:** N/A
- [X] **Journeys:** N/A
- [X] **Code Docs:** N/A

### Safety Considerations
- [X] Checked Safety Traceability Matrix.
- [X] No new hazards introduced.
- [X] Existing mitigations preserved.
- [X] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist
- [X] **Target Branch:** This PR correctly targets `develop` (features/bugs)
- [X] **Unit Tests:** N/A.
- [X] **Integration Tests:** N/A.
- [X] **Manual Testing:** N/A.
- [X] **DoD:** All Definition of Done items from the linked Sub-Task/Feature/Bug are met.
- [X] **Review:** I have performed a self-review of my own code and documentation.
- [X] **ADR:** Does this change require an Architectural Decision Record (ADR) update/creation? If yes, it is included.
