### PR TITLE
docs(repo): user documentation & dependency licensing policy (#31, #36)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,78 @@
+# Dependency Management & Licensing Policy
+
+AeroDash is licensed under **AGPL-3.0**. All third-party dependencies — software libraries, assets, fonts, and data — must be license-compatible. This document defines the approved licenses, the vetting process, and the current dependency inventory.
+
+---
+
+## Approved Licenses
+
+### Software Dependencies (npm packages, submodules, tools)
+
+| Status | Licenses |
+| :--- | :--- |
+| ✅ **Approved** | MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, GPL-3.0, AGPL-3.0, LGPL-3.0, EUPL-1.2 |
+| ⚠️ **Review Required** | LGPL-2.1, MPL-2.0, GPL-2.0-or-later |
+| ❌ **Prohibited** | GPL-2.0-only, JSON License, SSPL, proprietary, no-license / unlicensed |
+
+### Asset Dependencies (icons, images, fonts, map data)
+
+| Status | Licenses |
+| :--- | :--- |
+| ✅ **Approved** | CC0 (Public Domain), CC BY 3.0, CC BY 4.0, CC BY-SA 4.0, OFL (SIL Open Font License) |
+| ⚠️ **Review Required** | CC BY-SA 3.0 (older share-alike terms) |
+| ❌ **Prohibited** | CC BY-NC (any version), CC BY-ND (any version), CC BY-NC-ND (any version), proprietary |
+
+### Rationale for Key Decisions
+
+- **GPL-3.0 / AGPL-3.0:** Compatible — AGPL §13 explicitly allows combining with GPL-3.0 works.
+- **EUPL-1.2:** Compatible — its Appendix lists GPL-3.0 and AGPL-3.0 as compatible licenses. Relevant for EU-funded aviation tools and data.
+- **GPL-2.0-only:** Prohibited — cannot be upgraded to GPL-3.0, making it incompatible with AGPL-3.0.
+- **JSON License:** Prohibited — the clause *"shall be used for Good, not Evil"* is legally undefined. Rejected by Debian, Fedora, and Google. Use alternatives (e.g., `json5` under MIT).
+- **CC BY-NC:** Prohibited — "Non-Commercial" conflicts with open-source freedom; prevents commercial forks.
+- **CC BY-ND:** Prohibited — "No Derivatives" prevents modifying assets (e.g., recoloring icons).
+
+---
+
+## Vetting Process
+
+Before adding any new dependency to the project, verify:
+
+1. **License:** Must be on the approved list above. If "Review Required", open a discussion in the PR.
+2. **Maintenance:** Package must be actively maintained (commits within the last 12 months).
+3. **Security:** No known critical CVEs. Run `npm audit` or check via Snyk / GitHub Advisories.
+4. **Dependency Footprint:** Avoid packages with excessive transitive dependencies.
+5. **P1 Restriction:** Safety Core (P1) modules prefer zero external runtime dependencies.
+6. **Inventory:** Add the dependency to the Current Dependencies table below in the same PR.
+
+---
+
+## Current Dependencies
+
+### Software
+
+| Package | Version | License | Purpose | Scope |
+| :--- | :--- | :--- | :--- | :---: |
+| markdownlint-cli2 | ^0.21.0 | MIT | Markdown linting | Dev |
+| husky | ^9.x | MIT | Git hooks (pre-commit, commit-msg) | Dev |
+| @commitlint/cli | ^19.x | MIT | Commit message linting | Dev |
+| @commitlint/config-conventional | ^19.x | MIT | Conventional commit rules | Dev |
+| shtracer | submodule | MIT | Traceability engine | Dev |
+
+### Assets
+
+*No third-party assets integrated yet. This table will be populated when icons, fonts, or images are added.*
+
+| Asset | Source | License | Purpose |
+| :--- | :--- | :--- | :--- |
+| — | — | — | — |
+
+---
+
+## Future Automation
+
+Once AeroDash has runtime dependencies (`src/`), automated license checking will be added:
+
+- **CI (GitHub Action):** `license-checker --failOn "GPL-2.0;SSPL;UNLICENSED"` on PRs targeting `main`.
+- **Not a Husky hook:** License scanning walks the full dependency tree — too slow for local pre-push.
+
+See also: [ADR 308-DEV](docs/architecture/adr/308-DEV-traceability-engine.md) for the traceability automation approach.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -10,7 +10,7 @@
 
 **NO CERTIFIED AVIATION DEVICE. USE AT YOUR OWN RISK.**
 
-AeroDash is an open-source flight preparation tool provided for educational, informational, and recreational purposes only. It is **not** a certified aviation tool and has not been approved by the FAA, EASA, or any other aviation regulatory authority.
+AeroDash is an open-source flight preparation tool provided for educational, informational, and recreational purposes. It is **not** a certified aviation tool and has not been approved by the FAA, EASA, or any other aviation regulatory authority.
 
 ### No Warranty
 
@@ -21,10 +21,13 @@ This software is provided "as is" and "as available", without warranty of any ki
 The ultimate responsibility for the safe operation of an aircraft rests exclusively with the Pilot in Command (PIC). By using AeroDash, you acknowledge and agree that:
 
 1. **You must verify all calculations** (including but not limited to Mass & Balance, Takeoff/Landing Performance, and Endurance) against the official, certified Aircraft Flight Manual (AFM) / Pilot's Operating Handbook (POH) specific to your aircraft before any flight.
-2. **AeroDash does not replace official flight briefings.** You must obtain all mandatory weather reports (METAR/TAF), NOTAMs, and other required briefing materials from official sources.
-3. **Data may be inaccurate.** The aircraft profiles, environmental calculations, and physical models within this software rely entirely on user input and community-contributed data models algorithms that may contain errors, omissions, or outdated information.
+2. **The official handbook always takes precedence.** In the event of any discrepancy between AeroDash outputs and the official POH or AFM of the specific airframe (as identified by its serial number), the official handbook takes precedence.
+3. **AeroDash does not replace official flight briefings.** You must obtain all mandatory weather reports (METAR/TAF), NOTAMs, and other required briefing materials from official sources.
+4. **Data may be inaccurate.** The aircraft profiles, environmental calculations, and physical models within this software rely entirely on user input and community-contributed data models and algorithms that may contain errors, omissions, or outdated information.
 
 By running, installing, or modifying this software, you unconditionally agree to release the creators and contributors of AeroDash from any and all liability resulting from its use.
+
+This disclaimer supplements — and does not replace — the warranty disclaimer in the [GNU AGPL-3.0 License](LICENSE) (§15–§16).
 
 ---
 
@@ -34,7 +37,7 @@ By running, installing, or modifying this software, you unconditionally agree to
 
 **KEIN ZERTIFIZIERTES LUFTFAHRTGERÄT. NUTZUNG AUF EIGENE GEFAHR.**
 
-AeroDash ist ein Open-Source-Tool zur Flugvorbereitung, das ausschließlich zu Bildungs-, Informations- und Freizeitzwecken bereitgestellt wird. Es ist **kein** zertifiziertes Luftfahrtgerät und wurde weder von der EASA, FAA noch einer anderen Luftfahrtbehörde zugelassen oder geprüft.
+AeroDash ist ein Open-Source-Tool zur Flugvorbereitung, das zu Bildungs-, Informations- und Freizeitzwecken bereitgestellt wird. Es ist **kein** zertifiziertes Luftfahrtgerät und wurde weder von der EASA, FAA noch einer anderen Luftfahrtbehörde zugelassen oder geprüft.
 
 ### Keine Gewährleistung (No Warranty)
 
@@ -45,7 +48,10 @@ Diese Software wird "wie besehen" ("as is") und "wie verfügbar" bereitgestellt,
 Die letztendliche Verantwortung für den sicheren Betrieb eines Luftfahrzeugs liegt ausschließlich beim verantwortlichen Luftfahrzeugführer (Pilot in Command, PIC). Durch die Nutzung von AeroDash erkennen Sie an und stimmen zu, dass:
 
 1. **Sie alle Berechnungen überprüfen müssen.** (Dies umfasst insbesondere Masse & Schwerpunkt, Start-/Landestrecken und Reichweite/Ausdauer). Diese müssen vor jedem Flug zwingend anhand des offiziellen, genehmigten Flughandbuchs (AFM / POH) Ihres spezifischen Luftfahrzeugs validiert werden.
-2. **AeroDash kein offizielles Flugbriefing ersetzt.** Sie sind verpflichtet, alle vorgeschriebenen Wetterinformationen (METAR/TAF/GAFOR), NOTAMs und andere für den Flug erforderliche Unterlagen aus offiziellen und zertifizierten Quellen zu beziehen.
-3. **Daten ungenau sein können.** Die Flugzeugprofile, Umweltberechnungen und physikalischen Modelle in dieser Software basieren vollständig auf Benutzereingaben sowie Community-basierten Daten und Algorithmen, die Fehler, Auslassungen oder veraltete Informationen enthalten können.
+2. **Das offizielle Handbuch hat stets Vorrang.** Im Falle von Abweichungen zwischen den Ausgaben von AeroDash und dem offiziellen Flughandbuch (POH/AFM) des spezifischen Luftfahrzeugs (seriennummernbezogen) haben die Daten des offiziellen Handbuchs stets Vorrang.
+3. **AeroDash kein offizielles Flugbriefing ersetzt.** Sie sind verpflichtet, alle vorgeschriebenen Wetterinformationen (METAR/TAF/GAFOR), NOTAMs und andere für den Flug erforderliche Unterlagen aus offiziellen und zertifizierten Quellen zu beziehen.
+4. **Daten ungenau sein können.** Die Flugzeugprofile, Umweltberechnungen und physikalischen Modelle in dieser Software basieren vollständig auf Benutzereingaben sowie Community-basierten Daten und Algorithmen, die Fehler, Auslassungen oder veraltete Informationen enthalten können.
 
 Durch das Ausführen, Installieren oder Ändern dieser Software erklären Sie sich bedingungslos damit einverstanden, die Entwickler und Mitwirkenden von AeroDash von jeglicher Haftung freizustellen, die sich aus der Nutzung dieser Software ergeben könnte.
+
+Dieser Haftungsausschluss ergänzt — und ersetzt nicht — den Gewährleistungsausschluss der [GNU AGPL-3.0 Lizenz](LICENSE) (§15–§16).


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

This PR closes the final two **v0.1.0-pre-alpha** documentation tickets by enhancing the legal disclaimer and establishing a formal dependency management policy.

**Issue #36 — User Documentation:**

- Enhanced `DISCLAIMER.md` with **POH primacy clause** (EN + DE): the official handbook of the specific airframe (serial-number-bound) always takes precedence over AeroDash
- Added **AGPL-3.0 license cross-reference** (§15–§16) to both EN and DE sections
- Softened 'only' in purpose statement to avoid reading as a license restriction
- Fixed typo: 'data models algorithms' → 'data models and algorithms'

**Issue #31 — Dependency Management & Licensing Policy:**

- Created `DEPENDENCIES.md` with two-section license policy:
  - **Software:** MIT, Apache-2.0, BSD, ISC, GPL-3.0, AGPL-3.0, LGPL-3.0, EUPL-1.2 (approved); GPL-2.0-only, JSON License, SSPL (prohibited)
  - **Assets:** CC0, CC BY 3.0/4.0, CC BY-SA 4.0, OFL (approved); CC BY-NC, CC BY-ND (prohibited)
- Documented rationale for key decisions (JSON License, EUPL, GPL-2.0-only, CC restrictions)
- Defined 6-point vetting process for new dependencies
- Listed current dependency inventory (5 dev deps)
- Outlined future automation plan (`license-checker` in CI when `src/` exists)

### Related Issues

- Ref #31
- Ref #36

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Changed Issue Label to `ready` & Project Status to `Ready for Release`

### Affected Items

- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: No requirement changes)
- [x] **Architecture:** `N/A` (Reason: No architectural changes)
- [x] **Risk Management:** `N/A` (Reason: No hazard changes)
- [x] **Journeys:** `N/A` (Reason: No journey changes)
- [x] **Code Docs:** Created `DEPENDENCIES.md`, updated `DISCLAIMER.md`

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: Documentation-only PR).
- [x] **Integration Tests:** `N/A` (Reason: Documentation-only PR).
- [x] **Manual Testing:** `N/A` (Reason: Documentation-only PR. Markdown linting passes via pre-commit hook).
- [x] **DoD:** All Definition of Done items from the linked Sub-Task/Feature/Bug are met.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` (Reason: No architectural decisions required).