### PR TITLE
docs(repo): create CHANGELOG.md for v0.1.0-pre-alpha (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-pre-alpha] - 2026-02-27
+
+Initial project foundation. This milestone establishes governance,
+developer experience tooling, and the complete product documentation suite.
+**No runtime code is included in this release.**
+
+### Added
+
+- Bilingual README and Disclaimer with intended use, system boundaries, PIC authority, and POH primacy clause
+
+### Engineering
+
+- Added full requirements suite (115 REQs across 12 modules), hazard analysis (19 hazards), and user journeys (22 UJs across 7 phases) as developer blueprints
+- Added notification system design and domain glossary
+- Added bilingual Code of Conduct with aviation Just Culture, contributing guidelines, dependency and licensing policy, and security vulnerability reporting
+- Added Gitflow strategy with protected branch rules, PR template with safety and quality checklists, and issue templates (feature, bug, sub-task)
+- Added Markdown linting (markdownlint-cli2 in CI), conventional commit enforcement (commitlint + husky hooks), and code ownership rules
+- Added shtracer engine integration, automated HTML/JSON matrix generation, and GitHub Pages deployment on release
+
+### Architecture Decision Records
+
+- ADR 001: Notification System
+- ADR 300–308 DEV: Documentation as Code, Branching Strategy, Contributing Guidelines, Ticket Workflow, Testing Guidelines, Linting Strategy, Local Hooks, Master Traceability Structure, Traceability Engine
+
+[unreleased]: https://github.com/naturelle137/AeroDash/compare/v0.1.0-pre-alpha...HEAD
+[0.1.0-pre-alpha]: https://github.com/naturelle137/AeroDash/releases/tag/v0.1.0-pre-alpha

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,7 @@ A "Good PR" is small, focused, and easy to review.
 * If your changes affect Requirements, Architecture, or Risk Mitigation, you must update the corresponding `docs/` files in the same PR.
 * **Traceability Tags:** You must include `shtracer` inline code tags (e.g., `// @IMP-SYS-001@ (FROM: @REQ-SYS-001@)`) inside your new source files linking your implementation to the upstream Master Traceability Matrix requirements.
 * **Journey Coverage:** If your PR adds or modifies a P1 requirement, verify that the requirement is tagged in at least one UJ in `docs/journeys/`. If not, extend an existing journey or propose a new one. Check with: `grep -r "@REQ-XX-YYY@" docs/journeys/`
+* **Changelog:** Add your changes under `## [Unreleased]` in `CHANGELOG.md`. Use `### Added`, `### Changed`, `### Fixed`, or `### Engineering` (for non-user-facing work). Entries are moved to the release version during the release branch.
 
 ## 7. 🏗️ P1 Constraints (The Safety Core)
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Creates the initial `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) standard.

**Structure:**
- `### Added` — 10 user-facing documentation items (README, DISCLAIMER, requirements, hazards, UJs, etc.)
- `### Developer Experience` — 14 DX/tooling/governance items (Gitflow, husky, commitlint, CI workflows, shtracer, issue/PR templates)
- `### Architecture Decision Records` — 10 ADRs (1 product + 9 DEV)

Split from #22 — this ticket covers creating the changelog. Automation remains in #22 for a later milestone.

### Related Issues

- Ref #74

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Changed Issue Label to `ready` & Project Status to `Ready for Release`

### Affected Items

- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates

- [x] **Requirements:** `N/A`
- [x] **Architecture:** `N/A`
- [x] **Risk Management:** `N/A`
- [x] **Journeys:** `N/A`
- [x] **Code Docs:** Created `CHANGELOG.md`

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: Documentation-only PR).
- [x] **Integration Tests:** `N/A` (Reason: Documentation-only PR).
- [x] **Manual Testing:** `N/A` (Reason: Documentation-only PR).
- [x] **DoD:** All Definition of Done items from the linked Sub-Task/Feature/Bug are met.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A`.