### PR TITLE
chore(dependabot): retarget updates to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   # Scan the pnpm workspace (npm ecosystem) in the frontend package
   - package-ecosystem: npm
     directory: /frontend
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -19,6 +20,7 @@ updates:
   # Scan the root pnpm workspace
   - package-ecosystem: npm
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -33,6 +35,7 @@ updates:
   # Keep GitHub Actions up to date
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday

--- a/docs/architecture/adr/301-DEV-branching-strategy.md
+++ b/docs/architecture/adr/301-DEV-branching-strategy.md
@@ -29,6 +29,8 @@ All merges into `develop` or `main` must utilize Pull Requests, complete with ne
 
 For a detailed view of the rules, naming conventions, and exact CLI commands to support this workflow, refer to [Developer Branching Strategy & Workflow Guide](../development/BRANCHING_STRATEGY.md).
 
+This includes allowing dependency update automation (e.g. `dependabot/*`) to open PRs against `develop` as long as the required checks pass.
+
 ## Consequences
 
 ### Positive

--- a/docs/development/BRANCHING_STRATEGY.md
+++ b/docs/development/BRANCHING_STRATEGY.md
@@ -34,6 +34,13 @@ develop                    ← Integration branch for next release
 * **Naming Convention:** `feature/issue-<number>` or `feature/<short-description>`
 * **Purpose:** Developing new features AND fixing non-critical bugs for an upcoming release. Always use a Pull Request to merge back into `develop`.
 
+### 1a. Dependency Update Branches (`dependabot/`)
+
+* **Branched from:** `develop` *(automated)*
+* **Must merge back into:** `develop`
+* **Naming Convention:** `dependabot/*` *(GitHub-native Dependabot naming; not configurable to `feature/*`)*
+* **Purpose:** Automated dependency updates. Treated like feature branches: must go through a PR and pass required checks before merging into `develop`.
+
 ### 2. Release Branches (`release/`)
 
 * **Branched from:** `develop`
@@ -158,6 +165,15 @@ Configure the following rules in **Settings → Branches → Branch protection r
 * ✅ Require pull request reviews
 * ✅ Require status checks to pass
 * ❌ Allow force pushes (for rebasing feature branches)
+
+#### Allow Dependabot to merge into `develop`
+
+In GitHub **branch protection** / **rulesets**, ensure PRs from `dependabot/*` are permitted to merge into `develop`:
+
+* **Base branch pattern**: `develop`
+* **Allowed source branches** (for PRs): include `feature/*`, `release/*`, `hotfix/*`, and **`dependabot/*`**
+* **Required checks**: keep the same checks as other PRs into `develop`
+* **Bypass / exceptions**: optional, but if used, apply only to Dependabot and only for `develop` (never for `main`)
 
 ### `release/*`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Configure Dependabot to open PRs against `develop` instead of the repository default branch.

## Changes
- Add `target-branch: develop` to all update blocks in `.github/dependabot.yml`.

## Notes
- GitHub-native Dependabot does **not** support custom PR branch name prefixes like `feature/dependabot-*` (it only supports changing the separator). This PR addresses the critical part (retargeting away from `main`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9060c1b-32fb-4e86-8987-0e99534538a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9060c1b-32fb-4e86-8987-0e99534538a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

