### PR TITLE
docs(repo): simplify issue lifecycle — close on develop merge, no ready/Ready for Release

### DIFF
--- a/.cursor/rules/github-issues.mdc
+++ b/.cursor/rules/github-issues.mdc
@@ -10,7 +10,7 @@ alwaysApply: false
 - scope.domain: `product` `engineering`
 - scope.module: `ac` `ap` `ad` `fe` `mb` `pf` `wx` `ui` `uq` `sys` `doc` `sc` `repo`
 - tag.safety: `safety-critical`
-- status.active: `open` `accepted` `ready`
+- status.active: `open` `accepted`
 - status.closed: `fixed` `duplicate` `wont do`
 
 - type.`Bug`: flaw error failure
@@ -19,12 +19,11 @@ alwaysApply: false
 
 - flow.create: add `open`
 - flow.`open`: `accepted` | `duplicate` | `wont do`
-- flow.`accepted`: `ready` | `wont do`
-- flow.`ready`: `fixed`
+- flow.`accepted`: `fixed` (PR merged to `develop`) | `wont do`
+- flow.close.`fixed`: PR merged to `develop` | `release/*` | `hotfix/*`; use `Closes #` keyword
 - flow.close.`duplicate`: canonical issue link required
 - flow.close.`wont do`: rationale required
-- flow.parent.`ready`: all child `Task` issues closed
-- flow.parent.`fixed`: released on `main`
+- flow.parent.`fixed`: all child `Task` issues closed first
 - flow.task.done: merged to `develop` | `release/*` | `hotfix/*`
 
 - safety.path: `frontend/src/core/`

--- a/.cursor/rules/github-pr.mdc
+++ b/.cursor/rules/github-pr.mdc
@@ -7,7 +7,7 @@ alwaysApply: false
 - repo: `naturelle137/AeroDash`
 - tools.github: `get_me` `list_branches` `search_pull_requests` `create_pull_request` `update_pull_request`
 - template: `.github/pull_request_template.md`; preserve headings, order, and checklists
-- template.issue_state: in `### Issue State Management`, delete the bullet that does not match PR base (`develop` vs `main`); keep the section
+- template.issue_state: in `### Issue State Management`, keep the bullet if merging to `develop` (the common case); delete it if merging to `main` (no open issues expected)
 - template.no_stray_markers: remove placeholder `-` / empty list lines under `### Related Issues` when filling refs
 - template.na.allow: `N/A` and Reason only on rows that literally include `OR N/A` in the template; forbid N/A on Target Branch, DoD, self-review, ADR, and Safety bullets — verify or answer honestly
 - template.na.checked: if disposition for an `OR N/A` row is N/A, fill Reason and set `[x]`; do not leave `[ ]`
@@ -18,13 +18,12 @@ alwaysApply: false
 - branch.target.`feature/*`: `develop` only
 - branch.target.`release/*`: `main` | `develop`
 - branch.target.`hotfix/*`: `main` | `develop`
-- branch.keyword.`develop`: `Ref #...` | `Related to #...`; never `Closes #...` | `Fixes #...`
-- branch.keyword.`main`: `Closes #...` | `Fixes #...` allowed
+- branch.keyword.`develop`: `Closes #...` | `Fixes #...`; closes issue on merge
+- branch.keyword.`main`: `Ref #...` only; issues already closed on develop merge
 - issue.refs.commit.prefer: reuse valid issue refs from PR commit messages
-- issue.refs.`develop`: only issues actually worked in this PR; prefer explicit refs in `<target>..HEAD` commits,reference as `Ref <issue number>`
+- issue.refs.`develop`: only issues actually worked in this PR; prefer explicit refs in `<target>..HEAD` commits; reference as `Closes <issue number>`
 - issue.refs.`develop`.fallback: if worked issues are not explicit in PR commits, ask user; never add inferred-only, newly created, or agent-created issues
-- issue.refs.`main`: only issues this PR should close, reference as `Closed <issue number>`
-- issue.refs.`main`.filter: include only when label=`ready` AND project `AeroDash Dashboard` status=`Ready for Release`; both required
+- issue.refs.`main`: no open issues expected; use `Ref #` for documentation only if needed
 - pr.duplicate.check: exact open PR match on repo + `head:<branch>` + `base:<target>`
 - pr.duplicate.on_match: update existing PR; never create a duplicate
 - changelog.file: `CHANGELOG.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,16 +3,15 @@
 <!-- Briefly describe the code and documentation changes made in this PR. -->
 
 ### Related Issues
-<!-- How Does this PR relate to tickets? Use the correct keyword for your target branch! -->
-<!-- Target: develop  -> DO NOT CLOSE. Use "Related to #" or "Ref #" (e.g., Ref #123) -->
-<!-- Target: main     -> CLOSE ISSUE.   Use "Closes #" or "Fixes #" (e.g., Closes #123) -->
+<!-- How does this PR relate to tickets? Use the correct keyword for your target branch! -->
+<!-- Target: develop  -> CLOSE ISSUE.  Use "Closes #" or "Fixes #" (e.g., Closes #123) -->
+<!-- Target: main     -> No open issues expected (already closed on develop merge). Use "Ref #" if needed. -->
 -
 
 ### Issue State Management (Post-Merge)
 <!-- Please ensure these manual steps are taken once the PR is merged: -->
 <!-- Delete the following lines if not applicable: -->
-- [ ] If merging to `develop`: Changed Issue Label to `ready` & Project Status to `Ready for Release`
-- [ ] If merging to `main`: Changed Issue Label to `fixed` & Project Status to `Done`
+- [ ] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`
 
 ### Affected Items
 <!-- What existing items are implemented or affected by these code changes? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,46 @@ Exclusions for lint: `.tools/`, `.logs/`, `node_modules/`
 
 ---
 
+## Issue Workflow for Agents
+
+When processing GitHub issues, follow these steps exactly. Full rules in `docs/architecture/adr/303-DEV-ticket-workflow.md`.
+
+### Starting Work on a Ticket
+
+1. Read the issue with `mcp__github__get_issue`.
+2. **Set project status to `In Progress`** on the `AeroDash Dashboard` project board before writing any code.
+   - Resolve project/item/field IDs via `gh project list`, `gh project item-list`, `gh project field-list`.
+   - Update: `gh project item-edit --project-id <ID> --id <ITEM_ID> --field-id <STATUS_ID> --single-select-option-id <IN_PROGRESS_ID>`
+3. Implement the work on a `feature/*` branch.
+
+### Creating the PR
+
+1. Use `.github/pull_request_template.md` as the PR body template.
+2. Reference the issue with `Closes #<ISSUE_ID>` — this closes the issue automatically on merge to `develop`.
+3. **Set project status to `In Verification`** on the project board.
+
+### After PR Merges to `develop`
+
+- GitHub auto-closes the issue and applies the `fixed` label (via `Closes #` keyword).
+- Verify the project status moved to `Done`. Correct manually if needed.
+
+### Issue Label Flow
+
+```text
+open → accepted → fixed (closed, PR merged to develop)
+open → duplicate (closed, link canonical issue)
+open → wont do  (closed, rationale documented)
+```
+
+There is **no `ready` label** and **no `Ready for Release` status**. Issues close on `develop` merge, not on `main` merge.
+
+### Parent / Sub-Task Rules
+
+- **`Task` (sub-task):** Close with `fixed` when its own PR merges to `develop`.
+- **`Feature` / `Bug` (parent):** Close with `fixed` only after **all** child `Task` issues are closed.
+
+---
+
 ## What NOT to Do
 
 - **Never** add `vue`, `pinia`, `vue-router`, or any P2/P3 import inside `src/core/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,14 +266,13 @@ We use the GitHub Project Board (`AeroDash Dashboard`) to track all tasks and en
 
 ### Workflow Statuses & Lifecycle
 
-The following diagram shows how **issue labels** transition through the lifecycle. Labels above the line (`open`, `accepted`, `ready`) are **status labels** tracking active work. Labels below (`fixed`, `duplicate`, `wont_do`) are **resolution labels** applied when closing an issue.
+The following diagram shows how **issue labels** transition through the lifecycle. Labels above the line (`open`, `accepted`) are **status labels** tracking active work. Labels below (`fixed`, `duplicate`, `wont_do`) are **resolution labels** applied when closing an issue.
 
 ```mermaid
 stateDiagram-v2
     direction LR
     state "issue Open<br/>Status: open" as open
     state "issue Open<br/>Status: accepted" as accepted
-    state "issue Open<br/>Status: ready" as ready
     state "issue Closed<br/>Resolution: fixed" as fixed
     state "issue Closed<br/>Resolution: duplicate" as duplicate
     state "issue Closed<br/>Resolution: wont do" as wont_do
@@ -283,10 +282,8 @@ stateDiagram-v2
     open --> duplicate : Exists
     open --> wont_do : Rejected
 
-    accepted --> ready : PR merged (develop)
     accepted --> wont_do : Rejected later
-
-    ready --> fixed : Released (main)
+    accepted --> fixed : PR merged (develop)
     fixed --> [*]
     duplicate --> [*]
     wont_do --> [*]
@@ -296,11 +293,10 @@ stateDiagram-v2
 
 * **`open`**: Ticket created. This is the initial default label of any new ticket.
 * **`accepted`**: The ticket is reviewed, recognized as valid, and moved to *Waiting for Implementation* on the board.
-* **`ready`**: The ticket was implemented, verified, and the PR on `develop` is done. It is now waiting for the next release phase.
 
 **Resolution Labels** (applied when closing):
 
-* **`fixed`**: The ticket is released to production (`main`). The issue is closed and moved to *Done*.
+* **`fixed`**: The PR implementing the ticket was merged to `develop`. The issue is closed and moved to *Done*.
 * **`duplicate`**: The ticket already exists. You must link the duplicate issue before closing.
 * **`wont do`**: The ticket is valid but will not be implemented. The rationale must be documented.
 
@@ -312,13 +308,11 @@ stateDiagram-v2
 | Waiting for Implementation | Triaged, valid, prioritised |
 | In Progress | Actively being worked on |
 | In Verification | PR open, under review |
-| Ready for Release | PR merged to `develop` |
-| Done | Released on `main`, issue closed |
+| Done | PR merged to `develop`, issue closed |
 
 ### ⚠️ Special Rules: Parent Tickets vs. Sub-Tasks
 
 * A **`Task`** acts as a sub-task to a parent **`Feature`** or **`Bug`**.
-* **Sub-tasks (`Task`)**: Can be closed and moved to *Done* on the project board as soon as the developer finishes the work and it is merged into `develop`, a `release/`, or a `hotfix/` branch.
-* **Parent Tickets (`Feature` / `Bug`)**: Can **only** be marked **`ready`** (and moved to *Ready for Release* on the board) when **all** of its sub-tasks are closed. *(Note: A sub-task closed as `wont do` counts as closed, provided the rationale is documented in the ticket).*
-* The parent `Feature` or `Bug` itself is only labelled **`fixed`**, closed, and moved to *Done* **after** it has been formally released on the `main` branch.
+* **Sub-tasks (`Task`)**: Are closed with `fixed` and moved to *Done* as soon as their PR is merged into `develop`, a `release/`, or a `hotfix/` branch.
+* **Parent Tickets (`Feature` / `Bug`)**: Can **only** be labelled `fixed`, closed, and moved to *Done* when **all** of its sub-tasks are closed. *(Note: A sub-task closed as `wont do` counts as closed, provided the rationale is documented in the ticket).*
 * Tickets labelled `duplicate` or `wont do` are removed from the project board entirely.

--- a/docs/architecture/adr/303-DEV-ticket-workflow.md
+++ b/docs/architecture/adr/303-DEV-ticket-workflow.md
@@ -2,14 +2,17 @@
 
 * **Status:** Accepted
 * **Date:** 2026-02-27
+* **Amended:** 2026-04-07
 
 ## Context
 
-As AeroDash grows, managing the backlog, tracking in-progress work, and correlating development tasks with production releases becomes complex. Without a rigid, predefined lifecycle for tickets, we risk releasing unverified features, losing track of sub-tasks, or cluttering the project board with stale issues. We need a defined, scalable process to govern how `Features`, `Bugs`, and `Tasks` flow from creation to completion, ensuring the Project Board accurately reflects the safety and release state of the codebase.
+As AeroDash grows, managing the backlog, tracking in-progress work, and correlating development tasks with production releases becomes complex. Without a rigid, predefined lifecycle for tickets, we risk releasing unverified features, losing track of sub-tasks, or cluttering the project board with stale issues. We need a defined, scalable process to govern how `Features`, `Bugs`, and `Tasks` flow from creation to completion, ensuring the Project Board accurately reflects the state of the codebase.
+
+**Amendment (2026-04-07):** The original workflow required a two-phase close: `ready` on merge to `develop`, then `fixed` + closed on merge to `main`. This created unnecessary overhead and deferred issue closure long past when the work was actually done. The amended workflow closes issues immediately on merge to `develop`, removing the intermediate `ready` state and `Ready for Release` board column.
 
 ## Considered Options
 
-* **Option 1:** Ad-hoc issue tracking with standard "Open/Closed" states. (Rejected: insufficient granularity to track when code is ready for release vs. actively in development).
+* **Option 1:** Ad-hoc issue tracking with standard "Open/Closed" states. (Rejected: insufficient granularity to track when code is actively in development vs. completed).
 * **Option 2:** Heavyweight Jira-style workflows requiring dedicated scrum masters. (Rejected: too much overhead for the current team size).
 * **Option 3:** Leverage a GitHub Project Board with strict, rule-based column transitions and explicit parent/sub-task relationship requirements. (Accepted).
 
@@ -20,28 +23,37 @@ We will use a canonical GitHub Project Board ("AeroDash Dashboard") driven by sp
 1. **Issue Type Labels:** All issues must be categorized by Type (`Bug`, `Feature`, `Task`).
 2. **Scope Labels:** Issues must indicate their scope via `product` (user-facing functionality) or `engineering` (development environment, tooling, documentation). This distinction determines the changelog section (`### Added`/`Changed`/`Fixed` vs. `### Engineering`).
 3. **Safety Label:** Issues impacting the P1 Safety Core must carry the `safety-critical` label, triggering extra scrutiny and ADR traceability.
-4. **Status Labels:** Issues progress through status labels reflecting their active lifecycle: `open` → `accepted` → `ready`. These labels track work in progress.
-5. **Resolution Labels:** When an issue is closed, it receives a resolution label: `fixed` (released on `main`), `duplicate` (link the existing issue), or `wont do` (document the rationale). Resolution labels are not workflow statuses — they are applied at closure.
-6. **Board Columns:** The project board uses columns that map to the development lifecycle: `Backlog`, `Waiting for Implementation`, `In Progress`, `In Verification`, `Ready for Release`, `Done`.
+4. **Status Labels:** Issues progress through status labels reflecting their active lifecycle: `open` → `accepted`. These labels track work in progress.
+5. **Resolution Labels:** When an issue is closed, it receives a resolution label: `fixed` (PR merged to `develop`), `duplicate` (link the existing issue), or `wont do` (document the rationale). Resolution labels are not workflow statuses — they are applied at closure.
+6. **Board Columns:** The project board uses columns that map to the development lifecycle: `Backlog`, `Waiting for Implementation`, `In Progress`, `In Verification`, `Done`.
 
-7. **Parent/Sub-Task Rules:**
-    * `Task` tickets (sub-tasks) can be closed as soon as their specific PR is merged to `develop`.
-    * Parent tickets (`Feature` or `Bug`) **cannot** advance to `Ready for Release` until **all** corresponding sub-tasks are closed.
-    * Parent tickets are only moved to `Done` and labelled `fixed` when the cumulative changes are released on the `main` production branch.
-8. **Traceability Checks:** Developers must ensure all Source Code and Test files contain the appropriate `shtracer` tags (e.g., `// @IMP-SYS-001@ (FROM: @REQ-SYS-001@)`) linking back to the Master Traceability Matrix before marking any ticket as `Ready for Release`.
+7. **Agent Workflow (AI Agents — Claude, Cursor):**
+    * When starting work on a ticket, the agent **must** set the project status to `In Progress` before writing any code.
+    * When a PR is created, the agent **must** set the project status to `In Verification`.
+
+8. **Issue Closure on Merge to `develop`:**
+    * All issue types (`Task`, `Feature`, `Bug`) are closed with the `fixed` label when their PR is merged to `develop` (or `release/*` / `hotfix/*`).
+    * PR must use `Closes #` / `Fixes #` keywords so GitHub closes the issue automatically on merge.
+
+9. **Parent/Sub-Task Rules:**
+    * `Task` tickets (sub-tasks) are closed individually as soon as their specific PR is merged to `develop`.
+    * Parent tickets (`Feature` or `Bug`) are closed with `fixed` and moved to `Done` only when **all** corresponding sub-tasks are closed. *(A sub-task closed as `wont do` counts as closed, provided the rationale is documented.)*
+
+10. **Traceability Checks:** Developers must ensure all Source Code and Test files contain the appropriate `shtracer` tags (e.g., `// @IMP-SYS-001@ (FROM: @REQ-SYS-001@)`) linking back to the Master Traceability Matrix before merging.
 
 ## Consequences
 
 ### Positive
 
-* **Transparency:** The Project Board perfectly mirrors the actual state of the codebase and release cycles.
-* **Safety Assurance:** By forcing parent features to wait for all sub-tasks, we prevent partial, untested functionality from slipping into a release candidate.
-* **Predictability:** Developers know exactly when to move tickets and when they are allowed to close them.
+* **Transparency:** The Project Board reflects the actual state of the codebase without a long-lived "waiting for release" limbo state.
+* **Safety Assurance:** By forcing parent features to wait for all sub-tasks, we prevent partial, untested functionality from being marked complete prematurely.
+* **Predictability:** Developers and agents know exactly when to move tickets and when they are closed.
+* **Reduced Overhead:** Removing the `ready` / `Ready for Release` intermediate state cuts one manual step per issue.
 
 ### Negative
 
-* **Manual Overhead:** Developers must remember to manually move tickets (e.g., to "In Verification" when opening a PR) and carefully manage the state of parent tickets versus sub-tasks.
+* **Manual Overhead:** Developers must remember to manually move tickets (e.g., to "In Verification" when opening a PR) and carefully manage the state of parent tickets versus sub-tasks. Agents automate this step.
 
 ## Compliance
 
-This workflow enforces the organizational discipline required for aviation software, ensuring that no requirement or mapped hazard mitigation is "lost" or prematurely marked as completed before being fully integrated and released.
+This workflow enforces the organizational discipline required for aviation software, ensuring that no requirement or mapped hazard mitigation is "lost" or prematurely marked as completed before being fully integrated.


### PR DESCRIPTION
### Summary

Changes the issue processing workflow so that issues are closed (with the `fixed` label) when their PR merges to `develop`, rather than waiting for a `main` release. Removes the intermediate `ready` label and `Ready for Release` project board column. Documents the mandatory agent workflow (set _In Progress_ on ticket start, _In Verification_ on PR creation).

### Related Issues

No specific issue — this is a process change requested by the project owner.

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** N/A

### Documentation Updates

- [x] **Requirements:** N/A (Reason: no requirements change)
- [x] **Architecture:** Updated `docs/architecture/adr/303-DEV-ticket-workflow.md` — amended to reflect new lifecycle
- [x] **Risk Management:** N/A (Reason: no hazard impact)
- [x] **Journeys:** N/A (Reason: no journey impact)
- [x] **Code Docs:** `CONTRIBUTING.md`, `CLAUDE.md`, `.github/pull_request_template.md`, `.cursor/rules/github-issues.mdc`, `.cursor/rules/github-pr.mdc` updated

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** N/A (Reason: documentation/process change only).
- [x] **Integration Tests:** N/A (Reason: documentation/process change only).
- [x] **Manual Testing:** N/A (Reason: documentation/process change only).
- [x] **DoD:** All Definition of Done items from the linked Sub-Task/Feature/Bug are met.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** ADR 303 amended and included in this PR.

---

## What changed and why

### New issue lifecycle

| Before | After |
|:---|:---|
| Merge to `develop` → label `ready`, status `Ready for Release` | Merge to `develop` → label `fixed`, issue **closed**, status `Done` |
| Merge to `main` → label `fixed`, issue closed, status `Done` | Merge to `main` → no issue state change (issues already closed) |

The `ready` status label and `Ready for Release` board column are **removed**.

### Agent workflow (enforced in rules + CLAUDE.md)

1. Start ticket → set project status **In Progress**
2. Create PR → set project status **In Verification**
3. PR merged to `develop` → issue auto-closed via `Closes #` keyword

### Files changed

| File | Change |
|:---|:---|
| `docs/architecture/adr/303-DEV-ticket-workflow.md` | Amended with new lifecycle, agent workflow, removed Ready for Release column |
| `CONTRIBUTING.md` | Updated state diagram, status labels, Kanban table, parent/sub-task rules |
| `.github/pull_request_template.md` | Updated Related Issues keywords and Issue State Management checklist |
| `.cursor/rules/github-issues.mdc` | Removed `ready` from `status.active`; updated flow rules |
| `.cursor/rules/github-pr.mdc` | `develop` PRs now use `Closes #`; removed `ready`/`Ready for Release` filter for `main` |
| `CLAUDE.md` | New "Issue Workflow for Agents" section with step-by-step instructions |

https://claude.ai/code/session_01YFqFfwACLnGsigcF7tw8WZ