### PR TITLE
chore(repo): reduce P1 Safety Core coverage target from 100% to 90%

### DIFF
--- a/.cursor/commands/implement-issue.md
+++ b/.cursor/commands/implement-issue.md
@@ -46,7 +46,7 @@ argument-hint: <ISSUE_ID>
 - `coverage.source`: `docs/testing/TESTING.md`
 - `coverage.gates.product`: modified-file thresholds mandatory
 - `coverage.gates.engineering`: no mandatory creation/thresholds unless P1
-- `coverage.gates.p1`: `100%` line + branch + function
+- `coverage.gates.p1`: `90%` line + branch + function
 - `bug.protocol`: failing test first -> minimal fix -> passing verification
 - `verify.incremental`: after each logical unit
 - `verify.coverage.cmd`: `pnpm --filter frontend vitest run --coverage`

--- a/.cursor/skills/cloud-agent-runbook.md
+++ b/.cursor/skills/cloud-agent-runbook.md
@@ -76,7 +76,7 @@ pnpm test:unit
 # Run with coverage report
 pnpm coverage:unit
 
-# Run only P1 Safety Core tests (pure Node.js, 100 % coverage required)
+# Run only P1 Safety Core tests (pure Node.js, 90 % coverage required)
 pnpm --filter frontend test:p1
 
 # Run P1 with coverage enforcement
@@ -87,7 +87,7 @@ pnpm --filter frontend test:p1:coverage
 
 1. Run the relevant unit test command above.
 2. If you touched `frontend/src/core/`, always run `test:p1:coverage` and
-   confirm 100 % line/branch/function coverage.
+   confirm 90 % line/branch/function coverage.
 3. For other tiers, run `pnpm coverage:unit` and check thresholds (P2 ≥ 80 %,
    P3 ≥ 60 %).
 
@@ -191,7 +191,7 @@ either fails, the build fails.
 │   │   ├── e2e/            Playwright BDD features + steps
 │   │   └── assets/         Golden-sample aircraft JSON fixtures
 │   ├── vitest.config.ts        General unit test config (jsdom)
-│   ├── vitest.config.p1.ts     P1 core config (node, 100 % thresholds)
+│   ├── vitest.config.p1.ts     P1 core config (node, 90 % thresholds)
 │   ├── playwright.config.ts    E2E config (BDD, Chromium)
 │   └── stryker.config.mjs      Mutation testing config
 ├── docs/                   Requirements, architecture, ADRs, journeys
@@ -203,7 +203,7 @@ either fails, the build fails.
 
 | Tier | Path              | Coverage | Environment |
 |------|-------------------|----------|-------------|
-| P1   | `src/core/`       | 100 %    | Node.js     |
+| P1   | `src/core/`       | 90 %     | Node.js     |
 | P2   | `src/modules/`    | 80 %     | jsdom       |
 | P3   | `src/shared/`, `src/stores/`, `src/plugins/`, `src/router/` | 60 % | jsdom |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run unit tests
         run: pnpm --filter frontend run test:unit
 
-      - name: P1 safety-core tests (100% coverage gate)
+      - name: P1 safety-core tests (90% coverage gate)
         run: pnpm --filter frontend run test:p1:coverage
 
   type-check:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Reference issue numbers and requirement IDs when applicable.
 
 | Tier | Path | Required Coverage |
 | :--- | :--- | :---------------- |
-| **P1** Safety Core | `frontend/src/core/` | **100%** line + branch + function |
+| **P1** Safety Core | `frontend/src/core/` | **90%** line + branch + function |
 | **P2** Feature Modules | `frontend/src/modules/` | **80%** minimum |
 | **P3** UI & Shared | `frontend/src/shared/`, `plugins/`, `stores/` | **60%** minimum |
 
@@ -227,7 +227,7 @@ Requirements live in `docs/requirements/` using **EARS syntax** (Easy Approach t
 
 Priority aligns with code tiers:
 
-- **P1** — Safety-critical (must have 100% coverage + ADR for changes)
+- **P1** — Safety-critical (must have 90% coverage + ADR for changes)
 - **P2** — Standard operational
 - **P3** — Nice-to-have / polish
 
@@ -250,7 +250,7 @@ Module identifiers: `AC`, `AP`, `AD`, `FE`, `MB`, `PF`, `WX`, `UI`, `UQ`, `SYS`,
 
 - Full lint suite (`lint:ci:oxlint` + `lint:ci:eslint`)
 - Unit + integration + E2E tests
-- Coverage thresholds enforced (P1: 100%, P2: 80%, P3: 60%)
+- Coverage thresholds enforced (P1: 90%, P2: 80%, P3: 60%)
 - P1-ISOLATION ESLint rule must produce zero violations
 
 ---
@@ -264,7 +264,7 @@ Before completing a PR that touches `src/core/`, verify:
 - [ ] `pnpm --filter frontend run lint:ci:eslint` — zero `[P1-ISOLATION]` warnings
 - [ ] All new exported functions are pure (deterministic, side-effect free)
 - [ ] All external inputs validated with Zod before reaching math logic
-- [ ] 100% line + branch + function coverage on new P1 code
+- [ ] 90% line + branch + function coverage on new P1 code
 - [ ] If a new top-level `src/` directory was added, update `no-restricted-imports` in `frontend/eslint.config.ts`
 - [ ] An ADR exists or has been updated if the P1 interface surface changed
 

--- a/docs/architecture/adr/304-DEV-testing-guidelines.md
+++ b/docs/architecture/adr/304-DEV-testing-guidelines.md
@@ -20,7 +20,7 @@ We have decided to adopt **Option 3 (Risk-Based Tiered Strategy)**.
 To formalize this, we are creating a centralized `TESTING.md` guide that defines:
 
 1. **Types of Tests:** Explicit responsibilities for Unit, Integration, and End-to-End (E2E) testing.
-2. **Coverage Minimums:** 100% for P1 modules, 80% for P2, and practical best-efforts for P3.
+2. **Coverage Minimums:** 90% for P1 modules, 80% for P2, and practical best-efforts for P3.
 3. **Mocking External Data:** A strict requirement that all environmental variables (GPS coordinates, METAR, TAF, dynamic API data) must be statically mocked when testing P1 logic to ensure tests are deterministic.
 
 ## Consequences
@@ -34,7 +34,7 @@ To formalize this, we are creating a centralized `TESTING.md` guide that defines
 ### Negative
 
 * **Higher Initial Friction:** It takes significantly more time to deliver a feature regarding P1 components, as the testing burden is exceptionally high.
-* **Maintenance Overhead:** 100% coverage requirements on P1 mean that even slight, harmless internal refactoring might break test coverage and require test rewrites.
+* **Maintenance Overhead:** 90% coverage requirements on P1 mean that internal refactoring can occasionally affect coverage thresholds and require additional tests.
 
 ## Compliance
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -58,15 +58,15 @@ Our coverage requirements correlate directly to the Priority (P1, P2, P3) of the
 
 | Priority | Label | File Path(s) | Coverage |
 | :------- | :---------------- | :-------------------------------------------- | :------- |
-| **P1** | Safety Core | `frontend/src/core/` | 100% |
+| **P1** | Safety Core | `frontend/src/core/` | 90% |
 | **P2** | Operational Logic | `frontend/src/modules/` | 80% |
 | **P3** | UI & Shared | `frontend/src/shared/`, `frontend/src/plugins/`, `frontend/src/stores/` | 60% |
 
 This table is the **single source of truth** for coverage thresholds. All agent workflows, CI gates, and review checklists MUST reference this table rather than hardcoding values.
 
 - **P1 - Safety Core (e.g., Mass & Balance, Flight Performance)**
-  - **Requirement:** **100%** Line, Branch, and Function coverage.
-  - _Rationale:_ There is zero margin for error. Every single mathematical path must be verified.
+  - **Requirement:** **90%** Line, Branch, and Function coverage.
+  - _Rationale:_ This high threshold ensures the vast majority of mathematical paths are verified while allowing for pragmatic coverage of edge cases that are difficult to exercise in isolation.
 - **P2 - Operational Logic (e.g., Weather Parsing, Route APIs)**
   - **Requirement:** **80%** coverage minimum.
   - _Rationale:_ Failures here are highly inconvenient and degrade the tool, but they should be caught by safety boundaries before impacting P1 calculations.

--- a/frontend/vitest.config.p1.ts
+++ b/frontend/vitest.config.p1.ts
@@ -8,7 +8,7 @@
  * Usage: pnpm --filter frontend test:p1
  *
  * @see docs/architecture/adr/314-DEV-dependency-isolation.md
- * @see docs/testing/TESTING.md (P1 Safety Core: 100% line/branch/function coverage)
+ * @see docs/testing/TESTING.md (P1 Safety Core: 90% line/branch/function coverage)
  */
 import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
@@ -39,10 +39,10 @@ export default mergeConfig(
           '**/mass-balance.math-types.ts',
         ],
         thresholds: {
-          lines: 100,
-          branches: 100,
-          functions: 100,
-          statements: 100,
+          lines: 90,
+          branches: 90,
+          functions: 90,
+          statements: 90,
         },
       },
       root: fileURLToPath(new URL('./', import.meta.url)),


### PR DESCRIPTION
## Summary

- Reduces the P1 Safety Core coverage threshold from 100% to 90% across all enforcement points
- Updates Vitest config thresholds (`lines`, `branches`, `functions`, `statements` → 90)
- Updates CI workflow step name and all documentation references

## Changed Files

| File | Change |
|---|---|
| `frontend/vitest.config.p1.ts` | Thresholds set to 90 for all metrics |
| `.github/workflows/ci.yml` | Step name reflects 90% gate |
| `CLAUDE.md` | 4 references updated |
| `docs/testing/TESTING.md` | Table + rationale updated |
| `docs/architecture/adr/304-DEV-testing-guidelines.md` | Coverage minimums and consequences updated |
| `.cursor/commands/implement-issue.md` | `coverage.gates.p1` updated |
| `.cursor/skills/cloud-agent-runbook.md` | 4 references updated |

## Test plan

- [x] Verify `pnpm --filter frontend vitest run --config vitest.config.p1.ts --coverage` passes with the new 90% thresholds
- [x] Verify CI pipeline passes on this PR

https://claude.ai/code/session_01U8vuFz7kPiuCoHSqxjELbJ