### PR TITLE
feat(sys): session persistence store with debounced localStorage save/restore

### DIFF
--- a/docs/requirements/system.md
+++ b/docs/requirements/system.md
@@ -131,7 +131,7 @@ This document defines the system behavior using the **EARS** (Easy Approach to R
 ### REQ-SYS-013: Session Payload Persistence
 
 **Priority:** P3
-**Status:** Approved
+**Status:** Implemented
 
 **Requirement:** When the pilot has entered preflight data, the system shall automatically serialise the active session payload to `localStorage` on each value change (debounced) and restore it on page reload, provided the restored payload passes Zod schema validation. An invalid or absent payload shall result in a clean session with no pre-population. The session payload shall be cleared when a different aircraft profile is selected.
 


### PR DESCRIPTION
### Summary

Implements P3 session persistence: `useSessionPersistenceStore` debounces auto-save of M&B pilot inputs to `localStorage`, validates and restores the payload on page reload via Zod-validated `SessionPayloadSchema` (P1), and clears state on aircraft switch.

### Related Issues

- Closes #152
- Closes #164

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-SYS-013`

### Documentation Updates

- [x] **Requirements:** REQ-SYS-013 status → Implemented in `docs/requirements/system.md`
- [x] **Architecture:** `N/A`
- [x] **Risk Management:** `N/A` (no new hazards)
- [x] **Journeys:** `N/A`
- [x] **Code Docs:** CHANGELOG.md updated under `[Unreleased]`

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (`SessionPayloadSchema` lives in `src/core/`; store is P3).

### Quality & Testing Checklist

- [x] **Target Branch:** Targets `develop`.
- [x] **Unit Tests:** 16 unit tests (UT-SYS-STORE-001–016) covering save, restore, clear, debounce, and round-trip — all passing.
- [x] **Integration Tests:** `N/A`.
- [x] **Manual Testing:** `N/A`.
- [x] **DoD:** All Definition of Done items met.
- [x] **Review:** Self-review complete.
- [x] **ADR:** `N/A`.