### PR TITLE
feat(ac): Aircraft model catalogue JSON + async fleet load states (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Aircraft model catalogue as versioned JSON (`aircraft-model-catalogue.json`) with stable row `id`s; ICAO reverse lookup auto-fills manufacturer/model when the designator matches exactly one row (closes #158)
+- `useFleetStore` fleet hydration states `fleetLoadState` (`LOADING` / `READY` / `ERROR`) and `fleetLoadError`; fleet list shows error UI with retry on IndexedDB failure (closes #158)
 - PWA Service Worker with offline-first app shell caching via `vite-plugin-pwa` and Workbox (closes #150)
 - PWA update notification (`INFO-SYS-001`) — no silent auto-update, user must confirm reload (`registerType: 'prompt'`) (closes #151)
 - Minimum safe version enforcement on startup (`useAppVersionStore.checkMinSafeVersion`) — blocks execution when local version is below minimum (REQ-SYS-006)
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Engineering
 
+- Aircraft catalogue unit tests (filter, ICAO lookup, unique designator) and `AircraftModelSelector` component tests; fleet store tests for IndexedDB load state machine (closes #158)
 - 33 unit tests (ICAO validation × 16, import × 8, fleet FSM × 9) and 4 IndexedDB integration tests all passing
 - verifyProfile() now auto-updates active aircraft context when the verified Draft was in use
 - Canonical bilinear interpolation test vectors (TOR, TOD, LR, LD) established and passing in CI — de-risk for v0.4.0 performance distance calculations (closes #155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Aircraft model catalogue as versioned JSON (`aircraft-model-catalogue.json`) with stable row `id`s; ICAO reverse lookup auto-fills manufacturer/model when the designator matches exactly one row (closes #158)
-- `useFleetStore` fleet hydration states `fleetLoadState` (`LOADING` / `READY` / `ERROR`) and `fleetLoadError`; fleet list shows error UI with retry on IndexedDB failure (closes #158)
+- `useFleetStore` fleet hydration states `fleetLoadState` (`LOADING` / `READY` / `ERROR`) and `fleetLoadError`; initial state is `LOADING` so the fleet list does not flash empty before `loadAll()`; fleet list shows error UI with retry on IndexedDB failure (closes #158)
 - PWA Service Worker with offline-first app shell caching via `vite-plugin-pwa` and Workbox (closes #150)
 - PWA update notification (`INFO-SYS-001`) — no silent auto-update, user must confirm reload (`registerType: 'prompt'`) (closes #151)
 - Minimum safe version enforcement on startup (`useAppVersionStore.checkMinSafeVersion`) — blocks execution when local version is below minimum (REQ-SYS-006)

--- a/docs/architecture/aircraft-fleet-module.md
+++ b/docs/architecture/aircraft-fleet-module.md
@@ -111,7 +111,7 @@ The `schemaVersion` field on each document enables structured migration in the
 
 | Field | Purpose |
 | :---- | :------ |
-| `fleetLoadState` | `'LOADING'` while `findAll()` is in flight; `'READY'` on success; `'ERROR'` on failure |
+| `fleetLoadState` | Initial `'LOADING'` until the first `loadAll()` completes; then `'LOADING'` while `findAll()` is in flight; `'READY'` on success; `'ERROR'` on failure |
 | `fleetLoadError` | Human-readable message when `fleetLoadState === 'ERROR'` |
 | `isLoading` | Computed alias for `fleetLoadState === 'LOADING'` (legacy) |
 

--- a/docs/architecture/aircraft-fleet-module.md
+++ b/docs/architecture/aircraft-fleet-module.md
@@ -16,13 +16,14 @@ itself strictly P2 — it may use Vue, Pinia, and browser APIs.
 ```text
 frontend/src/modules/aircraft/
 ├── data/
-│   └── aircraft-model-catalogue.ts   — Static manufacturer/model/ICAO catalogue
+│   ├── aircraft-model-catalogue.json — Static catalogue rows (manufacturer → model → ICAO)
+│   └── aircraft-model-catalogue.ts   — Imports JSON + lookup helpers (getManufacturers, etc.)
 ├── services/
 │   ├── fleet.repository.ts           — Native IndexedDB CRUD (aerodash-fleet DB)
 │   ├── profile.validator.ts          — ICAO registration validation + duplicate check
 │   └── profile.import.ts             — JSON exchange file import/export
 ├── stores/
-│   ├── fleet.store.ts                — Fleet CRUD + Draft/Verified FSM (Pinia)
+│   ├── fleet.store.ts                — Fleet CRUD + Draft/Verified FSM; IndexedDB load emits LOADING/READY/ERROR
 │   └── active-aircraft.store.ts      — In-session active aircraft context (Pinia)
 ├── components/
 │   ├── AircraftModelSelector.vue     — Manufacturer→Model→ICAO hierarchy selector
@@ -33,7 +34,9 @@ frontend/src/modules/aircraft/
 └── __tests__/
     ├── profile.validator.spec.ts     — Unit tests (UT-AC-STORE-001..016)
     ├── profile.import.spec.ts        — Unit tests (UT-AC-STORE-017..024)
-    ├── fleet.store.spec.ts           — Unit tests (UT-AC-STORE-025..033)
+    ├── aircraft-model-catalogue.spec.ts — Unit tests (UT-AC-CAT-001..005)
+    ├── AircraftModelSelector.spec.ts — Unit tests (UT-AC-VIEW-009..011)
+    ├── fleet.store.spec.ts           — Unit tests (UT-AC-STORE-025..035)
     └── fleet.repository.int.spec.ts  — Integration tests (IT-AC-STORE-001..004)
 ```
 
@@ -56,15 +59,16 @@ display. P2 never calls back into P1 — P1 functions are invoked from P2 only.
 ```text
                    ┌─────────────────────────────────┐
                    │          NEW PROFILE              │
-                   │     createProfile() → Draft       │
+                   │     createProfile() → draft       │
                    └──────────────┬──────────────────┘
                                   │
                                   ▼
                   ┌───────────────────────────────┐
-                  │           DRAFT               │◄──────────────────┐
+                  │           draft               │◄──────────────────┐
                   │  - Editable in-place          │                   │
                   │  - Emits WARN-AC-002          │                   │
-                  │    when used in calculation   │                   │
+                  │    in Mass & Balance when used  │                   │
+                  │    for computation (REQ-AC-005) │                   │
                   └─────────────┬─────────────────┘                   │
                                 │                                     │
                      verifyProfile()                    editVerifiedProfile()
@@ -72,7 +76,7 @@ display. P2 never calls back into P1 — P1 functions are invoked from P2 only.
                                 │                                     │
                                 ▼                                     │
                   ┌───────────────────────────────┐                   │
-                  │          VERIFIED             │───────────────────┘
+                  │          verified             │───────────────────┘
                   │  - Immutable (read-only)      │
                   │  - Safe for calculations      │
                   │  - updateProfile() BLOCKED    │
@@ -81,13 +85,13 @@ display. P2 never calls back into P1 — P1 functions are invoked from P2 only.
 
 ### FSM Rules
 
-| Action | From Draft | From Verified |
+| Action | From draft | From verified |
 | :----- | :--------- | :------------ |
 | `updateProfile()` | Allowed | **Blocked** — throws `VerifiedMutationError` |
-| `verifyProfile()` | Creates Verified snapshot (new UUID), deletes Draft | Error: already Verified |
-| `editVerifiedProfile()` | Error: not Verified | Creates Draft copy (new UUID), Verified unchanged |
+| `verifyProfile()` | Creates verified snapshot (new UUID), deletes draft | Error: already verified |
+| `editVerifiedProfile()` | Error: not verified | Creates draft copy (new UUID); prior verified row unchanged |
 | `deleteProfile()` | Allowed | Allowed |
-| Use in calculations | Allowed + WARN-AC-002 | Allowed, no warning |
+| Use in M&B calculation | Allowed; store prepends `WARN-AC-002` | Allowed, no draft warning |
 
 ## IndexedDB Schema
 
@@ -100,6 +104,22 @@ Database: `aerodash-fleet`, Version: `1`
 The `schemaVersion` field on each document enables structured migration in the
 `onupgradeneeded` handler without data loss. See
 [ADR-006](adr/006-indexeddb-fleet-persistence.md) for migration strategy.
+
+## Fleet list hydration (`useFleetStore`)
+
+`loadAll()` reads the full fleet from IndexedDB asynchronously. The store exposes:
+
+| Field | Purpose |
+| :---- | :------ |
+| `fleetLoadState` | `'LOADING'` while `findAll()` is in flight; `'READY'` on success; `'ERROR'` on failure |
+| `fleetLoadError` | Human-readable message when `fleetLoadState === 'ERROR'` |
+| `isLoading` | Computed alias for `fleetLoadState === 'LOADING'` (legacy) |
+
+`FleetList.vue` shows loading, error (with retry), or the profile list accordingly.
+
+## Model catalogue data
+
+Manufacturer → model → ICAO rows live in `aircraft-model-catalogue.json` (versioned source of truth). `aircraft-model-catalogue.ts` imports that JSON and exports pure helpers (`getManufacturers`, `getModelsByManufacturer`, `findByIcaoDesignator`, `findUniqueByIcaoDesignator`). Editing the catalogue means editing the JSON file only.
 
 ## Related Requirements
 

--- a/frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for AircraftModelSelector (manufacturer / model / ICAO hierarchy).
+ *
+ * @see frontend/src/modules/aircraft/components/AircraftModelSelector.vue
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AircraftModelSelector from '../components/AircraftModelSelector.vue'
+
+describe('AircraftModelSelector', () => {
+  // @UT-AC-VIEW-009@ (FROM: @IMP-AC-VIEW-003@)
+  it('selecting a model auto-fills ICAO type designator', async () => {
+    const wrapper = mount(AircraftModelSelector, {
+      props: { manufacturer: 'Tecnam', model: '', icaoTypeDesignator: '' },
+    })
+
+    await wrapper.get('#model-input').setValue('P2008 JC')
+
+    const icaoEmits = wrapper.emitted('update:icaoTypeDesignator') as unknown[][] | undefined
+    expect(icaoEmits?.[icaoEmits.length - 1]?.[0]).toBe('P208')
+  })
+
+  // @UT-AC-VIEW-010@ (FROM: @IMP-AC-VIEW-003@)
+  it('typing a unique 4-char ICAO auto-fills manufacturer and model', async () => {
+    const wrapper = mount(AircraftModelSelector, {
+      props: { manufacturer: '', model: '', icaoTypeDesignator: '' },
+    })
+
+    const icao = wrapper.get('#icao-designator-input')
+    await icao.setValue('P208')
+
+    const mfr = wrapper.emitted('update:manufacturer') as unknown[][] | undefined
+    const mdl = wrapper.emitted('update:model') as unknown[][] | undefined
+    const icaoEmits = wrapper.emitted('update:icaoTypeDesignator') as unknown[][] | undefined
+    expect(mfr?.[mfr.length - 1]?.[0]).toBe('Tecnam')
+    expect(mdl?.[mdl.length - 1]?.[0]).toBe('P2008 JC')
+    expect(icaoEmits?.[icaoEmits.length - 1]?.[0]).toBe('P208')
+  })
+
+  // @UT-AC-VIEW-011@ (FROM: @IMP-AC-VIEW-003@)
+  it('shows text model input when manufacturer is Other', () => {
+    const wrapper = mount(AircraftModelSelector, {
+      props: { manufacturer: 'Other', model: '', icaoTypeDesignator: '' },
+    })
+
+    expect(wrapper.find('#model-input').element.tagName).toBe('INPUT')
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for static aircraft model catalogue lookups.
+ *
+ * @see frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getManufacturers,
+  getModelsByManufacturer,
+  findByIcaoDesignator,
+  findUniqueByIcaoDesignator,
+} from '../data/aircraft-model-catalogue'
+
+describe('aircraft-model-catalogue', () => {
+  // @UT-AC-CAT-001@ (FROM: @IMP-AC-VIEW-001@)
+  it('getManufacturers lists sorted names with Other last', () => {
+    const m = getManufacturers()
+    expect(m[m.length - 1]).toBe('Other')
+    expect(m).toContain('Cessna')
+    expect(m).toContain('Piper')
+    const withoutOther = m.filter((x) => x !== 'Other')
+    expect([...withoutOther].sort()).toEqual(withoutOther)
+  })
+
+  // @UT-AC-CAT-002@ (FROM: @IMP-AC-VIEW-001@)
+  it('getModelsByManufacturer returns only models for that manufacturer', () => {
+    const cessna = getModelsByManufacturer('Cessna')
+    expect(cessna.every((e) => e.manufacturer === 'Cessna')).toBe(true)
+    expect(cessna.map((e) => e.model)).toContain('C152')
+    expect(cessna.map((e) => e.model)).not.toContain('P2008 JC')
+
+    const piper = getModelsByManufacturer('Piper')
+    expect(piper.every((e) => e.manufacturer === 'Piper')).toBe(true)
+    expect(piper).toHaveLength(3)
+  })
+
+  // @UT-AC-CAT-003@ (FROM: @IMP-AC-VIEW-001@)
+  it('getModelsByManufacturer returns empty for Other', () => {
+    expect(getModelsByManufacturer('Other')).toEqual([])
+  })
+
+  // @UT-AC-CAT-004@ (FROM: @IMP-AC-VIEW-001@)
+  it('findByIcaoDesignator is case-insensitive and returns all matches', () => {
+    const pa28 = findByIcaoDesignator('pa28')
+    expect(pa28).toHaveLength(2)
+    expect(new Set(pa28.map((e) => e.model))).toEqual(
+      new Set(['PA-28-161 Warrior III', 'PA-28-181 Archer III']),
+    )
+  })
+
+  // @UT-AC-CAT-005@ (FROM: @IMP-AC-VIEW-001@)
+  it('findUniqueByIcaoDesignator returns entry only for unambiguous 4-char designator', () => {
+    expect(findUniqueByIcaoDesignator('P208')).toMatchObject({
+      manufacturer: 'Tecnam',
+      model: 'P2008 JC',
+      icaoTypeDesignator: 'P208',
+    })
+    expect(findUniqueByIcaoDesignator('pa28')).toBeNull()
+    expect(findUniqueByIcaoDesignator('PA28')).toBeNull()
+    expect(findUniqueByIcaoDesignator('PA')).toBeNull()
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useFleetStore, VerifiedMutationError } from '../stores/fleet.store'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import { fleetRepository } from '../services/fleet.repository'
 
 // Mock the fleet repository so we don't need real IndexedDB in unit tests
 vi.mock('../services/fleet.repository', () => ({
@@ -70,6 +71,7 @@ function minimalProfileData(): Omit<AircraftProfile, 'id' | 'status' | 'schemaVe
 describe('useFleetStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    vi.mocked(fleetRepository.findAll).mockResolvedValue([])
   })
 
   // @UT-AC-STORE-025@ (FROM: @IMP-AC-STORE-005@)
@@ -187,5 +189,37 @@ describe('useFleetStore', () => {
     const profile = await store.createProfile(minimalProfileData())
     await store.deleteProfile(profile.id)
     expect(store.profiles).toHaveLength(0)
+  })
+
+  // @UT-AC-STORE-034@ (FROM: @IMP-AC-STORE-005@)
+  it('loadAll sets fleetLoadState LOADING then READY when IndexedDB succeeds', async () => {
+    let resolveLoad!: (rows: AircraftProfile[]) => void
+    const loadPromise = new Promise<AircraftProfile[]>((r) => {
+      resolveLoad = r
+    })
+    vi.mocked(fleetRepository.findAll).mockReturnValueOnce(loadPromise)
+
+    const store = useFleetStore()
+    const done = store.loadAll()
+    expect(store.fleetLoadState).toBe('LOADING')
+    expect(store.fleetLoadError).toBeNull()
+
+    resolveLoad([])
+    await done
+    expect(store.fleetLoadState).toBe('READY')
+    expect(store.fleetLoadError).toBeNull()
+    expect(store.isLoading).toBe(false)
+  })
+
+  // @UT-AC-STORE-035@ (FROM: @IMP-AC-STORE-005@)
+  it('loadAll sets fleetLoadState ERROR when IndexedDB fails', async () => {
+    vi.mocked(fleetRepository.findAll).mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+
+    const store = useFleetStore()
+    await store.loadAll()
+
+    expect(store.fleetLoadState).toBe('ERROR')
+    expect(store.fleetLoadError).toBe('IndexedDB unavailable')
+    expect(store.isLoading).toBe(false)
   })
 })

--- a/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
@@ -191,6 +191,18 @@ describe('useFleetStore', () => {
     expect(store.profiles).toHaveLength(0)
   })
 
+  // @UT-AC-STORE-036@ (FROM: @IMP-AC-STORE-005@, @REQ-AC-001@)
+  it('starts with fleetLoadState LOADING until the first successful loadAll', async () => {
+    vi.mocked(fleetRepository.findAll).mockResolvedValueOnce([])
+
+    const store = useFleetStore()
+    expect(store.fleetLoadState).toBe('LOADING')
+
+    await store.loadAll()
+    expect(store.fleetLoadState).toBe('READY')
+    expect(store.profiles).toHaveLength(0)
+  })
+
   // @UT-AC-STORE-034@ (FROM: @IMP-AC-STORE-005@)
   it('loadAll sets fleetLoadState LOADING then READY when IndexedDB succeeds', async () => {
     let resolveLoad!: (rows: AircraftProfile[]) => void

--- a/frontend/src/modules/aircraft/components/AircraftModelSelector.vue
+++ b/frontend/src/modules/aircraft/components/AircraftModelSelector.vue
@@ -36,7 +36,7 @@
           @change="onModelChange(($event.target as HTMLSelectElement).value)"
         >
           <option value="">-- Select Model --</option>
-          <option v-for="entry in availableModels" :key="entry.model" :value="entry.model">
+          <option v-for="entry in availableModels" :key="entry.id" :value="entry.model">
             {{ entry.model }}
           </option>
         </select>
@@ -58,7 +58,7 @@
       <ul v-if="icaoLookupResults.length > 0" class="icao-lookup-results" role="listbox">
         <li
           v-for="entry in icaoLookupResults"
-          :key="`${entry.manufacturer}-${entry.model}`"
+          :key="entry.id"
           role="option"
           class="icao-lookup-result"
           @click="selectFromLookup(entry)"
@@ -77,6 +77,7 @@ import {
   getManufacturers,
   getModelsByManufacturer,
   findByIcaoDesignator,
+  findUniqueByIcaoDesignator,
   type AircraftModelEntry,
 } from '../data/aircraft-model-catalogue'
 
@@ -138,7 +139,16 @@ function onIcaoInput(value: string): void {
   const normalized = value.trim().toUpperCase()
   emit('update:icaoTypeDesignator', normalized)
 
-  // Bidirectional lookup: populate suggestion list (REQ-UI-004)
+  // Full designator with a single catalogue match: auto-fill hierarchy (REQ-UI-003, REQ-UI-004)
+  const unique = findUniqueByIcaoDesignator(normalized)
+  if (unique) {
+    emit('update:manufacturer', unique.manufacturer)
+    emit('update:model', unique.model)
+    icaoLookupResults.value = []
+    return
+  }
+
+  // Partial or ambiguous: suggestion list (REQ-UI-004)
   if (normalized.length >= 2) {
     icaoLookupResults.value = findByIcaoDesignator(normalized)
   } else {

--- a/frontend/src/modules/aircraft/components/FleetList.vue
+++ b/frontend/src/modules/aircraft/components/FleetList.vue
@@ -1,7 +1,18 @@
 <template>
   <!-- @IMP-AC-VIEW-005@ (FROM: @REQ-AC-001@, @REQ-AC-005@) -->
   <div class="fleet-list">
-    <div v-if="fleetStore.isLoading" class="loading-state">Loading fleet...</div>
+    <div v-if="fleetStore.fleetLoadState === 'LOADING'" class="loading-state">Loading fleet...</div>
+
+    <div
+      v-else-if="fleetStore.fleetLoadState === 'ERROR'"
+      class="error-state"
+      role="alert"
+      aria-live="assertive"
+    >
+      <p>Could not load your fleet from device storage.</p>
+      <p v-if="fleetStore.fleetLoadError" class="error-state__detail">{{ fleetStore.fleetLoadError }}</p>
+      <button type="button" class="btn btn-retry" @click="fleetStore.loadAll()">Retry</button>
+    </div>
 
     <div v-else-if="fleetStore.profiles.length === 0" class="empty-state">
       No aircraft profiles yet. Add your first aircraft above.
@@ -103,10 +114,36 @@ async function onDelete(id: string, registration: string): Promise<void> {
 }
 
 .loading-state,
-.empty-state {
+.empty-state,
+.error-state {
   padding: 1rem;
   text-align: center;
   color: #6b7280;
+}
+
+.error-state {
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.error-state__detail {
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0 0;
+  word-break: break-word;
+}
+
+.btn-retry {
+  margin-top: 0.75rem;
+  padding: 0.375rem 0.75rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  font-weight: 500;
+  background: #dc2626;
+  color: white;
 }
 
 .profiles-list {

--- a/frontend/src/modules/aircraft/data/aircraft-model-catalogue.json
+++ b/frontend/src/modules/aircraft/data/aircraft-model-catalogue.json
@@ -1,0 +1,14 @@
+[
+  { "id": "cessna-c152", "manufacturer": "Cessna", "model": "C152", "icaoTypeDesignator": "C152" },
+  { "id": "cessna-c172s", "manufacturer": "Cessna", "model": "C172S Skyhawk SP", "icaoTypeDesignator": "C172" },
+  { "id": "cessna-c182t", "manufacturer": "Cessna", "model": "C182T Skylane", "icaoTypeDesignator": "C82T" },
+  { "id": "piper-pa28-161", "manufacturer": "Piper", "model": "PA-28-161 Warrior III", "icaoTypeDesignator": "PA28" },
+  { "id": "piper-pa28-181", "manufacturer": "Piper", "model": "PA-28-181 Archer III", "icaoTypeDesignator": "PA28" },
+  { "id": "piper-pa44", "manufacturer": "Piper", "model": "PA-44-180 Seminole", "icaoTypeDesignator": "PA44" },
+  { "id": "diamond-da40", "manufacturer": "Diamond", "model": "DA40 Diamond Star", "icaoTypeDesignator": "DA40" },
+  { "id": "diamond-da42", "manufacturer": "Diamond", "model": "DA42 Twin Star", "icaoTypeDesignator": "DA42" },
+  { "id": "tecnam-p2008", "manufacturer": "Tecnam", "model": "P2008 JC", "icaoTypeDesignator": "P208" },
+  { "id": "tecnam-p2010", "manufacturer": "Tecnam", "model": "P2010", "icaoTypeDesignator": "P210" },
+  { "id": "robin-dr400-120", "manufacturer": "Robin", "model": "DR400/120 Petit Prince", "icaoTypeDesignator": "DR40" },
+  { "id": "robin-dr400-140b", "manufacturer": "Robin", "model": "DR400/140B Major", "icaoTypeDesignator": "DR40" }
+]

--- a/frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
+++ b/frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
@@ -1,6 +1,6 @@
 /**
  * Static aircraft model catalogue for the model hierarchy selector.
- * P2 Feature Module — static data, no external dependencies.
+ * P2 Feature Module — data loaded from JSON; pure lookup helpers (no framework).
  *
  * Provides manufacturer → model → ICAO type designator mapping.
  * Supports the AircraftModelSelector component (REQ-UI-001 through REQ-UI-004).
@@ -10,31 +10,17 @@
 
 // @IMP-AC-VIEW-001@ (FROM: @REQ-UI-001@, @REQ-UI-003@, @REQ-UI-004@)
 
+import rawCatalogue from './aircraft-model-catalogue.json'
+
 export interface AircraftModelEntry {
+  /** Stable key for list rendering (unique per catalogue row). */
+  id: string
   manufacturer: string
   model: string
   icaoTypeDesignator: string
 }
 
-export const AIRCRAFT_MODEL_CATALOGUE: AircraftModelEntry[] = [
-  // Cessna
-  { manufacturer: 'Cessna', model: 'C152', icaoTypeDesignator: 'C152' },
-  { manufacturer: 'Cessna', model: 'C172S Skyhawk SP', icaoTypeDesignator: 'C172' },
-  { manufacturer: 'Cessna', model: 'C182T Skylane', icaoTypeDesignator: 'C82T' },
-  // Piper
-  { manufacturer: 'Piper', model: 'PA-28-161 Warrior III', icaoTypeDesignator: 'PA28' },
-  { manufacturer: 'Piper', model: 'PA-28-181 Archer III', icaoTypeDesignator: 'PA28' },
-  { manufacturer: 'Piper', model: 'PA-44-180 Seminole', icaoTypeDesignator: 'PA44' },
-  // Diamond
-  { manufacturer: 'Diamond', model: 'DA40 Diamond Star', icaoTypeDesignator: 'DA40' },
-  { manufacturer: 'Diamond', model: 'DA42 Twin Star', icaoTypeDesignator: 'DA42' },
-  // Tecnam
-  { manufacturer: 'Tecnam', model: 'P2008 JC', icaoTypeDesignator: 'P208' },
-  { manufacturer: 'Tecnam', model: 'P2010', icaoTypeDesignator: 'P210' },
-  // Robin
-  { manufacturer: 'Robin', model: 'DR400/120 Petit Prince', icaoTypeDesignator: 'DR40' },
-  { manufacturer: 'Robin', model: 'DR400/140B Major', icaoTypeDesignator: 'DR40' },
-]
+export const AIRCRAFT_MODEL_CATALOGUE: AircraftModelEntry[] = rawCatalogue as AircraftModelEntry[]
 
 /**
  * Get unique manufacturer names from the catalogue, sorted alphabetically.
@@ -64,4 +50,15 @@ export function findByIcaoDesignator(icaoTypeDesignator: string): AircraftModelE
   return AIRCRAFT_MODEL_CATALOGUE.filter(
     (e) => e.icaoTypeDesignator.toUpperCase() === normalized,
   )
+}
+
+/**
+ * When ICAO input is a complete 4-character designator with exactly one catalogue
+ * match, return that entry for auto-fill (REQ-UI-003, REQ-UI-004).
+ */
+export function findUniqueByIcaoDesignator(icaoTypeDesignator: string): AircraftModelEntry | null {
+  const normalized = icaoTypeDesignator.trim().toUpperCase()
+  if (normalized.length !== 4) return null
+  const matches = findByIcaoDesignator(normalized)
+  return matches.length === 1 ? matches[0]! : null
 }

--- a/frontend/src/modules/aircraft/stores/fleet.store.ts
+++ b/frontend/src/modules/aircraft/stores/fleet.store.ts
@@ -59,7 +59,8 @@ export const useFleetStore = defineStore('fleet', () => {
   // ─── State ────────────────────────────────────────────────────────────────
 
   const profiles = ref<AircraftProfile[]>([])
-  const fleetLoadState = ref<FleetLoadState>('READY')
+  /** Start LOADING so fleet UI never shows an empty list before the first `loadAll()` (#158 hydration). */
+  const fleetLoadState = ref<FleetLoadState>('LOADING')
   const fleetLoadError = ref<string | null>(null)
   const notifications = ref<FleetNotification[]>([])
 

--- a/frontend/src/modules/aircraft/stores/fleet.store.ts
+++ b/frontend/src/modules/aircraft/stores/fleet.store.ts
@@ -14,7 +14,7 @@
  */
 
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { v4 as uuidv4 } from 'uuid'
 import { AircraftProfileSchema } from '@/core/adapters/aircraft.schema'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
@@ -52,12 +52,19 @@ export type FleetNotification = {
   message: string
 }
 
+/** IndexedDB fleet hydration lifecycle for UI feedback (refs #158). */
+export type FleetLoadState = 'LOADING' | 'READY' | 'ERROR'
+
 export const useFleetStore = defineStore('fleet', () => {
   // ─── State ────────────────────────────────────────────────────────────────
 
   const profiles = ref<AircraftProfile[]>([])
-  const isLoading = ref(false)
+  const fleetLoadState = ref<FleetLoadState>('READY')
+  const fleetLoadError = ref<string | null>(null)
   const notifications = ref<FleetNotification[]>([])
+
+  /** @deprecated Prefer `fleetLoadState === 'LOADING'` for new code. */
+  const isLoading = computed(() => fleetLoadState.value === 'LOADING')
 
   // ─── Internal helpers ─────────────────────────────────────────────────────
 
@@ -85,11 +92,15 @@ export const useFleetStore = defineStore('fleet', () => {
 
   /** Load all profiles from IndexedDB into the store. */
   async function loadAll(): Promise<void> {
-    isLoading.value = true
+    fleetLoadState.value = 'LOADING'
+    fleetLoadError.value = null
     try {
       profiles.value = await fleetRepository.findAll()
-    } finally {
-      isLoading.value = false
+      fleetLoadState.value = 'READY'
+    } catch (err) {
+      fleetLoadState.value = 'ERROR'
+      fleetLoadError.value =
+        err instanceof Error ? err.message : 'Failed to load aircraft fleet from storage.'
     }
   }
 
@@ -249,6 +260,8 @@ export const useFleetStore = defineStore('fleet', () => {
   return {
     // State
     profiles,
+    fleetLoadState,
+    fleetLoadError,
     isLoading,
     notifications,
     // Actions

--- a/trace/implementation/ac.yaml
+++ b/trace/implementation/ac.yaml
@@ -69,12 +69,13 @@ AC Store — Fleet Repository
 
 AC View — Model Catalogue and Components
   IMP-AC-VIEW-001
-    title: AIRCRAFT_MODEL_CATALOGUE — static manufacturer→model→ICAO mapping with helper functions
+    title: AIRCRAFT_MODEL_CATALOGUE — JSON source + helper functions (manufacturer→model→ICAO)
     req:
       - REQ-UI-001
       - REQ-UI-003
       - REQ-UI-004
     files:
+      - frontend/src/modules/aircraft/data/aircraft-model-catalogue.json
       - frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
 
   IMP-AC-VIEW-002

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -295,3 +295,25 @@ AC Store — Fleet Store (Unit)
       - IMP-AC-STORE-005
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-034
+    title: loadAll sets fleetLoadState LOADING then READY when IndexedDB succeeds
+    impl:
+      - IMP-AC-STORE-005
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-035
+    title: loadAll sets fleetLoadState ERROR when IndexedDB fails
+    impl:
+      - IMP-AC-STORE-005
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-036
+    title: starts with fleetLoadState LOADING until the first successful loadAll
+    impl:
+      - IMP-AC-STORE-005
+      - REQ-AC-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Implements Milestone 3 sub-task **#158** (parent **#146**): versioned manufacturer → model → ICAO catalogue (static JSON), selector behaviour (ICAO reverse lookup, "Other" manual path), stable row ids for Vue keys, and fleet store `LOADING` / `READY` / `ERROR` with UI feedback in fleet list.

**Post-QA (CPO loop):** Initial `fleetLoadState` is now `LOADING` until the first successful `loadAll()` so the fleet list does not flash the empty state before parent `onMounted` hydration (`9768443`). Trace registry updated with `UT-AC-STORE-034`–`036`.

### Related Issues

Closes #158

Parent feature: #146

### Issue State Management (Post-Merge)

- [ ] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** REQ-AC / REQ-UI catalogue and fleet UX (trace updated in `trace/unit_test/ac.yaml`)

### Documentation Updates

- [x] **Architecture:** `docs/architecture/aircraft-fleet-module.md` updated
- [x] **Code Docs:** CHANGELOG Unreleased; trace registry

### Safety Considerations

- [x] P1 isolation maintained (catalogue is data + P2/P3 wiring).

### Quality & Testing Checklist

- [x] **Target Branch:** `develop`
- [x] **Unit Tests:** Catalogue + selector + fleet store load-state tests (including initial LOADING)
- [x] **Integration Tests:** Passed locally
- [x] **E2E:** Chromium project passed locally
- [x] **DoD:** Aligned with #158
- [x] **ADR:** N/A unless reviewer requests persistence ADR extension
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-336650b4-bd5d-450c-a9a7-13bbc19a5eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-336650b4-bd5d-450c-a9a7-13bbc19a5eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

