### PR TITLE
feat(ac,sys): Aircraft catalogue tests, PWA/version gate, schemaVersion ADR, supplementary field tests (closes #158, #160, #161, #162, #163, #166, #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ADR-008: IndexedDB migration strategy — defines schema versioning, forward-only migrations, and `schemaVersion` field contract for all IndexedDB stores
+- `docs/architecture/aircraft-exchange-file-format.md`: canonical specification for the aircraft profile exchange (`.adp.json`) file format used by import/export
+- Unit tests for `AircraftModelSelector.vue`: manufacturer list, model dropdown filter, ICAO auto-fill, reverse lookup, and free-text mode (`Other`) (refs #146)
+- Unit tests for `aircraft-model-catalogue.ts`: ICAO designator integrity (including C182T Skylane correction), catalogue lookup, and `getManufacturers()`/`getModelsByManufacturer()`/`findByIcaoDesignator()` functions (refs #146)
+- Unit tests for `FleetList.vue`: loading state, empty state, profile list rendering, active profile highlighting, and action button behaviour (Select/Active, Verify, Edit, Delete) (refs #144)
+- Unit tests for `ProfileStatusBadge.vue`: Verified/Draft label rendering, CSS class application, `aria-label`, and `title` accessibility attributes (refs #145)
+- Version-blocked screen in `App.vue` (REQ-SYS-006): `<RouterView>` is now wrapped in `v-if="!appVersionStore.versionBlocked"` — when version is below minimum, a full-screen error panel is rendered instead, blocking all safety-critical features
+- Offline E2E smoke test (`offline-smoke.feature`): verifies that the app shell loads and M\&B navigation is available after the browser goes offline (refs #162)
 - PWA Service Worker with offline-first app shell caching via `vite-plugin-pwa` and Workbox (closes #150)
 - PWA update notification (`INFO-SYS-001`) — no silent auto-update, user must confirm reload (`registerType: 'prompt'`) (closes #151)
 - Minimum safe version enforcement on startup (`useAppVersionStore.checkMinSafeVersion`) — blocks execution when local version is below minimum (REQ-SYS-006)
@@ -27,13 +35,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-session aircraft switching without full page reload (closes #153)
 - AircraftContext schemaVersion field for structured migration safety (closes #154)
 
+### Changed
+
+- ADR-007 enhanced with versioning, update-path, and notification sections documenting the PWA update lifecycle
+- `App.vue`: version-blocked screen replaces the prior banner — `<RouterView>` is now gated behind `v-if="!appVersionStore.versionBlocked"` so all safety-critical features are blocked when the version is below minimum (REQ-SYS-006)
+- `app-version.store.ts`: JSDoc updated to document the build-time constant limitation for `minSafeVersion` and the planned remote fetch path before v1.0.0 (REQ-SYS-006)
+- `pwa-update.store.ts`: `onNeedsRefresh()` documented to clarify that the direct banner in `App.vue` IS the INFO-SYS-001 notification (architectural exception per ADR-007)
+- C182T Skylane ICAO type designator corrected: `C82T` → `C182` (aviation safety data correction)
+
 ### Engineering
 
 - 33 unit tests (ICAO validation × 16, import × 8, fleet FSM × 9) and 4 IndexedDB integration tests all passing
-- verifyProfile() now auto-updates active aircraft context when the verified Draft was in use
+- `verifyProfile()` now auto-updates active aircraft context when the verified Draft was in use
 - Canonical bilinear interpolation test vectors (TOR, TOD, LR, LD) established and passing in CI — de-risk for v0.4.0 performance distance calculations (closes #155)
 - 40 canonical bilinear interpolation unit tests (VEC-TOR-001–015, VEC-TOD-001–004, VEC-LR-001–006, VEC-LD-001–005, VEC-EDGE-001–010) all passing in CI P1 isolation mode
 - 16 unit tests for `useSessionPersistenceStore` covering save, restore, clear, debounce, and round-trip scenarios
+- Added `FleetList.vue`, `ProfileStatusBadge.vue`, and additional `aircraft-model-catalogue` unit tests to bring `modules/aircraft` P2 coverage above the 80% threshold
+- Added `app-version-blocked.spec.ts` unit tests validating REQ-SYS-006 gate (version-blocked state renders blocked screen; content hidden when blocked; gate is reactive)
+- Offline E2E smoke test added for PWA offline-first DoD verification (refs #162)
 
 ## [0.2.0-alpha] - 2026-04-03
 

--- a/docs/architecture/adr/007-aircraft-data-update-pipeline.md
+++ b/docs/architecture/adr/007-aircraft-data-update-pipeline.md
@@ -84,7 +84,7 @@ The notification is delivered via the AeroDash notification bus
 
 | Notification Code | Trigger | Message |
 | :---------------- | :------ | :------ |
-| `WARN-CATALOGUE-001` | App load, stored version ≠ current `CATALOGUE_VERSION` | "Aircraft catalogue updated. Review profiles that use updated manufacturer/model data and re-verify if needed." |
+| `WARN-CATALOGUE-001` | App load, stored version ≠ `CATALOGUE_VERSION` | "Aircraft catalogue updated. Review profiles that use updated manufacturer/model data and re-verify if needed." |
 
 The notification persists until dismissed by the pilot. It is not re-emitted
 until the next catalogue version change.

--- a/docs/architecture/adr/007-aircraft-data-update-pipeline.md
+++ b/docs/architecture/adr/007-aircraft-data-update-pipeline.md
@@ -3,7 +3,7 @@
 <!-- @DES-ARCH-008@ (FROM: @REQ-AC-001@, @REQ-AC-004@) -->
 
 * **Status:** Accepted
-* **Date:** 2026-04-09
+* **Date:** 2026-04-10
 
 ## Context
 
@@ -28,20 +28,66 @@ catalogue is updated and a user has stored profiles derived from older catalogue
 ## Decision
 
 Aircraft profiles are **self-contained documents**. There is no foreign key
-relationship between a stored `AircraftProfile` and the static `AIRCRAFT_MODEL_CATALOGUE`.
+relationship between a stored `AircraftProfile` and the static
+`AIRCRAFT_MODEL_CATALOGUE`.
 
 When the catalogue is updated (new models added, ICAO designators corrected):
 
 1. Existing stored profiles are **never auto-mutated** — preventing silent data
    corruption on safety-critical fields (registration, ICAO designator).
 2. A `WARN-CATALOGUE-001` notification is emitted on the next app load when the
-   catalogue version hash changes, informing the pilot that a catalogue update is
-   available and profiles should be reviewed.
+   catalogue version string changes, informing the pilot that a catalogue update
+   is available and profiles should be reviewed.
 3. Pilots who wish to adopt the new data must: (a) set the profile to Draft,
    (b) update fields manually, (c) re-verify.
 
 The static catalogue is embedded in the bundle. Catalogue updates are delivered
 via a new application version (standard PWA update flow with service worker).
+
+## Versioning Strategy
+
+The catalogue exposes a `CATALOGUE_VERSION` constant (semver string, e.g.
+`"1.0.0"`) in `aircraft-model-catalogue.ts`. This string:
+
+* Is incremented on every catalogue change (new entries, corrections, removals)
+  as part of the PR that modifies the catalogue.
+* Is stored in `localStorage` under the key `aerodash.catalogueVersion` after
+  the first app load with that version.
+* On each subsequent app load the stored version is compared to
+  `CATALOGUE_VERSION`. If they differ, `WARN-CATALOGUE-001` is emitted and the
+  stored version is updated.
+
+Version comparison is strict string equality — the version is treated as an
+opaque label rather than a numeric range, ensuring no accidental skips.
+
+## Update Path for Affected Profiles
+
+When `WARN-CATALOGUE-001` fires, the notification message guides the pilot
+through the following manual review path:
+
+1. Navigate to the Fleet Management view.
+2. Identify any profile whose `manufacturer`, `model`, or `icaoTypeDesignator`
+   was corrected in the catalogue update (described in the app release notes).
+3. Use `editVerifiedProfile()` to place the profile back into Draft state.
+4. Update the affected fields manually using the `AircraftModelSelector`
+   component, which will present the corrected catalogue values.
+5. Re-verify the profile to return it to Verified state.
+
+**No automated field patching is performed.** The pilot bears explicit
+responsibility for reviewing and re-verifying any profile affected by a
+catalogue correction, consistent with REQ-AC-005.
+
+## Notification Mechanism for Affected Profiles
+
+The notification is delivered via the AeroDash notification bus
+(`useNotificationStore`) as a persistent `WARNING`-level notification:
+
+| Notification Code | Trigger | Message |
+| :---------------- | :------ | :------ |
+| `WARN-CATALOGUE-001` | App load, stored version ≠ current `CATALOGUE_VERSION` | "Aircraft catalogue updated. Review profiles that use updated manufacturer/model data and re-verify if needed." |
+
+The notification persists until dismissed by the pilot. It is not re-emitted
+until the next catalogue version change.
 
 ## Consequences
 
@@ -52,12 +98,14 @@ via a new application version (standard PWA update flow with service worker).
 * No FK complexity; profiles can be shared (imported/exported) without catalogue
   context.
 * Simple implementation: no migration needed when catalogue changes.
+* Version string in source makes catalogue changes visible in code review diffs.
 
 ### Negative
 
 * Stale profiles are possible if the catalogue corrects a type designator error.
   Mitigated by the `WARN-CATALOGUE-001` notification prompting review.
 * Catalogue cannot grow beyond bundle size limits (acceptable for GA fleet sizes).
+* Pilots must manually re-verify affected profiles; no automated assistance.
 
 ## Compliance
 

--- a/docs/architecture/adr/008-indexeddb-migration-strategy.md
+++ b/docs/architecture/adr/008-indexeddb-migration-strategy.md
@@ -1,0 +1,167 @@
+# ADR-008: IndexedDB Schema Migration Strategy for AircraftProfile
+
+<!-- @DES-ARCH-008@ (FROM: @REQ-AC-004@, @REQ-AC-005@) -->
+
+* **Status:** Accepted
+* **Date:** 2026-04-10
+
+## Context
+
+AeroDash is an offline-first PWA. `AircraftProfile` documents are persisted in
+IndexedDB (`aerodash-fleet`, object store `aircraft_profiles`) as defined in
+ADR-006. As the application evolves across milestones, the shape of
+`AircraftProfile` will change: new required fields are added, optional fields
+become required, types are narrowed, and sub-schemas are extended.
+
+Without a controlled migration strategy, existing user data becomes unreadable
+(parse errors at the Zod boundary) or silently incorrect (missing fields default
+to unexpected values). Both outcomes are unacceptable in a safety-critical
+aviation tool.
+
+The `schemaVersion` integer field (`z.number().int().positive().default(1)`)
+was added to every persisted `AircraftProfile` document in Milestone 3 (M3)
+to enable safe, structured migration (refs GitHub #154, #166).
+
+## Considered Options
+
+* **Option 1 — IndexedDB `onupgradeneeded` only (version-number migration):**
+  Bump the IndexedDB database version integer on every schema change and run a
+  cursor migration inside `onupgradeneeded`. Simple for a single store, but the
+  `onupgradeneeded` handler only fires when the DB version number changes. It
+  does not support in-place document migration without bumping the DB version,
+  and it cannot detect or repair partially-migrated documents.
+
+* **Option 2 — Document-level `schemaVersion` field with lazy migration
+  (chosen):** Store a `schemaVersion` integer on every persisted document.
+  On `findById` / `findAll`, inspect the `schemaVersion` of the returned raw
+  document and apply incremental migration transforms before passing the result
+  to the Zod parser. Documents are written back with the current `schemaVersion`
+  after a successful migration. No DB version bump is needed for document-level
+  changes.
+
+* **Option 3 — Versioned stores (per-milestone object store):** Create a new
+  object store per milestone (e.g., `aircraft_profiles_v2`). Old stores are
+  migrated in `onupgradeneeded` and then dropped. High operational complexity,
+  requires coordinated DB version bumps, and risks data loss if migration
+  partially fails.
+
+## Decision
+
+Adopt **Option 2**: document-level `schemaVersion` with lazy migration at the
+repository read boundary (`findById`, `findAll`).
+
+### Detection Logic
+
+1. Read the raw document from IndexedDB (untyped `unknown` at this point).
+2. Extract `schemaVersion`. If the field is absent or not a positive integer,
+   treat the document as `schemaVersion = 1` (the baseline established in M3).
+3. Compare `schemaVersion` against `CURRENT_SCHEMA_VERSION` (a constant
+   exported from `fleet.repository.ts`).
+4. If `schemaVersion < CURRENT_SCHEMA_VERSION`, run the migration chain
+   (see below).
+5. After migration the document passes through `AircraftProfileSchema.parse()`.
+   A failed parse is surfaced as a `MigrationError` — the document is quarantined
+   (not deleted) and the user is notified.
+
+### Migration Path per Version Delta
+
+Migrations are modelled as a chain of pure functions, each accepting and
+returning an untyped record. Each step brings the document from
+`schemaVersion = N` to `schemaVersion = N+1`.
+
+| From → To | Transform applied |
+| :-------- | :---------------- |
+| `1 → 2`   | Add `passengerProfiles: []` if absent. Add `status: 'Draft'` if absent. |
+| `2 → 3`   | *(future — reserved)* |
+
+```text
+migrate(raw, fromVersion, toVersion):
+  while fromVersion < toVersion:
+    raw = MIGRATIONS[fromVersion](raw)
+    fromVersion += 1
+  return raw
+```
+
+The migration transform is applied before Zod parsing, so the parser always
+sees a document at `CURRENT_SCHEMA_VERSION`.
+
+After a successful migration the updated document is written back to IndexedDB
+via `put()`, so future reads are fast (no re-migration needed).
+
+### Fallback Behavior
+
+If the migration chain throws for a given document (e.g., data is corrupt or
+a transform assumption fails):
+
+1. The raw document is preserved in IndexedDB untouched (no data deletion).
+2. A `MigrationError` is thrown from `findById`/`findAll`.
+3. The fleet store catches the error and emits an `ERROR` severity notification
+   identifying the affected registration (if readable) and advising the user to
+   re-import the profile from a backup.
+4. The corrupted document is excluded from the fleet list but not deleted,
+   allowing manual recovery.
+
+### Portability Format (IndexedDB Schema Documentation)
+
+The following table documents the canonical field set of a version-1
+`AircraftProfile` document as persisted in IndexedDB. This format is the
+baseline for all future migrations and for tools that inspect the IndexedDB
+store directly (e.g., DevTools, integration tests with `fake-indexeddb`).
+
+| Field | Type | Default | Notes |
+| :---- | :--- | :------ | :---- |
+| `id` | `string` (UUID v4) | — | Primary key. Indexed. |
+| `ownerId` | `string` | — | Indexed (non-unique). |
+| `registration` | `string` | — | Indexed (non-unique). |
+| `manufacturer` | `string` | — | |
+| `model` | `string` | — | |
+| `icaoTypeDesignator` | `string` | — | |
+| `sourceUnit` | `string` | — | |
+| `referenceDatumDescription` | `string` | — | |
+| `referenceDatumLocation` | `string` | — | |
+| `shareCode` | `string \| null` | `null` | |
+| `status` | `'Draft' \| 'Verified'` | `'Draft'` | M3 field |
+| `schemaVersion` | `number` (positive int) | `1` | M3 migration key |
+| `passengerProfiles` | `PassengerProfile[]` | `[]` | M3 field |
+| `weighingReports` | `WeighingReport[]` | — | Min 1 element |
+| `loadPoints` | `LoadPoint[]` | — | Max 20 elements |
+| `certificationCategories` | `CertificationCategory[]` | — | Min 1 element |
+| `windLimits` | `WindLimit[]` | `undefined` | Optional |
+| `surfaceConditions` | `SurfaceCondition[]` | `undefined` | Optional |
+| `safetyFactors` | `SafetyFactors` | `undefined` | Optional |
+| `costPerHour` | `number` | `undefined` | Optional, M3 |
+| `checklistScaffold` | `ChecklistScaffoldItem[]` | `undefined` | Optional, M3 |
+| `performanceProfiles` | `unknown[]` | `undefined` | M4 placeholder |
+
+All documents are validated against `AircraftProfileSchema` (Zod) before use
+in P1 calculations. No raw-document value ever reaches the Safety Core without
+passing through the Zod boundary.
+
+## Consequences
+
+### Positive
+
+* Documents can be migrated without bumping the IndexedDB DB version, which
+  avoids triggering `onupgradeneeded` for document-level changes.
+* Lazy migration at read time is transparent to the rest of the application:
+  callers always receive a fully up-to-date `AircraftProfile`.
+* The migration chain is fully tested in the Node.js integration test
+  environment (`fake-indexeddb`) without browser involvement.
+* Corrupted documents are never silently deleted — they are quarantined and
+  reported to the user.
+
+### Negative
+
+* Every `findById`/`findAll` call incurs a `schemaVersion` check. For typical
+  fleet sizes (< 50 profiles) the overhead is negligible.
+* Migration code must be maintained alongside the schema and can accumulate
+  over many milestones. Each migration step must be thoroughly tested.
+* The write-back after migration requires a `readwrite` transaction on read
+  paths; callers must be aware that `findById`/`findAll` may mutate the store.
+
+## Compliance
+
+Offline persistence of safety-critical aircraft data. All stored documents are
+validated against `AircraftProfileSchema` (Zod) before use in P1 calculations.
+The migration strategy ensures that no stale or partially-migrated document can
+reach the Safety Core, preserving the integrity of Go/No-Go advisories.

--- a/docs/architecture/adr/008-indexeddb-migration-strategy.md
+++ b/docs/architecture/adr/008-indexeddb-migration-strategy.md
@@ -69,10 +69,10 @@ Migrations are modelled as a chain of pure functions, each accepting and
 returning an untyped record. Each step brings the document from
 `schemaVersion = N` to `schemaVersion = N+1`.
 
-| From → To | Transform applied |
-| :-------- | :---------------- |
-| `1 → 2`   | Add `passengerProfiles: []` if absent. Add `status: 'Draft'` if absent. |
-| `2 → 3`   | *(future — reserved)* |
+| Version delta | Transform applied                                                         |
+| :------------ | :------------------------------------------------------------------------ |
+| `1 -> 2`      | Add `passengerProfiles: []` if absent. Add `status: 'Draft'` if absent.   |
+| `2 -> 3`      | *(future - reserved)*                                                     |
 
 ```text
 migrate(raw, fromVersion, toVersion):

--- a/docs/architecture/aircraft-exchange-file-format.md
+++ b/docs/architecture/aircraft-exchange-file-format.md
@@ -1,0 +1,194 @@
+# Aircraft Profile Exchange File Format
+
+<!-- @DES-ARCH-010@ (FROM: @REQ-AC-004@) -->
+
+**Version:** 1.0
+**Date:** 2026-04-10
+**Status:** Approved
+**ADR:** [003-aircraft-data-model](adr/003-aircraft-data-model.md)
+
+## Overview
+
+The AeroDash **aircraft profile exchange file** is a plain JSON document that
+represents a single `AircraftProfile` aggregate root, serialised with
+`JSON.stringify`. It is used to transfer aircraft configuration data between
+AeroDash installations or to back up a profile offline.
+
+The format is defined by and validated against the canonical
+`AircraftProfileSchema` (Zod) in
+`frontend/src/core/adapters/aircraft.schema.ts`.
+
+## Safety Constraints
+
+| Constraint | Rationale |
+| :--------- | :-------- |
+| Imported profile is always forced to `status = 'Draft'` | Prevents unverified data from being used in safety calculations without pilot review |
+| Imported profile always receives a new UUID | Prevents ID collisions with existing fleet entries |
+| Malformed JSON → `ImportError` thrown, fleet unmodified | Atomicity: the fleet is never partially updated |
+| Zod validation failure → `ImportError` thrown, fleet unmodified | All safety-critical fields must pass schema constraints before persistence |
+
+## File Format
+
+### File Extension
+
+`.aerodash.json`
+
+### Encoding
+
+UTF-8, no BOM.
+
+### MIME Type
+
+`application/json`
+
+### Top-Level Structure
+
+The file is a single JSON object that maps directly to an `AircraftProfile`
+document. All fields defined in `AircraftProfileSchema` may appear. The
+`schemaVersion` field determines which version of the schema the file was
+written against.
+
+```json
+{
+  "id": "<uuid-v4>",
+  "schemaVersion": 1,
+  "status": "Verified",
+  "ownerId": "<user-identifier>",
+  "registration": "D-EBPN",
+  "manufacturer": "Tecnam",
+  "model": "P2008 JC",
+  "icaoTypeDesignator": "P208",
+  "sourceUnit": "kg",
+  "referenceDatumDescription": "Leading edge of wing",
+  "referenceDatumLocation": "Station 0",
+  "shareCode": null,
+  "passengerProfiles": [],
+  "weighingReports": [
+    {
+      "bem": 432.0,
+      "emptyCg": 1.882,
+      "weighingDate": "2025-01-01",
+      "validFrom": "2025-01-01"
+    }
+  ],
+  "loadPoints": [
+    {
+      "name": "Pilot",
+      "arm": 1.8,
+      "armLookup": [],
+      "operationalLimit": 110,
+      "defaultQuantity": 0,
+      "unit": "kg",
+      "allowableCategories": null,
+      "fuelTank": null
+    }
+  ],
+  "certificationCategories": [
+    {
+      "category": "Normal",
+      "mtom": 650,
+      "maxZeroFuelMass": null,
+      "graphType": "arm",
+      "envelope": [
+        { "armOrMoment": 1.841, "mass": 432 },
+        { "armOrMoment": 1.841, "mass": 650 },
+        { "armOrMoment": 1.978, "mass": 650 },
+        { "armOrMoment": 1.978, "mass": 432 }
+      ]
+    }
+  ],
+  "costPerHour": 185.5,
+  "checklistScaffold": [
+    {
+      "title": "Pre-flight",
+      "items": ["Check fuel", "Check oil"]
+    }
+  ]
+}
+```
+
+## Required Fields
+
+| Field | Type | Constraint |
+| :---- | :--- | :--------- |
+| `id` | `string` | UUID v4 format |
+| `schemaVersion` | `integer` | Positive integer (currently `1`) |
+| `ownerId` | `string` | Non-empty |
+| `registration` | `string` | Non-empty |
+| `manufacturer` | `string` | Non-empty |
+| `model` | `string` | Non-empty |
+| `icaoTypeDesignator` | `string` | Non-empty |
+| `sourceUnit` | `string` | Non-empty |
+| `referenceDatumDescription` | `string` | Non-empty |
+| `referenceDatumLocation` | `string` | Non-empty |
+| `shareCode` | `string \| null` | Nullable |
+| `status` | `'Draft' \| 'Verified'` | Overridden to `'Draft'` on import |
+| `weighingReports` | `array` | Minimum 1 entry |
+| `loadPoints` | `array` | Maximum 20 entries; each entry must satisfy arm XOR armLookup |
+| `certificationCategories` | `array` | Minimum 1 entry; each envelope has 4–20 points |
+
+## Optional Fields
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `passengerProfiles` | `array` | Standard passenger weight profiles (defaults to `[]`) |
+| `windLimits` | `array` | Wind component limits |
+| `surfaceConditions` | `array` | Runway surface correction factors |
+| `safetyFactors` | `object` | Takeoff and landing safety multipliers |
+| `costPerHour` | `number` | Estimated operating cost per flight hour (non-negative) |
+| `checklistScaffold` | `array` | Checklist section scaffold (title + items) |
+| `performanceProfiles` | `array` | M4 placeholder — ignored until milestone spec finalised |
+
+## Import Behaviour
+
+The import pipeline (`profile.import.ts`) performs the following steps:
+
+1. **JSON parse** — `JSON.parse(jsonText)`. Malformed JSON throws `ImportError`.
+2. **Zod validation** — `AircraftProfileSchema.safeParse(parsed)`. Any
+   validation failure throws `ImportError` with a human-readable issues summary.
+3. **Status override** — `status` is forced to `'Draft'` regardless of file value.
+4. **ID reassignment** — A new UUID v4 is assigned to prevent collision with
+   existing fleet entries.
+5. **Return** — The validated `AircraftProfile` object is returned to the
+   caller (typically the fleet store), which then persists it via
+   `fleetRepository.create()`.
+
+At no point is the fleet modified unless step 5 completes successfully.
+
+## Export Behaviour
+
+`exportProfileToJson(profile)` serialises the profile as:
+
+```typescript
+JSON.stringify(profile, null, 2)
+```
+
+The result is a pretty-printed JSON string with 2-space indentation. The
+exported file can be re-imported with full round-trip fidelity (all fields
+except `id` and `status` are preserved exactly).
+
+## Round-Trip Fidelity
+
+A profile exported with `exportProfileToJson` and re-imported with
+`importProfileFromJson` must satisfy:
+
+- All fields **except** `id` (reassigned) and `status` (forced `'Draft'`)
+  are byte-identical to the original.
+
+This guarantee is verified by unit test `UT-AC-STORE-023`.
+
+## Versioning and Compatibility
+
+The `schemaVersion` field tracks the data model version:
+
+| Version | Description |
+| :------ | :---------- |
+| `1` | M2 + M3 fields: all current fields including `costPerHour`, `checklistScaffold`, `passengerProfiles`, `status` |
+
+## Related Documents
+
+- `docs/architecture/aircraft_data_model.md` — Full aircraft data model
+- `docs/architecture/adr/003-aircraft-data-model.md` — Aircraft data model ADR
+- `docs/architecture/adr/006-indexeddb-fleet-persistence.md` — IndexedDB persistence ADR
+- `frontend/src/core/adapters/aircraft.schema.ts` — Canonical Zod schema
+- `frontend/src/modules/aircraft/services/profile.import.ts` — Import/export service

--- a/docs/architecture/aircraft-exchange-file-format.md
+++ b/docs/architecture/aircraft-exchange-file-format.md
@@ -22,31 +22,20 @@ The format is defined by and validated against the canonical
 
 | Constraint | Rationale |
 | :--------- | :-------- |
-| Imported profile is always forced to `status = 'Draft'` | Prevents unverified data from being used in safety calculations without pilot review |
+| Imported profile always forced to `status = 'Draft'` | Prevents unverified data being used in safety calculations without pilot review |
 | Imported profile always receives a new UUID | Prevents ID collisions with existing fleet entries |
-| Malformed JSON → `ImportError` thrown, fleet unmodified | Atomicity: the fleet is never partially updated |
-| Zod validation failure → `ImportError` thrown, fleet unmodified | All safety-critical fields must pass schema constraints before persistence |
+| Malformed JSON → `ImportError`, fleet unmodified | Atomicity: fleet is never partially updated |
+| Zod validation failure → `ImportError`, fleet unmodified | All safety-critical fields must pass schema constraints before persistence |
 
 ## File Format
 
-### File Extension
+### File Extension and Encoding
 
-`.aerodash.json`
-
-### Encoding
-
-UTF-8, no BOM.
-
-### MIME Type
-
-`application/json`
+`.aerodash.json` — UTF-8, no BOM, MIME type `application/json`.
 
 ### Top-Level Structure
 
-The file is a single JSON object that maps directly to an `AircraftProfile`
-document. All fields defined in `AircraftProfileSchema` may appear. The
-`schemaVersion` field determines which version of the schema the file was
-written against.
+The file is a single JSON object mapping directly to an `AircraftProfile` document.
 
 ```json
 {
@@ -64,46 +53,25 @@ written against.
   "shareCode": null,
   "passengerProfiles": [],
   "weighingReports": [
-    {
-      "bem": 432.0,
-      "emptyCg": 1.882,
-      "weighingDate": "2025-01-01",
-      "validFrom": "2025-01-01"
-    }
+    { "bem": 432.0, "emptyCg": 1.882, "weighingDate": "2025-01-01", "validFrom": "2025-01-01" }
   ],
   "loadPoints": [
     {
-      "name": "Pilot",
-      "arm": 1.8,
-      "armLookup": [],
-      "operationalLimit": 110,
-      "defaultQuantity": 0,
-      "unit": "kg",
-      "allowableCategories": null,
-      "fuelTank": null
+      "name": "Pilot", "arm": 1.8, "armLookup": [], "operationalLimit": 110,
+      "defaultQuantity": 0, "unit": "kg", "allowableCategories": null, "fuelTank": null
     }
   ],
   "certificationCategories": [
     {
-      "category": "Normal",
-      "mtom": 650,
-      "maxZeroFuelMass": null,
-      "graphType": "arm",
+      "category": "Normal", "mtom": 650, "maxZeroFuelMass": null, "graphType": "arm",
       "envelope": [
-        { "armOrMoment": 1.841, "mass": 432 },
-        { "armOrMoment": 1.841, "mass": 650 },
-        { "armOrMoment": 1.978, "mass": 650 },
-        { "armOrMoment": 1.978, "mass": 432 }
+        { "armOrMoment": 1.841, "mass": 432 }, { "armOrMoment": 1.841, "mass": 650 },
+        { "armOrMoment": 1.978, "mass": 650 }, { "armOrMoment": 1.978, "mass": 432 }
       ]
     }
   ],
   "costPerHour": 185.5,
-  "checklistScaffold": [
-    {
-      "title": "Pre-flight",
-      "items": ["Check fuel", "Check oil"]
-    }
-  ]
+  "checklistScaffold": [{ "title": "Pre-flight", "items": ["Check fuel", "Check oil"] }]
 }
 ```
 
@@ -124,8 +92,8 @@ written against.
 | `shareCode` | `string \| null` | Nullable |
 | `status` | `'Draft' \| 'Verified'` | Overridden to `'Draft'` on import |
 | `weighingReports` | `array` | Minimum 1 entry |
-| `loadPoints` | `array` | Maximum 20 entries; each entry must satisfy arm XOR armLookup |
-| `certificationCategories` | `array` | Minimum 1 entry; each envelope has 4–20 points |
+| `loadPoints` | `array` | Max 20; each entry must satisfy arm XOR armLookup |
+| `certificationCategories` | `array` | Min 1; each envelope 4–20 points |
 
 ## Optional Fields
 
@@ -136,54 +104,27 @@ written against.
 | `surfaceConditions` | `array` | Runway surface correction factors |
 | `safetyFactors` | `object` | Takeoff and landing safety multipliers |
 | `costPerHour` | `number` | Estimated operating cost per flight hour (non-negative) |
-| `checklistScaffold` | `array` | Checklist section scaffold (title + items) |
+| `checklistScaffold` | `array` | Checklist section scaffold — structure only, no functional UI in M3 |
 | `performanceProfiles` | `array` | M4 placeholder — ignored until milestone spec finalised |
 
-## Import Behaviour
+## Import Pipeline (`profile.import.ts`)
 
-The import pipeline (`profile.import.ts`) performs the following steps:
+1. **JSON parse** — malformed JSON throws `ImportError`
+2. **Zod validation** — `AircraftProfileSchema.safeParse`. Failure throws `ImportError`
+3. **Status override** — `status` forced to `'Draft'`
+4. **ID reassignment** — new UUID v4 assigned to prevent collision
+5. **Return** — caller persists via `fleetRepository.create()`
 
-1. **JSON parse** — `JSON.parse(jsonText)`. Malformed JSON throws `ImportError`.
-2. **Zod validation** — `AircraftProfileSchema.safeParse(parsed)`. Any
-   validation failure throws `ImportError` with a human-readable issues summary.
-3. **Status override** — `status` is forced to `'Draft'` regardless of file value.
-4. **ID reassignment** — A new UUID v4 is assigned to prevent collision with
-   existing fleet entries.
-5. **Return** — The validated `AircraftProfile` object is returned to the
-   caller (typically the fleet store), which then persists it via
-   `fleetRepository.create()`.
+## Export
 
-At no point is the fleet modified unless step 5 completes successfully.
+`exportProfileToJson(profile)` outputs `JSON.stringify(profile, null, 2)`.
+Round-trip fidelity: all fields except `id` and `status` are preserved (verified by `UT-AC-STORE-023`).
 
-## Export Behaviour
-
-`exportProfileToJson(profile)` serialises the profile as:
-
-```typescript
-JSON.stringify(profile, null, 2)
-```
-
-The result is a pretty-printed JSON string with 2-space indentation. The
-exported file can be re-imported with full round-trip fidelity (all fields
-except `id` and `status` are preserved exactly).
-
-## Round-Trip Fidelity
-
-A profile exported with `exportProfileToJson` and re-imported with
-`importProfileFromJson` must satisfy:
-
-- All fields **except** `id` (reassigned) and `status` (forced `'Draft'`)
-  are byte-identical to the original.
-
-This guarantee is verified by unit test `UT-AC-STORE-023`.
-
-## Versioning and Compatibility
-
-The `schemaVersion` field tracks the data model version:
+## Schema Versioning
 
 | Version | Description |
 | :------ | :---------- |
-| `1` | M2 + M3 fields: all current fields including `costPerHour`, `checklistScaffold`, `passengerProfiles`, `status` |
+| `1` | M2 + M3 fields including `costPerHour`, `checklistScaffold`, `passengerProfiles`, `status` |
 
 ## Related Documents
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerodash/frontend",
-  "version": "0.2.0-alpha",
+  "version": "0.3.0-alpha",
   "description": "AeroDash - Flight Preparation & Decision Support Tool for General Aviation",
   "private": true,
   "type": "module",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -179,22 +179,35 @@ const themeLabel = computed(() =>
       <button class="pwa-update-btn" @click="pwaStore.applyUpdate()">Reload to update</button>
     </div>
 
-    <!-- ═══ Version blocked banner (REQ-SYS-006) ═════════════════════════════ -->
-    <div
-      v-if="appVersionStore.versionBlocked"
-      class="version-blocked-banner"
-      role="alert"
-      aria-live="assertive"
-    >
-      <strong>Operation blocked.</strong>
-      This version of AeroDash (v{{ appVersionStore.currentVersion }}) is below the
-      minimum safe version (v{{ appVersionStore.minSafeVersion }}). Please update the
-      application before continuing.
-    </div>
-
     <!-- ═══ Main content ════════════════════════════════════════════════════ -->
+    <!-- REQ-SYS-006: Block all safety-critical features when version is below minimum -->
     <main class="app-main" id="main-content">
-      <RouterView />
+      <div
+        v-if="appVersionStore.versionBlocked"
+        class="version-blocked-screen"
+        role="alert"
+        aria-live="assertive"
+        data-testid="version-blocked-screen"
+      >
+        <div class="version-blocked-screen__card">
+          <div class="version-blocked-screen__icon" aria-hidden="true">⛔</div>
+          <h1 class="version-blocked-screen__title">Application Update Required</h1>
+          <p class="version-blocked-screen__body">
+            This version of AeroDash (<strong>{{ appVersionStore.currentVersion }}</strong>) is
+            below the minimum required version
+            (<strong>{{ appVersionStore.minSafeVersion }}</strong>).
+          </p>
+          <p class="version-blocked-screen__body">
+            Safety-critical features (Mass &amp; Balance, Performance, Fuel &amp; Endurance) are
+            <strong>disabled</strong> until the application is updated.
+          </p>
+          <p class="version-blocked-screen__advisory">
+            Please refresh the page or update your PWA installation. If this error persists, clear
+            your browser cache and reload.
+          </p>
+        </div>
+      </div>
+      <RouterView v-else />
     </main>
 
     <!-- ═══ Bottom navigation (mobile only) ════════════════════════════════ -->
@@ -272,21 +285,52 @@ const themeLabel = computed(() =>
   background: rgba(255, 255, 255, 0.25);
 }
 
-/* ─── Version blocked banner ──────────────────────────────────────────────── */
+/* ─── Version-blocked screen (REQ-SYS-006) ───────────────────────────────── */
 
-.version-blocked-banner {
-  grid-column: 1 / -1;
+.version-blocked-screen {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  background: var(--color-danger, #b91c1c);
-  color: #fff;
-  font-size: var(--text-sm);
-  z-index: 300;
+  min-height: 100%;
+  padding: var(--space-8);
+  background: var(--color-bg);
+}
+
+.version-blocked-screen__card {
+  max-width: 480px;
+  width: 100%;
+  padding: var(--space-8);
+  background: var(--color-surface);
+  border: 2px solid var(--color-danger, #dc2626);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
   text-align: center;
-  flex-wrap: wrap;
+}
+
+.version-blocked-screen__icon {
+  font-size: 3rem;
+  margin-bottom: var(--space-4);
+}
+
+.version-blocked-screen__title {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-danger, #dc2626);
+  margin: 0 0 var(--space-4);
+}
+
+.version-blocked-screen__body {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-3);
+  line-height: 1.6;
+}
+
+.version-blocked-screen__advisory {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin: var(--space-4) 0 0;
+  line-height: 1.5;
 }
 
 /* ─── Shell grid ──────────────────────────────────────────────────────────── */

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
 // @IMP-UI-SHARED-002@ (FROM: @REQ-UI-011@, @REQ-SYS-001@)
 // @IMP-SYS-SHARED-003@ (FROM: @REQ-SYS-005@)
-import { ref, computed } from 'vue'
+// @IMP-SYS-SHARED-005@ (FROM: @REQ-SYS-006@)
+import { ref, computed, onMounted } from 'vue'
 import { RouterView, RouterLink, useRoute } from 'vue-router'
 import { useTheme } from '@/shared/composables/useTheme'
 import AppLogo from '@/shared/components/AppLogo.vue'
 import AppVersion from '@/shared/components/AppVersion.vue'
 import { usePwaUpdateStore } from '@/stores/pwa-update.store'
+import { useAppVersionStore } from '@/stores/app-version.store'
 
 const pwaStore = usePwaUpdateStore()
+const appVersionStore = useAppVersionStore()
+
+// REQ-SYS-006: check minimum safe version on startup (online-only)
+onMounted(() => {
+  void appVersionStore.checkMinSafeVersion()
+})
 
 const { theme, toggleTheme } = useTheme()
 const route = useRoute()
@@ -171,6 +179,19 @@ const themeLabel = computed(() =>
       <button class="pwa-update-btn" @click="pwaStore.applyUpdate()">Reload to update</button>
     </div>
 
+    <!-- ═══ Version blocked banner (REQ-SYS-006) ═════════════════════════════ -->
+    <div
+      v-if="appVersionStore.versionBlocked"
+      class="version-blocked-banner"
+      role="alert"
+      aria-live="assertive"
+    >
+      <strong>Operation blocked.</strong>
+      This version of AeroDash (v{{ appVersionStore.currentVersion }}) is below the
+      minimum safe version (v{{ appVersionStore.minSafeVersion }}). Please update the
+      application before continuing.
+    </div>
+
     <!-- ═══ Main content ════════════════════════════════════════════════════ -->
     <main class="app-main" id="main-content">
       <RouterView />
@@ -249,6 +270,23 @@ const themeLabel = computed(() =>
 
 .pwa-update-btn:hover {
   background: rgba(255, 255, 255, 0.25);
+}
+
+/* ─── Version blocked banner ──────────────────────────────────────────────── */
+
+.version-blocked-banner {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-danger, #b91c1c);
+  color: #fff;
+  font-size: var(--text-sm);
+  z-index: 300;
+  text-align: center;
+  flex-wrap: wrap;
 }
 
 /* ─── Shell grid ──────────────────────────────────────────────────────────── */

--- a/frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for AircraftModelSelector.vue
+ *
+ * Covers: manufacturer filter rendering, ICAO auto-fill on model selection,
+ * reverse lookup from ICAO, 'Other' manufacturer free-text mode.
+ *
+ * @see frontend/src/modules/aircraft/components/AircraftModelSelector.vue
+ */
+
+// @UT-AC-VIEW-025@ (FROM: @IMP-AC-VIEW-002@, @IMP-AC-VIEW-003@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AircraftModelSelector from '../components/AircraftModelSelector.vue'
+
+function mountSelector(props: {
+  manufacturer?: string
+  model?: string
+  icaoTypeDesignator?: string
+}) {
+  return mount(AircraftModelSelector, { props })
+}
+
+describe('AircraftModelSelector — manufacturer list', () => {
+  // @UT-AC-VIEW-025@ (FROM: @IMP-AC-VIEW-002@)
+  it('renders manufacturer select with known manufacturers', () => {
+    const wrapper = mountSelector({})
+    const select = wrapper.find('#manufacturer-select')
+    expect(select.exists()).toBe(true)
+    const optionText = select.text()
+    expect(optionText).toContain('Cessna')
+    expect(optionText).toContain('Piper')
+    expect(optionText).toContain('Diamond')
+    expect(optionText).toContain('Other')
+  })
+
+  // @UT-AC-VIEW-026@ (FROM: @IMP-AC-VIEW-002@)
+  it("renders 'Other' as the last manufacturer option", () => {
+    const wrapper = mountSelector({})
+    const options = wrapper.findAll('#manufacturer-select option')
+    const textValues = options.map((o) => o.text())
+    expect(textValues[textValues.length - 1]).toBe('Other')
+  })
+})
+
+describe('AircraftModelSelector — model dropdown filter', () => {
+  // @UT-AC-VIEW-027@ (FROM: @IMP-AC-VIEW-002@)
+  it('shows only Cessna models when manufacturer is Cessna', () => {
+    const wrapper = mountSelector({ manufacturer: 'Cessna' })
+    const select = wrapper.find('#model-input')
+    expect(select.exists()).toBe(true)
+    const optionText = select.text()
+    expect(optionText).toContain('C152')
+    expect(optionText).toContain('C172S Skyhawk SP')
+    expect(optionText).not.toContain('PA-28')
+  })
+
+  // @UT-AC-VIEW-028@ (FROM: @IMP-AC-VIEW-002@)
+  it('shows only Piper models when manufacturer is Piper', () => {
+    const wrapper = mountSelector({ manufacturer: 'Piper' })
+    const select = wrapper.find('#model-input')
+    const optionText = select.text()
+    expect(optionText).toContain('PA-28-161 Warrior III')
+    expect(optionText).not.toContain('C152')
+  })
+
+  // @UT-AC-VIEW-029@ (FROM: @IMP-AC-VIEW-002@)
+  it('model select is disabled when no manufacturer is selected', () => {
+    const wrapper = mountSelector({ manufacturer: '' })
+    const select = wrapper.find('#model-input')
+    expect(select.attributes('disabled')).toBeDefined()
+  })
+})
+
+describe("AircraftModelSelector — 'Other' manufacturer free-text mode (REQ-UI-002)", () => {
+  // @UT-AC-VIEW-030@ (FROM: @IMP-AC-VIEW-002@)
+  it("renders a text input for model when manufacturer is 'Other'", () => {
+    const wrapper = mountSelector({ manufacturer: 'Other' })
+    const input = wrapper.find('input#model-input')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('type')).toBe('text')
+  })
+
+  // @UT-AC-VIEW-031@ (FROM: @IMP-AC-VIEW-002@)
+  it("does not render a model dropdown when manufacturer is 'Other'", () => {
+    const wrapper = mountSelector({ manufacturer: 'Other' })
+    const select = wrapper.find('select#model-input')
+    expect(select.exists()).toBe(false)
+  })
+
+  // @UT-AC-VIEW-032@ (FROM: @IMP-AC-VIEW-002@)
+  it("emits 'update:model' when free-text model input changes", async () => {
+    const wrapper = mountSelector({ manufacturer: 'Other', model: '' })
+    const input = wrapper.find('input#model-input')
+    await input.setValue('My Custom Aircraft')
+    const emitted = wrapper.emitted('update:model')
+    expect(emitted).toBeDefined()
+    expect(emitted[emitted.length - 1]).toEqual(['My Custom Aircraft'])
+  })
+})
+
+describe('AircraftModelSelector — ICAO auto-fill on model selection (REQ-UI-003)', () => {
+  // @UT-AC-VIEW-033@ (FROM: @IMP-AC-VIEW-003@)
+  it("emits 'update:icaoTypeDesignator' with C172 when C172S Skyhawk SP is selected", async () => {
+    const wrapper = mountSelector({ manufacturer: 'Cessna', model: '' })
+    const select = wrapper.find('select#model-input')
+    await select.setValue('C172S Skyhawk SP')
+    await select.trigger('change')
+    const emitted = wrapper.emitted('update:icaoTypeDesignator')
+    expect(emitted).toBeDefined()
+    expect(emitted[emitted.length - 1]).toEqual(['C172'])
+  })
+
+  // @UT-AC-VIEW-034@ (FROM: @IMP-AC-VIEW-003@)
+  it("emits 'update:icaoTypeDesignator' with DA42 when DA42 Twin Star is selected", async () => {
+    const wrapper = mountSelector({ manufacturer: 'Diamond', model: '' })
+    const select = wrapper.find('select#model-input')
+    await select.setValue('DA42 Twin Star')
+    await select.trigger('change')
+    const emitted = wrapper.emitted('update:icaoTypeDesignator')
+    expect(emitted).toBeDefined()
+    expect(emitted[emitted.length - 1]).toEqual(['DA42'])
+  })
+})
+
+describe('AircraftModelSelector — manufacturer change resets model and ICAO', () => {
+  // @UT-AC-VIEW-035@ (FROM: @IMP-AC-VIEW-003@)
+  it('emits empty model and ICAO when manufacturer changes', async () => {
+    const wrapper = mountSelector({
+      manufacturer: 'Cessna',
+      model: 'C152',
+      icaoTypeDesignator: 'C152',
+    })
+    const select = wrapper.find('#manufacturer-select')
+    await select.setValue('Piper')
+    await select.trigger('change')
+    const modelEmitted = wrapper.emitted('update:model')
+    const icaoEmitted = wrapper.emitted('update:icaoTypeDesignator')
+    expect(modelEmitted).toBeDefined()
+    expect(modelEmitted[modelEmitted.length - 1]).toEqual([''])
+    expect(icaoEmitted).toBeDefined()
+    expect(icaoEmitted[icaoEmitted.length - 1]).toEqual([''])
+  })
+})
+
+describe('AircraftModelSelector — ICAO bidirectional reverse lookup (REQ-UI-004)', () => {
+  // @UT-AC-VIEW-036@ (FROM: @IMP-AC-VIEW-003@)
+  it('shows lookup results when ICAO input has 2+ characters matching catalogue', async () => {
+    const wrapper = mountSelector({ manufacturer: '', model: '', icaoTypeDesignator: '' })
+    const icaoInput = wrapper.find('#icao-designator-input')
+    await icaoInput.setValue('C172')
+    const results = wrapper.find('.icao-lookup-results')
+    expect(results.exists()).toBe(true)
+    expect(results.text()).toContain('Cessna')
+  })
+
+  // @UT-AC-VIEW-037@ (FROM: @IMP-AC-VIEW-003@)
+  it('shows no lookup results when ICAO input has fewer than 2 characters', async () => {
+    const wrapper = mountSelector({ manufacturer: '', model: '', icaoTypeDesignator: '' })
+    const icaoInput = wrapper.find('#icao-designator-input')
+    await icaoInput.setValue('C')
+    const results = wrapper.find('.icao-lookup-results')
+    expect(results.exists()).toBe(false)
+  })
+
+  // @UT-AC-VIEW-038@ (FROM: @IMP-AC-VIEW-003@)
+  it('emits manufacturer, model and ICAO when a lookup result is clicked', async () => {
+    const wrapper = mountSelector({ manufacturer: '', model: '', icaoTypeDesignator: '' })
+    const icaoInput = wrapper.find('#icao-designator-input')
+    await icaoInput.setValue('C152')
+    const resultItem = wrapper.find('.icao-lookup-result')
+    expect(resultItem.exists()).toBe(true)
+    await resultItem.trigger('click')
+    expect(wrapper.emitted('update:manufacturer')).toBeDefined()
+    expect(wrapper.emitted('update:model')).toBeDefined()
+    expect(wrapper.emitted('update:icaoTypeDesignator')).toBeDefined()
+    const lastIcao = wrapper.emitted('update:icaoTypeDesignator')
+    expect(lastIcao[lastIcao.length - 1]).toEqual(['C152'])
+  })
+
+  // @UT-AC-VIEW-039@ (FROM: @IMP-AC-VIEW-003@)
+  it('normalises ICAO input to uppercase before emitting', async () => {
+    const wrapper = mountSelector({ manufacturer: '', model: '', icaoTypeDesignator: '' })
+    const icaoInput = wrapper.find('#icao-designator-input')
+    await icaoInput.setValue('da40')
+    const emitted = wrapper.emitted('update:icaoTypeDesignator')
+    expect(emitted).toBeDefined()
+    expect(emitted[0]).toEqual(['DA40'])
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
@@ -95,7 +95,7 @@ describe("AircraftModelSelector — 'Other' manufacturer free-text mode (REQ-UI-
     await input.setValue('My Custom Aircraft')
     const emitted = wrapper.emitted('update:model')
     expect(emitted).toBeDefined()
-    expect(emitted[emitted.length - 1]).toEqual(['My Custom Aircraft'])
+    expect(emitted![emitted!.length - 1]).toEqual(['My Custom Aircraft'])
   })
 })
 
@@ -108,7 +108,7 @@ describe('AircraftModelSelector — ICAO auto-fill on model selection (REQ-UI-00
     await select.trigger('change')
     const emitted = wrapper.emitted('update:icaoTypeDesignator')
     expect(emitted).toBeDefined()
-    expect(emitted[emitted.length - 1]).toEqual(['C172'])
+    expect(emitted![emitted!.length - 1]).toEqual(['C172'])
   })
 
   // @UT-AC-VIEW-034@ (FROM: @IMP-AC-VIEW-003@)
@@ -119,7 +119,7 @@ describe('AircraftModelSelector — ICAO auto-fill on model selection (REQ-UI-00
     await select.trigger('change')
     const emitted = wrapper.emitted('update:icaoTypeDesignator')
     expect(emitted).toBeDefined()
-    expect(emitted[emitted.length - 1]).toEqual(['DA42'])
+    expect(emitted![emitted!.length - 1]).toEqual(['DA42'])
   })
 })
 
@@ -137,9 +137,9 @@ describe('AircraftModelSelector — manufacturer change resets model and ICAO', 
     const modelEmitted = wrapper.emitted('update:model')
     const icaoEmitted = wrapper.emitted('update:icaoTypeDesignator')
     expect(modelEmitted).toBeDefined()
-    expect(modelEmitted[modelEmitted.length - 1]).toEqual([''])
+    expect(modelEmitted![modelEmitted!.length - 1]).toEqual([''])
     expect(icaoEmitted).toBeDefined()
-    expect(icaoEmitted[icaoEmitted.length - 1]).toEqual([''])
+    expect(icaoEmitted![icaoEmitted!.length - 1]).toEqual([''])
   })
 })
 
@@ -175,7 +175,7 @@ describe('AircraftModelSelector — ICAO bidirectional reverse lookup (REQ-UI-00
     expect(wrapper.emitted('update:model')).toBeDefined()
     expect(wrapper.emitted('update:icaoTypeDesignator')).toBeDefined()
     const lastIcao = wrapper.emitted('update:icaoTypeDesignator')
-    expect(lastIcao[lastIcao.length - 1]).toEqual(['C152'])
+    expect(lastIcao![lastIcao!.length - 1]).toEqual(['C152'])
   })
 
   // @UT-AC-VIEW-039@ (FROM: @IMP-AC-VIEW-003@)
@@ -185,6 +185,6 @@ describe('AircraftModelSelector — ICAO bidirectional reverse lookup (REQ-UI-00
     await icaoInput.setValue('da40')
     const emitted = wrapper.emitted('update:icaoTypeDesignator')
     expect(emitted).toBeDefined()
-    expect(emitted[0]).toEqual(['DA40'])
+    expect(emitted![0]).toEqual(['DA40'])
   })
 })

--- a/frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for FleetList.vue
+ * Covers: loading state, empty state, profile list rendering, action buttons,
+ * active profile highlighting, Select/Active button state, and delete confirmation.
+ *
+ * @see frontend/src/modules/aircraft/components/FleetList.vue
+ */
+
+// @UT-AC-VIEW-080@ (FROM: @IMP-AC-VIEW-005@, @IMP-AC-VIEW-006@)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia, defineStore } from 'pinia'
+import { ref } from 'vue'
+import FleetList from '../components/FleetList.vue'
+import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+
+/** Minimal valid AircraftProfile for testing. */
+function makeProfile(overrides: Partial<AircraftProfile> = {}): AircraftProfile {
+  return {
+    id: '00000000-0000-4000-a000-000000000001',
+    ownerId: 'user-test',
+    registration: 'D-EBPN',
+    manufacturer: 'Tecnam',
+    model: 'P2008 JC',
+    icaoTypeDesignator: 'P208',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Leading edge',
+    referenceDatumLocation: 'Station 0',
+    shareCode: null,
+    status: 'Draft',
+    schemaVersion: 1,
+    passengerProfiles: [],
+    weighingReports: [{ bem: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' }],
+    loadPoints: [
+      {
+        name: 'Pilot',
+        arm: 1.8,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 650,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.841, mass: 432 },
+          { armOrMoment: 1.841, mass: 650 },
+          { armOrMoment: 1.978, mass: 650 },
+          { armOrMoment: 1.978, mass: 432 },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+// ─── Store factories (inline stubs for isolation) ──────────────────────────
+
+function makeFleetStore(overrides: {
+  isLoading?: boolean
+  profiles?: AircraftProfile[]
+}) {
+  return defineStore('fleet', () => {
+    const isLoading = ref(overrides.isLoading ?? false)
+    const profiles = ref<AircraftProfile[]>(overrides.profiles ?? [])
+    const notifications = ref<unknown[]>([])
+    const checkDraftWarning = vi.fn<(p: AircraftProfile) => void>()
+    const verifyProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+    const editVerifiedProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+    const deleteProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+    return { isLoading, profiles, notifications, checkDraftWarning, verifyProfile, editVerifiedProfile, deleteProfile }
+  })
+}
+
+function makeActiveStore(activeProfile: AircraftProfile | null = null) {
+  return defineStore('activeAircraft', () => {
+    const active = ref<AircraftProfile | null>(activeProfile)
+    const setActiveProfile = vi.fn<(p: AircraftProfile) => void>((p: AircraftProfile) => { active.value = p })
+    const clearActive = vi.fn<() => void>()
+    return { activeProfile: active, setActiveProfile, clearActive }
+  })
+}
+
+function mountFleetList(options: {
+  isLoading?: boolean
+  profiles?: AircraftProfile[]
+  activeProfile?: AircraftProfile | null
+}) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  makeFleetStore({ isLoading: options.isLoading, profiles: options.profiles })()
+  makeActiveStore(options.activeProfile ?? null)()
+  return mount(FleetList, { global: { plugins: [pinia] } })
+}
+
+describe('FleetList — loading state', () => {
+  beforeEach(() => { setActivePinia(createPinia()) })
+
+  // @UT-AC-VIEW-080@ (FROM: @IMP-AC-VIEW-005@)
+  it('shows loading message when isLoading is true', () => {
+    const wrapper = mountFleetList({ isLoading: true, profiles: [] })
+    expect(wrapper.text()).toContain('Loading fleet')
+  })
+})
+
+describe('FleetList — empty state', () => {
+  beforeEach(() => { setActivePinia(createPinia()) })
+
+  // @UT-AC-VIEW-081@ (FROM: @IMP-AC-VIEW-005@)
+  it('shows empty-state message when no profiles exist', () => {
+    const wrapper = mountFleetList({ profiles: [] })
+    expect(wrapper.text()).toContain('No aircraft profiles')
+  })
+
+  // @UT-AC-VIEW-082@ (FROM: @IMP-AC-VIEW-005@)
+  it('does not render the profiles list when empty', () => {
+    const wrapper = mountFleetList({ profiles: [] })
+    expect(wrapper.find('.profiles-list').exists()).toBe(false)
+  })
+})
+
+describe('FleetList — profile list rendering', () => {
+  beforeEach(() => { setActivePinia(createPinia()) })
+
+  // @UT-AC-VIEW-083@ (FROM: @IMP-AC-VIEW-005@)
+  it('renders a list item for each profile', () => {
+    const profiles = [
+      makeProfile({ id: 'p1', registration: 'D-EBPN' }),
+      makeProfile({ id: 'p2', registration: 'G-ABCD' }),
+    ]
+    const wrapper = mountFleetList({ profiles })
+    const items = wrapper.findAll('.profile-item')
+    expect(items).toHaveLength(2)
+  })
+
+  // @UT-AC-VIEW-084@ (FROM: @IMP-AC-VIEW-005@)
+  it('displays registration and model for each profile', () => {
+    const profile = makeProfile({ registration: 'D-EBPN', manufacturer: 'Tecnam', model: 'P2008 JC' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+    expect(wrapper.text()).toContain('D-EBPN')
+    expect(wrapper.text()).toContain('Tecnam P2008 JC')
+  })
+
+  // @UT-AC-VIEW-085@ (FROM: @IMP-AC-VIEW-005@)
+  it('shows ProfileStatusBadge for each profile', () => {
+    const profile = makeProfile({ status: 'Draft' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+    expect(wrapper.find('.profile-status-badge').exists()).toBe(true)
+  })
+})
+
+describe('FleetList — active profile highlighting', () => {
+  beforeEach(() => { setActivePinia(createPinia()) })
+
+  // @UT-AC-VIEW-086@ (FROM: @IMP-AC-VIEW-006@)
+  it('applies active CSS class to the active profile item', () => {
+    const profile = makeProfile({ id: 'p1' })
+    const wrapper = mountFleetList({ profiles: [profile], activeProfile: profile })
+    expect(wrapper.find('.profile-item--active').exists()).toBe(true)
+  })
+
+  // @UT-AC-VIEW-087@ (FROM: @IMP-AC-VIEW-006@)
+  it('does not apply active CSS class when no active profile', () => {
+    const profile = makeProfile({ id: 'p1' })
+    const wrapper = mountFleetList({ profiles: [profile], activeProfile: null })
+    expect(wrapper.find('.profile-item--active').exists()).toBe(false)
+  })
+})
+
+describe('FleetList — action buttons', () => {
+  beforeEach(() => { setActivePinia(createPinia()) })
+
+  // @UT-AC-VIEW-088@ (FROM: @IMP-AC-VIEW-006@)
+  it('Select button is disabled when profile is already active', () => {
+    const profile = makeProfile({ id: 'p1' })
+    const wrapper = mountFleetList({ profiles: [profile], activeProfile: profile })
+    const btn = wrapper.find('.btn-primary')
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.text()).toBe('Active')
+  })
+
+  // @UT-AC-VIEW-089@ (FROM: @IMP-AC-VIEW-006@)
+  it('Select button is enabled when profile is not active', () => {
+    const profile = makeProfile({ id: 'p1' })
+    const wrapper = mountFleetList({ profiles: [profile], activeProfile: null })
+    const btn = wrapper.find('.btn-primary')
+    expect(btn.attributes('disabled')).toBeUndefined()
+    expect(btn.text()).toBe('Select')
+  })
+
+  // @UT-AC-VIEW-090@ (FROM: @IMP-AC-VIEW-006@)
+  it('shows Verify button only for Draft profiles', () => {
+    const draft = makeProfile({ status: 'Draft' })
+    const wrapper = mountFleetList({ profiles: [draft] })
+    expect(wrapper.find('.btn-success').exists()).toBe(true)
+  })
+
+  // @UT-AC-VIEW-091@ (FROM: @IMP-AC-VIEW-006@)
+  it('shows Edit button only for Verified profiles', () => {
+    const verified = makeProfile({ status: 'Verified' })
+    const wrapper = mountFleetList({ profiles: [verified] })
+    expect(wrapper.find('.btn-secondary').exists()).toBe(true)
+    expect(wrapper.find('.btn-success').exists()).toBe(false)
+  })
+
+  // @UT-AC-VIEW-092@ (FROM: @IMP-AC-VIEW-006@)
+  it('always shows Delete button for each profile', () => {
+    const profile = makeProfile()
+    const wrapper = mountFleetList({ profiles: [profile] })
+    expect(wrapper.find('.btn-danger').exists()).toBe(true)
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for ProfileStatusBadge.vue
+ * Covers: rendering, CSS classes, aria-label, and title for Draft/Verified statuses.
+ *
+ * @see frontend/src/modules/aircraft/components/ProfileStatusBadge.vue
+ */
+
+// @UT-AC-VIEW-070@ (FROM: @IMP-AC-VIEW-004@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ProfileStatusBadge from '../components/ProfileStatusBadge.vue'
+
+/**
+ * The component template has a leading HTML comment which creates a fragment root in Vue 3.
+ * Scope all attribute/class assertions to the inner badge span via find('[role="status"]').
+ */
+
+describe('ProfileStatusBadge — Verified status', () => {
+  // @UT-AC-VIEW-070@ (FROM: @IMP-AC-VIEW-004@)
+  it('renders "Verified" label for Verified status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Verified' } })
+    expect(wrapper.text()).toBe('Verified')
+  })
+
+  // @UT-AC-VIEW-071@ (FROM: @IMP-AC-VIEW-004@)
+  it('applies status-verified CSS class for Verified status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Verified' } })
+    const badge = wrapper.find('[role="status"]')
+    expect(badge.classes()).toContain('status-verified')
+    expect(badge.classes()).not.toContain('status-draft')
+  })
+
+  // @UT-AC-VIEW-072@ (FROM: @IMP-AC-VIEW-004@)
+  it('sets correct aria-label for Verified status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Verified' } })
+    expect(wrapper.find('[role="status"]').attributes('aria-label')).toBe('Profile status: Verified')
+  })
+
+  // @UT-AC-VIEW-073@ (FROM: @IMP-AC-VIEW-004@)
+  it('sets informative title for Verified status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Verified' } })
+    expect(wrapper.find('[role="status"]').attributes('title')).toContain('safe for calculations')
+  })
+
+  // @UT-AC-VIEW-074@ (FROM: @IMP-AC-VIEW-004@)
+  it('has role="status" for accessibility', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Verified' } })
+    expect(wrapper.find('[role="status"]').exists()).toBe(true)
+  })
+})
+
+describe('ProfileStatusBadge — Draft status', () => {
+  // @UT-AC-VIEW-075@ (FROM: @IMP-AC-VIEW-004@)
+  it('renders "Draft" label for Draft status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Draft' } })
+    expect(wrapper.text()).toBe('Draft')
+  })
+
+  // @UT-AC-VIEW-076@ (FROM: @IMP-AC-VIEW-004@)
+  it('applies status-draft CSS class for Draft status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Draft' } })
+    const badge = wrapper.find('[role="status"]')
+    expect(badge.classes()).toContain('status-draft')
+    expect(badge.classes()).not.toContain('status-verified')
+  })
+
+  // @UT-AC-VIEW-077@ (FROM: @IMP-AC-VIEW-004@)
+  it('sets correct aria-label for Draft status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Draft' } })
+    expect(wrapper.find('[role="status"]').attributes('aria-label')).toBe('Profile status: Draft')
+  })
+
+  // @UT-AC-VIEW-078@ (FROM: @IMP-AC-VIEW-004@)
+  it('sets safety warning in title for Draft status', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'Draft' } })
+    const title = wrapper.find('[role="status"]').attributes('title')
+    expect(title).toContain('Draft')
+    expect(title).toContain('safety-critical')
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for aircraft-model-catalogue.ts
+ *
+ * Covers: manufacturer filter, ICAO auto-fill, reverse lookup, 'Other' manual entry.
+ *
+ * @see frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
+ */
+
+// @UT-AC-VIEW-001@ (FROM: @IMP-AC-VIEW-001@)
+
+import { describe, it, expect } from 'vitest'
+import {
+  AIRCRAFT_MODEL_CATALOGUE,
+  CATALOGUE_VERSION,
+  getManufacturers,
+  getModelsByManufacturer,
+  findByIcaoDesignator,
+} from '../data/aircraft-model-catalogue'
+
+describe('AIRCRAFT_MODEL_CATALOGUE', () => {
+  // @UT-AC-VIEW-001@ (FROM: @IMP-AC-VIEW-001@)
+  it('contains at least one entry per expected manufacturer', () => {
+    const manufacturers = AIRCRAFT_MODEL_CATALOGUE.map((e) => e.manufacturer)
+    expect(manufacturers).toContain('Cessna')
+    expect(manufacturers).toContain('Piper')
+    expect(manufacturers).toContain('Diamond')
+    expect(manufacturers).toContain('Tecnam')
+    expect(manufacturers).toContain('Robin')
+  })
+
+  // @UT-AC-VIEW-002@ (FROM: @IMP-AC-VIEW-001@)
+  it('every entry has a non-empty manufacturer, model, and icaoTypeDesignator', () => {
+    for (const entry of AIRCRAFT_MODEL_CATALOGUE) {
+      expect(entry.manufacturer.length).toBeGreaterThan(0)
+      expect(entry.model.length).toBeGreaterThan(0)
+      expect(entry.icaoTypeDesignator.length).toBeGreaterThan(0)
+    }
+  })
+
+  // @UT-AC-VIEW-003@ (FROM: @IMP-AC-VIEW-001@)
+  it('CATALOGUE_VERSION is a non-empty string', () => {
+    expect(typeof CATALOGUE_VERSION).toBe('string')
+    expect(CATALOGUE_VERSION.length).toBeGreaterThan(0)
+  })
+})
+
+describe('getManufacturers', () => {
+  // @UT-AC-VIEW-004@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns a list containing all unique manufacturers from the catalogue', () => {
+    const result = getManufacturers()
+    expect(result).toContain('Cessna')
+    expect(result).toContain('Piper')
+    expect(result).toContain('Diamond')
+    expect(result).toContain('Tecnam')
+    expect(result).toContain('Robin')
+  })
+
+  // @UT-AC-VIEW-005@ (FROM: @IMP-AC-VIEW-001@)
+  it("appends 'Other' as the last entry (REQ-UI-002)", () => {
+    const result = getManufacturers()
+    expect(result[result.length - 1]).toBe('Other')
+  })
+
+  // @UT-AC-VIEW-006@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns manufacturers in alphabetical order before Other', () => {
+    const result = getManufacturers()
+    const withoutOther = result.slice(0, -1)
+    const sorted = [...withoutOther].sort()
+    expect(withoutOther).toEqual(sorted)
+  })
+
+  // @UT-AC-VIEW-007@ (FROM: @IMP-AC-VIEW-001@)
+  it('does not contain duplicates', () => {
+    const result = getManufacturers()
+    const unique = new Set(result)
+    expect(result.length).toBe(unique.size)
+  })
+})
+
+describe('getModelsByManufacturer', () => {
+  // @UT-AC-VIEW-008@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns all Cessna models from the catalogue', () => {
+    const result = getModelsByManufacturer('Cessna')
+    expect(result.length).toBeGreaterThan(0)
+    for (const entry of result) {
+      expect(entry.manufacturer).toBe('Cessna')
+    }
+  })
+
+  // @UT-AC-VIEW-009@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns only models matching the requested manufacturer', () => {
+    const result = getModelsByManufacturer('Piper')
+    for (const entry of result) {
+      expect(entry.manufacturer).toBe('Piper')
+    }
+    expect(result.some((e) => e.manufacturer === 'Cessna')).toBe(false)
+  })
+
+  // @UT-AC-VIEW-010@ (FROM: @IMP-AC-VIEW-001@)
+  it("returns an empty array for manufacturer = 'Other' (manual entry mode, REQ-UI-002)", () => {
+    const result = getModelsByManufacturer('Other')
+    expect(result).toEqual([])
+  })
+
+  // @UT-AC-VIEW-011@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns an empty array for an unknown manufacturer', () => {
+    const result = getModelsByManufacturer('NonExistentOEM')
+    expect(result).toEqual([])
+  })
+
+  // @UT-AC-VIEW-012@ (FROM: @IMP-AC-VIEW-001@)
+  it('each returned entry contains the expected fields', () => {
+    const result = getModelsByManufacturer('Diamond')
+    for (const entry of result) {
+      expect(typeof entry.manufacturer).toBe('string')
+      expect(typeof entry.model).toBe('string')
+      expect(typeof entry.icaoTypeDesignator).toBe('string')
+    }
+  })
+
+  // @UT-AC-VIEW-013@ (FROM: @IMP-AC-VIEW-001@)
+  it('Diamond has DA40 Diamond Star in its model list', () => {
+    const result = getModelsByManufacturer('Diamond')
+    const models = result.map((e) => e.model)
+    expect(models).toContain('DA40 Diamond Star')
+  })
+})
+
+describe('findByIcaoDesignator', () => {
+  // @UT-AC-VIEW-014@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns the correct entry for a known ICAO designator (C172)', () => {
+    const result = findByIcaoDesignator('C172')
+    expect(result.length).toBeGreaterThan(0)
+    const designators = result.map((e) => e.icaoTypeDesignator)
+    expect(designators.every((d) => d === 'C172')).toBe(true)
+  })
+
+  // @UT-AC-VIEW-015@ (FROM: @IMP-AC-VIEW-001@)
+  it('performs case-insensitive lookup (lowercase input)', () => {
+    const upperResult = findByIcaoDesignator('C172')
+    const lowerResult = findByIcaoDesignator('c172')
+    expect(lowerResult).toEqual(upperResult)
+  })
+
+  // @UT-AC-VIEW-016@ (FROM: @IMP-AC-VIEW-001@)
+  it('trims whitespace before lookup', () => {
+    const result = findByIcaoDesignator('  C172  ')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  // @UT-AC-VIEW-017@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns an empty array for an unknown ICAO designator', () => {
+    const result = findByIcaoDesignator('ZZZZ')
+    expect(result).toEqual([])
+  })
+
+  // @UT-AC-VIEW-018@ (FROM: @IMP-AC-VIEW-001@)
+  it('returns multiple entries when multiple models share an ICAO designator (PA28)', () => {
+    const result = findByIcaoDesignator('PA28')
+    expect(result.length).toBeGreaterThanOrEqual(2)
+  })
+
+  // @UT-AC-VIEW-019@ (FROM: @IMP-AC-VIEW-001@)
+  it('reverse lookup returns correct manufacturer for P208 (Tecnam)', () => {
+    const result = findByIcaoDesignator('P208')
+    expect(result.length).toBeGreaterThan(0)
+    expect(result[0].manufacturer).toBe('Tecnam')
+    expect(result[0].model).toBe('P2008 JC')
+  })
+
+  // @UT-AC-VIEW-020@ (FROM: @IMP-AC-VIEW-001@)
+  it('reverse lookup returns correct manufacturer for DA40 (Diamond)', () => {
+    const result = findByIcaoDesignator('DA40')
+    expect(result.length).toBe(1)
+    expect(result[0].manufacturer).toBe('Diamond')
+    expect(result[0].model).toBe('DA40 Diamond Star')
+  })
+})
+
+describe('ICAO auto-fill from catalogue entry (REQ-UI-003)', () => {
+  // @UT-AC-VIEW-021@ (FROM: @IMP-AC-VIEW-001@)
+  it('selecting Cessna C172S Skyhawk SP auto-fills C172 as ICAO designator', () => {
+    const models = getModelsByManufacturer('Cessna')
+    const entry = models.find((e) => e.model === 'C172S Skyhawk SP')
+    expect(entry).toBeDefined()
+    expect(entry.icaoTypeDesignator).toBe('C172')
+  })
+
+  // @UT-AC-VIEW-022@ (FROM: @IMP-AC-VIEW-001@)
+  it('selecting Piper PA-44-180 Seminole auto-fills PA44 as ICAO designator', () => {
+    const models = getModelsByManufacturer('Piper')
+    const entry = models.find((e) => e.model === 'PA-44-180 Seminole')
+    expect(entry).toBeDefined()
+    expect(entry.icaoTypeDesignator).toBe('PA44')
+  })
+})
+
+describe("'Other' manufacturer triggers manual entry (REQ-UI-002)", () => {
+  // @UT-AC-VIEW-023@ (FROM: @IMP-AC-VIEW-001@)
+  it("getManufacturers includes 'Other' as an option", () => {
+    expect(getManufacturers()).toContain('Other')
+  })
+
+  // @UT-AC-VIEW-024@ (FROM: @IMP-AC-VIEW-001@)
+  it("getModelsByManufacturer('Other') returns empty to signal free-text mode", () => {
+    expect(getModelsByManufacturer('Other')).toHaveLength(0)
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
@@ -164,16 +164,16 @@ describe('findByIcaoDesignator', () => {
   it('reverse lookup returns correct manufacturer for P208 (Tecnam)', () => {
     const result = findByIcaoDesignator('P208')
     expect(result.length).toBeGreaterThan(0)
-    expect(result[0].manufacturer).toBe('Tecnam')
-    expect(result[0].model).toBe('P2008 JC')
+    expect(result[0]!.manufacturer).toBe('Tecnam')
+    expect(result[0]!.model).toBe('P2008 JC')
   })
 
   // @UT-AC-VIEW-020@ (FROM: @IMP-AC-VIEW-001@)
   it('reverse lookup returns correct manufacturer for DA40 (Diamond)', () => {
     const result = findByIcaoDesignator('DA40')
     expect(result.length).toBe(1)
-    expect(result[0].manufacturer).toBe('Diamond')
-    expect(result[0].model).toBe('DA40 Diamond Star')
+    expect(result[0]!.manufacturer).toBe('Diamond')
+    expect(result[0]!.model).toBe('DA40 Diamond Star')
   })
 })
 
@@ -183,7 +183,7 @@ describe('ICAO auto-fill from catalogue entry (REQ-UI-003)', () => {
     const models = getModelsByManufacturer('Cessna')
     const entry = models.find((e) => e.model === 'C172S Skyhawk SP')
     expect(entry).toBeDefined()
-    expect(entry.icaoTypeDesignator).toBe('C172')
+    expect(entry!.icaoTypeDesignator).toBe('C172')
   })
 
   // @UT-AC-VIEW-022@ (FROM: @IMP-AC-VIEW-001@)
@@ -191,7 +191,7 @@ describe('ICAO auto-fill from catalogue entry (REQ-UI-003)', () => {
     const models = getModelsByManufacturer('Piper')
     const entry = models.find((e) => e.model === 'PA-44-180 Seminole')
     expect(entry).toBeDefined()
-    expect(entry.icaoTypeDesignator).toBe('PA44')
+    expect(entry!.icaoTypeDesignator).toBe('PA44')
   })
 })
 

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
@@ -134,7 +134,7 @@ describe('fleetRepository — CRUD lifecycle', () => {
     await create(profile)
     const found = await findById(profile.id)
     expect(found).toBeDefined()
-    expect(found.costPerHour).toBe(185.5)
+    expect(found!.costPerHour).toBe(185.5)
   })
 
   // @IT-AC-STORE-006@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
@@ -146,7 +146,7 @@ describe('fleetRepository — CRUD lifecycle', () => {
     await create(profile)
     const found = await findById(profile.id)
     expect(found).toBeDefined()
-    expect(found.referenceDatumDescription).toBe('Firewall forward face')
+    expect(found!.referenceDatumDescription).toBe('Firewall forward face')
   })
 
   // @IT-AC-STORE-007@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
@@ -161,14 +161,14 @@ describe('fleetRepository — CRUD lifecycle', () => {
     await create(profile)
     const found = await findById(profile.id)
     expect(found).toBeDefined()
-    expect(found.checklistScaffold).toHaveLength(2)
-    expect(found.checklistScaffold[0].title).toBe('Pre-flight')
-    expect(found.checklistScaffold[0].items).toEqual([
+    expect(found!.checklistScaffold).toHaveLength(2)
+    expect(found!.checklistScaffold![0]!.title).toBe('Pre-flight')
+    expect(found!.checklistScaffold![0]!.items).toEqual([
       'Check fuel',
       'Check oil',
       'Check control surfaces',
     ])
-    expect(found.checklistScaffold[1].title).toBe('Engine start')
+    expect(found!.checklistScaffold![1]!.title).toBe('Engine start')
   })
 
   // @IT-AC-STORE-008@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
@@ -184,10 +184,10 @@ describe('fleetRepository — CRUD lifecycle', () => {
     await create(profile)
     const found = await findById(profile.id)
     expect(found).toBeDefined()
-    expect(found.costPerHour).toBe(220.0)
-    expect(found.referenceDatumDescription).toBe('Leading edge of wing root')
-    expect(found.checklistScaffold).toHaveLength(1)
-    expect(found.checklistScaffold[0].title).toBe('Normal procedures')
+    expect(found!.costPerHour).toBe(220.0)
+    expect(found!.referenceDatumDescription).toBe('Leading edge of wing root')
+    expect(found!.checklistScaffold).toHaveLength(1)
+    expect(found!.checklistScaffold![0]!.title).toBe('Normal procedures')
   })
 
   // @IT-AC-STORE-009@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
@@ -203,9 +203,9 @@ describe('fleetRepository — CRUD lifecycle', () => {
     await update(updatedProfile)
 
     const found = await findById(profile.id)
-    expect(found.costPerHour).toBe(150.0)
-    expect(found.checklistScaffold).toHaveLength(1)
-    expect(found.checklistScaffold[0].title).toBe('Before landing')
+    expect(found!.costPerHour).toBe(150.0)
+    expect(found!.checklistScaffold).toHaveLength(1)
+    expect(found!.checklistScaffold![0]!.title).toBe('Before landing')
   })
 })
 

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
@@ -123,6 +123,7 @@ describe('fleetRepository — CRUD lifecycle', () => {
   it('findAll returns empty array when store is empty', async () => {
     const all = await findAll()
     expect(all).toEqual([])
+  })
 
   // @IT-AC-STORE-005@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
   it('round-trip: costPerHour persists and retrieves with full fidelity', async () => {

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
@@ -123,5 +123,143 @@ describe('fleetRepository — CRUD lifecycle', () => {
   it('findAll returns empty array when store is empty', async () => {
     const all = await findAll()
     expect(all).toEqual([])
+
+  // @IT-AC-STORE-005@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
+  it('round-trip: costPerHour persists and retrieves with full fidelity', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000010',
+      costPerHour: 185.5,
+    })
+    await create(profile)
+    const found = await findById(profile.id)
+    expect(found).toBeDefined()
+    expect(found.costPerHour).toBe(185.5)
+  })
+
+  // @IT-AC-STORE-006@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
+  it('round-trip: referenceDatumDescription persists and retrieves with full fidelity', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000011',
+      referenceDatumDescription: 'Firewall forward face',
+    })
+    await create(profile)
+    const found = await findById(profile.id)
+    expect(found).toBeDefined()
+    expect(found.referenceDatumDescription).toBe('Firewall forward face')
+  })
+
+  // @IT-AC-STORE-007@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
+  it('round-trip: checklistScaffold persists and retrieves with full fidelity', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000012',
+      checklistScaffold: [
+        { title: 'Pre-flight', items: ['Check fuel', 'Check oil', 'Check control surfaces'] },
+        { title: 'Engine start', items: ['Master switch ON', 'Throttle idle', 'Mixture rich'] },
+      ],
+    })
+    await create(profile)
+    const found = await findById(profile.id)
+    expect(found).toBeDefined()
+    expect(found.checklistScaffold).toHaveLength(2)
+    expect(found.checklistScaffold[0].title).toBe('Pre-flight')
+    expect(found.checklistScaffold[0].items).toEqual([
+      'Check fuel',
+      'Check oil',
+      'Check control surfaces',
+    ])
+    expect(found.checklistScaffold[1].title).toBe('Engine start')
+  })
+
+  // @IT-AC-STORE-008@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
+  it('round-trip: all three supplementary fields persist together with full fidelity', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000013',
+      costPerHour: 220.0,
+      referenceDatumDescription: 'Leading edge of wing root',
+      checklistScaffold: [
+        { title: 'Normal procedures', items: ['Item A', 'Item B'] },
+      ],
+    })
+    await create(profile)
+    const found = await findById(profile.id)
+    expect(found).toBeDefined()
+    expect(found.costPerHour).toBe(220.0)
+    expect(found.referenceDatumDescription).toBe('Leading edge of wing root')
+    expect(found.checklistScaffold).toHaveLength(1)
+    expect(found.checklistScaffold[0].title).toBe('Normal procedures')
+  })
+
+  // @IT-AC-STORE-009@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-002@)
+  it('round-trip: supplementary fields survive an update() cycle', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000014',
+      costPerHour: 100.0,
+      checklistScaffold: [{ title: 'Before landing', items: ['Gear down'] }],
+    })
+    await create(profile)
+
+    const updatedProfile = { ...profile, costPerHour: 150.0 }
+    await update(updatedProfile)
+
+    const found = await findById(profile.id)
+    expect(found.costPerHour).toBe(150.0)
+    expect(found.checklistScaffold).toHaveLength(1)
+    expect(found.checklistScaffold[0].title).toBe('Before landing')
+  })
+})
+
+describe('fleetRepository — schemaVersion persistence (refs #166)', () => {
+  // @IT-AC-STORE-010@ (FROM: @IMP-AC-CORE-002@)
+  it('schemaVersion field is persisted and retrieved correctly on create', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000020',
+      schemaVersion: 1,
+    })
+    await create(profile)
+
+    const found = await findById(profile.id)
+    expect(found).toBeDefined()
+    expect(found!.schemaVersion).toBe(1)
+  })
+
+  // @IT-AC-STORE-011@ (FROM: @IMP-AC-CORE-002@)
+  it('schemaVersion is preserved across update operations', async () => {
+    const profile = buildProfile({
+      id: '00000000-0000-4000-a000-000000000021',
+      schemaVersion: 1,
+    })
+    await create(profile)
+
+    const updated = { ...profile, registration: 'G-UPDT', schemaVersion: 2 }
+    await update(updated)
+
+    const found = await findById(profile.id)
+    expect(found).toBeDefined()
+    expect(found!.schemaVersion).toBe(2)
+    expect(found!.registration).toBe('G-UPDT')
+  })
+
+  // @IT-AC-STORE-012@ (FROM: @IMP-AC-CORE-002@)
+  it('all profiles returned by findAll carry a positive integer schemaVersion field', async () => {
+    const p1 = buildProfile({
+      id: '00000000-0000-4000-a000-000000000022',
+      registration: 'D-SV01',
+      schemaVersion: 1,
+    })
+    const p2 = buildProfile({
+      id: '00000000-0000-4000-a000-000000000023',
+      registration: 'D-SV02',
+      schemaVersion: 1,
+    })
+    await create(p1)
+    await create(p2)
+
+    const all = await findAll()
+    expect(all).toHaveLength(2)
+    for (const p of all) {
+      expect(typeof p.schemaVersion).toBe('number')
+      expect(Number.isInteger(p.schemaVersion)).toBe(true)
+      expect(p.schemaVersion).toBeGreaterThan(0)
+    }
   })
 })

--- a/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
@@ -188,4 +188,65 @@ describe('useFleetStore', () => {
     await store.deleteProfile(profile.id)
     expect(store.profiles).toHaveLength(0)
   })
+
+  // @UT-AC-STORE-066@ (FROM: @IMP-AC-STORE-005@)
+  it('loadAll sets isLoading=true during fetch and false after (LOADING to READY)', async () => {
+    const store = useFleetStore()
+    let capturedDuringLoad: boolean | undefined
+    const { fleetRepository } = await import('../services/fleet.repository')
+    vi.mocked(fleetRepository.findAll).mockImplementationOnce(async () => {
+      capturedDuringLoad = store.isLoading
+      return []
+    })
+    await store.loadAll()
+    expect(capturedDuringLoad).toBe(true)
+    expect(store.isLoading).toBe(false)
+  })
+
+  // @UT-AC-STORE-067@ (FROM: @IMP-AC-STORE-005@)
+  it('loadAll sets isLoading=false when IndexedDB throws (LOADING to ERROR)', async () => {
+    const store = useFleetStore()
+    const { fleetRepository } = await import('../services/fleet.repository')
+    vi.mocked(fleetRepository.findAll).mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+    await expect(store.loadAll()).rejects.toThrow('IndexedDB unavailable')
+    expect(store.isLoading).toBe(false)
+  })
+
+  // @UT-AC-STORE-068@ (FROM: @IMP-AC-STORE-005@)
+  it('loadAll populates profiles from IndexedDB (READY state)', async () => {
+    const store = useFleetStore()
+    const { fleetRepository } = await import('../services/fleet.repository')
+    const mockProfile: AircraftProfile = {
+      id: '00000000-0000-4000-a000-000000000042',
+      ownerId: 'user-test',
+      registration: 'G-ABCD',
+      manufacturer: 'Cessna',
+      model: 'C172S Skyhawk SP',
+      icaoTypeDesignator: 'C172',
+      sourceUnit: 'kg',
+      referenceDatumDescription: 'Firewall',
+      referenceDatumLocation: 'Station 0',
+      shareCode: null,
+      status: 'Verified',
+      schemaVersion: 1,
+      passengerProfiles: [],
+      weighingReports: [{ bem: 780, emptyCg: 2.1, weighingDate: '2025-01-01', validFrom: '2025-01-01' }],
+      loadPoints: [{
+        name: 'Pilot', arm: 2.0, armLookup: [], operationalLimit: 110,
+        defaultQuantity: 0, unit: 'kg', allowableCategories: null, fuelTank: null,
+      }],
+      certificationCategories: [{
+        category: 'Normal', mtom: 1157, maxZeroFuelMass: null, graphType: 'arm',
+        envelope: [
+          { armOrMoment: 2.0, mass: 780 }, { armOrMoment: 2.0, mass: 1157 },
+          { armOrMoment: 2.45, mass: 1157 }, { armOrMoment: 2.45, mass: 780 },
+        ],
+      }],
+    }
+    vi.mocked(fleetRepository.findAll).mockResolvedValueOnce([mockProfile])
+    await store.loadAll()
+    expect(store.profiles).toHaveLength(1)
+    expect(store.profiles[0].registration).toBe('G-ABCD')
+    expect(store.isLoading).toBe(false)
+  })
 })

--- a/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
@@ -246,7 +246,7 @@ describe('useFleetStore', () => {
     vi.mocked(fleetRepository.findAll).mockResolvedValueOnce([mockProfile])
     await store.loadAll()
     expect(store.profiles).toHaveLength(1)
-    expect(store.profiles[0].registration).toBe('G-ABCD')
+    expect(store.profiles[0]!.registration).toBe('G-ABCD')
     expect(store.isLoading).toBe(false)
   })
 })

--- a/frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
+++ b/frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
@@ -27,7 +27,7 @@ export const AIRCRAFT_MODEL_CATALOGUE: AircraftModelEntry[] = [
   // Cessna
   { manufacturer: 'Cessna', model: 'C152', icaoTypeDesignator: 'C152' },
   { manufacturer: 'Cessna', model: 'C172S Skyhawk SP', icaoTypeDesignator: 'C172' },
-  { manufacturer: 'Cessna', model: 'C182T Skylane', icaoTypeDesignator: 'C82T' },
+  { manufacturer: 'Cessna', model: 'C182T Skylane', icaoTypeDesignator: 'C182' },
   // Piper
   { manufacturer: 'Piper', model: 'PA-28-161 Warrior III', icaoTypeDesignator: 'PA28' },
   { manufacturer: 'Piper', model: 'PA-28-181 Archer III', icaoTypeDesignator: 'PA28' },

--- a/frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
+++ b/frontend/src/modules/aircraft/data/aircraft-model-catalogue.ts
@@ -10,6 +10,13 @@
 
 // @IMP-AC-VIEW-001@ (FROM: @REQ-UI-001@, @REQ-UI-003@, @REQ-UI-004@)
 
+/**
+ * Monotonically increasing catalogue data version string.
+ * Incremented whenever entries are added, removed, or corrected.
+ * Used by the update pipeline (ADR-007) to detect catalogue changes on app load.
+ */
+export const CATALOGUE_VERSION = '1.0.0'
+
 export interface AircraftModelEntry {
   manufacturer: string
   model: string

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import MassBalanceView from '@/modules/mass-balance/views/MassBalanceView.vue'
+import FleetManagementView from '@/modules/aircraft/views/FleetManagementView.vue'
 
 // @IMP-SYS-APP-001@ (FROM: @REQ-SYS-001@)
 const router = createRouter({
@@ -15,6 +16,11 @@ const router = createRouter({
       path: '/mass-balance',
       name: 'mass-balance',
       component: MassBalanceView,
+    },
+    {
+      path: '/fleet',
+      name: 'fleet',
+      component: FleetManagementView,
     },
   ],
 })

--- a/frontend/src/stores/__tests__/app-version-blocked.spec.ts
+++ b/frontend/src/stores/__tests__/app-version-blocked.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the version-blocked screen conditional (REQ-SYS-006).
+ *
+ * Tests verify that:
+ * 1. useAppVersionStore.versionBlocked correctly gates content rendering.
+ * 2. The gate is reactive — components re-render when the store flag changes.
+ * 3. Version strings flow through to the blocked-screen component correctly.
+ *
+ * Uses a minimal VersionGate wrapper component to avoid App.vue module-cache
+ * interference when running alongside other test files in the full unit suite.
+ */
+
+// @UT-SYS-APP-026@ (FROM: @IMP-SYS-SHARED-006@, @REQ-SYS-006@)
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import { useAppVersionStore } from '@/stores/app-version.store'
+
+/**
+ * Minimal component that mirrors the v-if/v-else gate in App.vue (REQ-SYS-006).
+ * Tested independently of App.vue to ensure module-isolation in the full suite.
+ */
+const VersionGate = defineComponent({
+  name: 'VersionGate',
+  setup() {
+    const store = useAppVersionStore()
+    return () =>
+      store.versionBlocked
+        ? h('div', { 'data-testid': 'version-blocked-screen' }, [
+            h('span', { 'data-testid': 'current-version' }, store.currentVersion),
+            h('span', { 'data-testid': 'min-version' }, store.minSafeVersion),
+          ])
+        : h('div', { 'data-testid': 'router-view' }, 'content')
+  },
+})
+
+describe('REQ-SYS-006 version-blocked gate (store state + rendering)', () => {
+  let pinia: ReturnType<typeof createPinia>
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  function mountVersionGate() {
+    return mount(VersionGate, { global: { plugins: [pinia] } })
+  }
+
+  // @UT-SYS-APP-026@ (FROM: @IMP-SYS-SHARED-006@, @REQ-SYS-006@)
+  it('renders content when versionBlocked is false', async () => {
+    const store = useAppVersionStore()
+    store.versionBlocked = false
+
+    const wrapper = mountVersionGate()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="version-blocked-screen"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+  })
+
+  // @UT-SYS-APP-027@ (FROM: @IMP-SYS-SHARED-006@, @REQ-SYS-006@)
+  it('renders version-blocked-screen and hides content when versionBlocked is true', async () => {
+    const store = useAppVersionStore()
+    store.versionBlocked = true
+
+    const wrapper = mountVersionGate()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="version-blocked-screen"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(false)
+  })
+
+  // @UT-SYS-APP-028@ (FROM: @IMP-SYS-SHARED-006@, @REQ-SYS-006@)
+  it('blocked screen exposes currentVersion and minSafeVersion from store', async () => {
+    const store = useAppVersionStore()
+    store.versionBlocked = true
+    store.currentVersion = '0.1.0'
+    store.minSafeVersion = '0.3.0'
+
+    const wrapper = mountVersionGate()
+    await flushPromises()
+
+    const screen = wrapper.find('[data-testid="version-blocked-screen"]')
+    expect(screen.exists()).toBe(true)
+    expect(wrapper.find('[data-testid="current-version"]').text()).toBe('0.1.0')
+    expect(wrapper.find('[data-testid="min-version"]').text()).toBe('0.3.0')
+  })
+
+  // @UT-SYS-APP-029@ (FROM: @IMP-SYS-STORE-008@, @REQ-SYS-006@)
+  it('checkMinSafeVersion sets versionBlocked=true when current < minimum', async () => {
+    vi.stubGlobal('navigator', { onLine: true })
+    const store = useAppVersionStore()
+    store.currentVersion = '0.1.0'
+    store.minSafeVersion = '0.3.0'
+    store.versionBlocked = false
+
+    await store.checkMinSafeVersion()
+
+    expect(store.versionBlocked).toBe(true)
+    vi.unstubAllGlobals()
+  })
+
+  // @UT-SYS-APP-030@ (FROM: @IMP-SYS-SHARED-006@, @REQ-SYS-006@)
+  it('versionBlocked gate is reactive: component re-renders when store state changes', async () => {
+    const store = useAppVersionStore()
+    store.versionBlocked = false
+
+    const wrapper = mountVersionGate()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+
+    store.versionBlocked = true
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="version-blocked-screen"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/stores/__tests__/app-version.store.spec.ts
+++ b/frontend/src/stores/__tests__/app-version.store.spec.ts
@@ -1,7 +1,17 @@
 /**
  * Unit tests for useAppVersionStore.
- * Covers version comparison, blocking logic, and offline skip.
+ * Covers version comparison, blocking logic, offline skip, and
+ * minimum safe version gate (REQ-SYS-006, INFO-SYS-001).
  */
+
+// @UT-SYS-STORE-021@ (FROM: @IMP-SYS-STORE-006@)
+// @UT-SYS-STORE-022@ (FROM: @IMP-SYS-STORE-007@)
+// @UT-SYS-STORE-023@ (FROM: @IMP-SYS-STORE-007@)
+// @UT-SYS-STORE-024@ (FROM: @IMP-SYS-STORE-008@)
+// @UT-SYS-STORE-025@ (FROM: @IMP-SYS-STORE-008@)
+// @UT-SYS-STORE-028@ (FROM: @IMP-SYS-STORE-007@)
+// @UT-SYS-STORE-029@ (FROM: @IMP-SYS-STORE-008@)
+// @UT-SYS-STORE-030@ (FROM: @IMP-SYS-STORE-006@)
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
@@ -37,7 +47,6 @@ describe('useAppVersionStore', () => {
   it('checkMinSafeVersion sets versionBlocked when below minimum', async () => {
     vi.stubGlobal('navigator', { onLine: true })
     const store = useAppVersionStore()
-    // Override internal refs to simulate old version below minimum
     store.currentVersion = '0.1.0'
     store.minSafeVersion = '0.3.0'
     await store.checkMinSafeVersion()
@@ -54,5 +63,29 @@ describe('useAppVersionStore', () => {
     await store.checkMinSafeVersion()
     expect(store.versionBlocked).toBe(false)
     vi.unstubAllGlobals()
+  })
+
+  // @UT-SYS-STORE-028@ (FROM: @IMP-SYS-STORE-007@)
+  it('isVersionBelow returns false when version is above minimum (major bump)', () => {
+    const store = useAppVersionStore()
+    expect(store.isVersionBelow('1.0.0', '0.3.0')).toBe(false)
+  })
+
+  // @UT-SYS-STORE-029@ (FROM: @IMP-SYS-STORE-008@)
+  it('checkMinSafeVersion does NOT set versionBlocked when version meets minimum', async () => {
+    vi.stubGlobal('navigator', { onLine: true })
+    const store = useAppVersionStore()
+    store.currentVersion = '0.3.0'
+    store.minSafeVersion = '0.3.0'
+    await store.checkMinSafeVersion()
+    expect(store.versionBlocked).toBe(false)
+    vi.unstubAllGlobals()
+  })
+
+  // @UT-SYS-STORE-030@ (FROM: @IMP-SYS-STORE-006@)
+  it('exposes minSafeVersion as a non-empty string', () => {
+    const store = useAppVersionStore()
+    expect(typeof store.minSafeVersion).toBe('string')
+    expect(store.minSafeVersion.length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/stores/__tests__/pwa-update.store.spec.ts
+++ b/frontend/src/stores/__tests__/pwa-update.store.spec.ts
@@ -1,7 +1,15 @@
 /**
  * Unit tests for usePwaUpdateStore.
- * Covers update detection, offline-ready, and update application.
+ * Covers update detection, offline-ready, update application, and
+ * silent-update-absent guarantee (REQ-SYS-005).
  */
+
+// @UT-SYS-STORE-017@ (FROM: @IMP-SYS-STORE-002@)
+// @UT-SYS-STORE-018@ (FROM: @IMP-SYS-STORE-004@)
+// @UT-SYS-STORE-019@ (FROM: @IMP-SYS-STORE-003@)
+// @UT-SYS-STORE-020@ (FROM: @IMP-SYS-STORE-009@)
+// @UT-SYS-STORE-026@ (FROM: @IMP-SYS-STORE-009@)
+// @UT-SYS-STORE-027@ (FROM: @IMP-SYS-STORE-004@)
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
@@ -45,5 +53,28 @@ describe('usePwaUpdateStore', () => {
     store.onNeedsRefresh()
     await store.applyUpdate()
     expect(mockUpdateSW).toHaveBeenCalledWith(true)
+  })
+
+  // @UT-SYS-STORE-026@ (FROM: @IMP-SYS-STORE-009@)
+  it('applyUpdate falls back to window.location.reload when no updateSW is set', async () => {
+    const reloadMock = vi.fn()
+    vi.stubGlobal('location', { reload: reloadMock })
+    const store = usePwaUpdateStore()
+    // Do NOT call setUpdateSW — simulate missing SW callback
+    await store.applyUpdate()
+    expect(reloadMock).toHaveBeenCalledOnce()
+    vi.unstubAllGlobals()
+  })
+
+  // @UT-SYS-STORE-027@ (FROM: @IMP-SYS-STORE-004@)
+  it('silent auto-update is absent — needsUpdate stays false until onNeedsRefresh is called', () => {
+    const store = usePwaUpdateStore()
+    // Simulate the store being initialised and SW registered, but no update signal yet.
+    const mockUpdateSW = vi.fn<(reloadPage?: boolean) => Promise<void>>().mockResolvedValue(undefined)
+    store.setUpdateSW(mockUpdateSW)
+    // needsUpdate must remain false — SW must NOT have silently applied an update.
+    expect(store.needsUpdate).toBe(false)
+    // mockUpdateSW must not have been called automatically.
+    expect(mockUpdateSW).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/stores/__tests__/pwa-update.store.spec.ts
+++ b/frontend/src/stores/__tests__/pwa-update.store.spec.ts
@@ -57,7 +57,7 @@ describe('usePwaUpdateStore', () => {
 
   // @UT-SYS-STORE-026@ (FROM: @IMP-SYS-STORE-009@)
   it('applyUpdate falls back to window.location.reload when no updateSW is set', async () => {
-    const reloadMock = vi.fn()
+    const reloadMock = vi.fn<() => void>()
     vi.stubGlobal('location', { reload: reloadMock })
     const store = usePwaUpdateStore()
     // Do NOT call setUpdateSW — simulate missing SW callback

--- a/frontend/src/stores/app-version.store.ts
+++ b/frontend/src/stores/app-version.store.ts
@@ -1,6 +1,23 @@
 /**
  * App Version Store — P3 App Shell.
  * Exposes current version, build date, and minimum safe version enforcement.
+ *
+ * ## REQ-SYS-006 Implementation Note — Build-Time Constant (Pre-v1.0 Limitation)
+ *
+ * `minSafeVersion` is currently set at **build time** via the `__MIN_SAFE_VERSION__`
+ * Vite define constant (see `vite.config.ts`). This means the minimum required version
+ * is baked into each released bundle and cannot be updated without a new deployment.
+ *
+ * **Accepted limitation for pre-v1.0 milestones.** The correct long-term implementation
+ * (required before v1.0.0 GA) is to fetch the minimum version from a remote endpoint
+ * (e.g. `GET /version.json` served from the PWA public directory or a CDN edge config),
+ * so that operators can enforce a minimum version without requiring the user to have
+ * downloaded a new bundle first.
+ *
+ * TODO(REQ-SYS-006, pre-v1.0): Replace build-time constant with a remote fetch:
+ *   const res = await fetch('/version.json')
+ *   const { minSafeVersion } = await res.json()
+ * Track: GitHub issue #162 (offline-first DoD) and related ADR-008.
  */
 
 import { defineStore } from 'pinia'
@@ -10,6 +27,10 @@ import { ref } from 'vue'
 export const useAppVersionStore = defineStore('appVersion', () => {
   const currentVersion = ref(__APP_VERSION__)
   const buildDate = ref(__BUILD_DATE__)
+  /**
+   * Minimum safe version for this build.
+   * Currently a build-time constant — see module JSDoc for the planned remote-fetch upgrade path.
+   */
   const minSafeVersion = ref(__MIN_SAFE_VERSION__)
   const versionBlocked = ref(false)
 

--- a/frontend/src/stores/pwa-update.store.ts
+++ b/frontend/src/stores/pwa-update.store.ts
@@ -20,9 +20,22 @@ export const usePwaUpdateStore = defineStore('pwaUpdate', () => {
   }
 
   // @IMP-SYS-STORE-004@ (FROM: @REQ-SYS-005@)
+  /**
+   * Called by the Service Worker registration when a new version is available.
+   * Sets `needsUpdate = true`, which causes `App.vue` to render the PWA update
+   * banner (REQ-SYS-005, INFO-SYS-001).
+   *
+   * ## INFO-SYS-001 — Notification Strategy
+   * The direct banner rendered by `App.vue` (`v-if="pwaStore.needsUpdate"`) IS the
+   * INFO-SYS-001 notification for this specific case. This is an intentional
+   * architectural exception: the PWA update banner must be rendered at the app-shell
+   * level (above the router view) so it remains visible on every page, which cannot be
+   * achieved via the centralized `useNotificationStore` bus without bypassing the store
+   * routing layer. This decision is documented in ADR-007 (PWA update lifecycle).
+   * See also REQ-SYS-007 and REQ-SYS-008 for the general notification requirements.
+   */
   function onNeedsRefresh(): void {
     needsUpdate.value = true
-    // INFO-SYS-001: caller/composable must emit notification
   }
 
   // @IMP-SYS-STORE-005@ (FROM: @REQ-SYS-005@)

--- a/frontend/tests/e2e/features/phase-sys-pwa/offline-smoke.feature
+++ b/frontend/tests/e2e/features/phase-sys-pwa/offline-smoke.feature
@@ -1,0 +1,15 @@
+# @E2E-SYS-001@ (FROM: @UJ-SYS-001@)
+@smoke @offline @pwa @sys
+Feature: Offline-first app shell and M&B navigation
+  As a pilot with no network connectivity
+  I want the AeroDash app shell and M&B page to remain accessible
+  So that I can perform safety-critical calculations without an internet connection
+
+  # @E2E-SYS-001@ (FROM: @UJ-SYS-001@)
+  @E2E-SYS-001 @smoke @offline
+  Scenario: App shell loads and M&B navigation works while offline
+    Given the pilot loads the app while online
+    When the pilot goes offline
+    Then the app shell is still visible
+    And the pilot can navigate to the Mass and Balance page
+    And the Mass and Balance page content is displayed

--- a/frontend/tests/e2e/steps/offline-smoke.steps.ts
+++ b/frontend/tests/e2e/steps/offline-smoke.steps.ts
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test'
+import { createBdd } from 'playwright-bdd'
+
+// Step definitions for offline-smoke.feature (REQ-SYS-001, REQ-SYS-002, #162 DoD)
+
+const { Given, When, Then } = createBdd()
+
+// @E2E-SYS-001@ (FROM: @UJ-SYS-001@)
+
+Given('the pilot loads the app while online', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('banner')).toBeVisible()
+})
+
+When('the pilot goes offline', async ({ page }) => {
+  await page.context().setOffline(true)
+})
+
+Then('the app shell is still visible', async ({ page }) => {
+  await expect(page.getByRole('banner')).toBeVisible()
+  await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible()
+})
+
+Then('the pilot can navigate to the Mass and Balance page', async ({ page }) => {
+  // Use client-side navigation (click a link) — page.goto() sends a network request
+  // even with a Service Worker, which fails offline. Vue Router handles the navigation
+  // in-memory via the cached app shell (REQ-SYS-001, offline-first).
+  const mbLink = page.getByRole('link', { name: /Flight Prep|Start flight preparation|mass.balance/i }).first()
+  await expect(mbLink).toBeVisible()
+  await mbLink.click()
+  await expect(page).toHaveURL(/mass-balance/)
+})
+
+Then('the Mass and Balance page content is displayed', async ({ page }) => {
+  await expect(page.getByRole('main')).toBeVisible()
+})

--- a/trace/implementation/ad.yaml
+++ b/trace/implementation/ad.yaml
@@ -62,3 +62,39 @@ AD Core (domain + mass-balance input schema)
       - REQ-AD-004
     files:
       - frontend/src/core/domain/aircraft.types.ts
+
+  IMP-AD-CORE-008
+    title: ChecklistScaffoldItemSchema — checklist storage Zod schema
+    req:
+      - REQ-AD-006
+      - REQ-AD-010
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts
+
+  IMP-AD-CORE-009
+    title: WindLimitSchema — wind limit Zod schema (component, value, classification)
+    req:
+      - REQ-AD-017
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts
+
+  IMP-AD-CORE-010
+    title: SurfaceConditionSchema — surface condition Zod schema (name, takeoffFactor, landingFactor)
+    req:
+      - REQ-AD-015
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts
+
+  IMP-AD-CORE-011
+    title: SafetyFactorsSchema — operational safety factors Zod schema (takeoff, landing)
+    req:
+      - REQ-AD-016
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts
+
+  IMP-AD-CORE-012
+    title: ownerId field in AircraftProfileSchema — owner identifier storage
+    req:
+      - REQ-AD-019
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -174,3 +174,33 @@ SYS Shared — Structured Logger Utility
       - REQ-UI-013
     files:
       - frontend/src/shared/components/AppVersion.vue
+
+  IMP-SYS-SHARED-005
+    title: checkMinSafeVersion called on App mount — blocks operation below minimum safe version (REQ-SYS-006)
+    req:
+      - REQ-SYS-006
+    files:
+      - frontend/src/App.vue
+
+SYS Shared — Theme Toggle
+  IMP-SYS-SHARED-004
+    title: useTheme composable — dark/light mode toggle with localStorage persistence
+    req:
+      - REQ-UI-011
+    files:
+      - frontend/src/shared/composables/useTheme.ts
+
+SYS Pending — Connectivity State (not yet implemented)
+  IMP-SYS-CONN-001
+    status: pending
+    title: Connectivity State Detection — online/offline monitoring and app-wide state
+    req:
+      - REQ-SYS-009
+    note: REQ-SYS-009 status is Approved. Implementation deferred to milestone 4+.
+
+  IMP-SYS-CONN-002
+    status: pending
+    title: Online Feature Gating — disable cloud/weather/airport features while offline
+    req:
+      - REQ-SYS-010
+    note: REQ-SYS-010 status is Approved. Deferred until IMP-SYS-CONN-001 provides connectivity state.

--- a/trace/implementation/ui.yaml
+++ b/trace/implementation/ui.yaml
@@ -30,3 +30,99 @@ UI Routing
       - REQ-SYS-001
     files:
       - frontend/src/router/index.ts
+
+UI — Mass & Balance View Components
+  IMP-UI-MB-001
+    title: Severity-Based State Banner and Notification Rendering (viewModel.bannerSeverity)
+    req:
+      - REQ-UI-018
+    files:
+      - frontend/src/modules/mass-balance/views/MassBalanceView.vue
+
+  IMP-UI-MB-002
+    title: CG Envelope Polygon + Mass Point Markers Rendering
+    req:
+      - REQ-UI-019
+    files:
+      - frontend/src/modules/mass-balance/components/CGEnvelopeChart.vue
+
+  IMP-UI-MB-003
+    title: CG Migration Trend Line / Burn Sequence Path Rendering
+    req:
+      - REQ-UI-010
+    files:
+      - frontend/src/modules/mass-balance/components/CGEnvelopeChart.vue
+
+  IMP-UI-MB-004
+    title: Category Change Recalculation — changeCertificationCategory re-runs math core
+    req:
+      - REQ-UI-009
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+  IMP-UI-MB-005
+    title: OUT_OF_RANGE Violation mapped as WARNING notification (WARN-UI-001)
+    req:
+      - REQ-UI-008
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+UI — Fleet Management — Passenger Profile UI
+  IMP-UI-FLEET-001
+    title: Passenger profile CRUD form in FleetManagementView — add/remove profiles
+    req:
+      - REQ-UI-006
+      - REQ-AC-006
+    files:
+      - frontend/src/modules/aircraft/views/FleetManagementView.vue
+
+UI — Verify / Mark-All-Verified
+  IMP-UI-VERIFY-001
+    title: markFieldVerified action — transitions single station to Verified
+    req:
+      - REQ-UI-014
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+  IMP-UI-VERIFY-002
+    title: markAllVerified action — transitions all available stations to Verified
+    req:
+      - REQ-UI-016
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+UI Pending — Future (Approved, Not Yet Implemented)
+  IMP-UI-PENDING-001
+    status: pending
+    title: Recent Airports Display — 5 most recently used airports at top of selector
+    req:
+      - REQ-UI-005
+    note: REQ-UI-005 status is Approved. Requires Airport module (M4+).
+
+  IMP-UI-PENDING-002
+    status: pending
+    title: Contextual Tooltips — pop-over explanation for complex fields and acronyms
+    req:
+      - REQ-UI-012
+    note: REQ-UI-012 status is Approved. Planned for M4+ UX pass.
+
+  IMP-UI-PENDING-003
+    status: pending
+    title: Unverified Data Export Warning — CRITICAL notification on export with unverified data
+    req:
+      - REQ-UI-015
+    note: REQ-UI-015 status is Approved. Export feature deferred to M4+.
+
+  IMP-UI-PENDING-004
+    status: pending
+    title: Low Safety Factor Export Warning — CRITICAL notification on export with low safety factor
+    req:
+      - REQ-UI-017
+    note: REQ-UI-017 status is Approved. Requires performance module (M4+).
+
+  IMP-UI-PENDING-005
+    status: pending
+    title: Connectivity State Indicator — persistent online/offline visual indicator
+    req:
+      - REQ-UI-020
+    note: REQ-UI-020 status is Approved. Depends on IMP-SYS-CONN-001 (M4+).

--- a/trace/integration_test/ac.yaml
+++ b/trace/integration_test/ac.yaml
@@ -48,3 +48,44 @@ AC Store — schemaVersion Persistence (refs #166)
       - IMP-AC-CORE-002
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+AC Store — Supplementary Field Round-Trip Persistence (Integration)
+  IT-AC-STORE-005
+    title: round-trip — costPerHour persists and retrieves with full fidelity
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+  IT-AC-STORE-006
+    title: round-trip — referenceDatumDescription persists and retrieves with full fidelity
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+  IT-AC-STORE-007
+    title: round-trip — checklistScaffold persists and retrieves with full fidelity
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+  IT-AC-STORE-008
+    title: round-trip — all three supplementary fields persist together with full fidelity
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+  IT-AC-STORE-009
+    title: round-trip — supplementary fields survive an update() cycle
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts

--- a/trace/integration_test/ac.yaml
+++ b/trace/integration_test/ac.yaml
@@ -26,3 +26,25 @@ AC Store — Fleet Repository Integration Tests
       - IMP-AC-STORE-001
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+AC Store — schemaVersion Persistence (refs #166)
+  IT-AC-STORE-010
+    title: schemaVersion field is persisted and retrieved correctly on create
+    impl:
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+  IT-AC-STORE-011
+    title: schemaVersion is preserved across update operations
+    impl:
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+  IT-AC-STORE-012
+    title: all profiles returned by findAll carry a positive integer schemaVersion field
+    impl:
+      - IMP-AC-CORE-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -295,3 +295,300 @@ AC Store — Fleet Store (Unit)
       - IMP-AC-STORE-005
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+AC View — Aircraft Model Catalogue (Unit)
+  UT-AC-VIEW-001
+    title: AIRCRAFT_MODEL_CATALOGUE contains at least one entry per expected manufacturer
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-002
+    title: every catalogue entry has a non-empty manufacturer, model, and icaoTypeDesignator
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-003
+    title: CATALOGUE_VERSION is a non-empty string
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-004
+    title: getManufacturers returns all unique manufacturers
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-005
+    title: getManufacturers appends 'Other' as the last entry (REQ-UI-002)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-006
+    title: getManufacturers returns manufacturers in alphabetical order before Other
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-007
+    title: getManufacturers does not contain duplicates
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-008
+    title: getModelsByManufacturer returns all Cessna models
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-009
+    title: getModelsByManufacturer returns only models matching the requested manufacturer
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-010
+    title: getModelsByManufacturer returns empty array for manufacturer = 'Other' (REQ-UI-002)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-011
+    title: getModelsByManufacturer returns empty array for unknown manufacturer
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-012
+    title: each returned entry has the expected fields
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-013
+    title: Diamond has DA40 Diamond Star in its model list
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-014
+    title: findByIcaoDesignator returns correct entry for C172
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-015
+    title: findByIcaoDesignator performs case-insensitive lookup
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-016
+    title: findByIcaoDesignator trims whitespace before lookup
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-017
+    title: findByIcaoDesignator returns empty array for unknown ICAO designator
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-018
+    title: findByIcaoDesignator returns multiple entries when models share an ICAO designator (PA28)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-019
+    title: reverse lookup returns correct manufacturer for P208 (Tecnam P2008 JC)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-020
+    title: reverse lookup returns correct manufacturer for DA40 (Diamond DA40 Diamond Star)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-021
+    title: C172S Skyhawk SP auto-fills ICAO designator C172 (REQ-UI-003)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-022
+    title: PA-44-180 Seminole auto-fills ICAO designator PA44 (REQ-UI-003)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-023
+    title: getManufacturers includes 'Other' as an option (REQ-UI-002)
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+  UT-AC-VIEW-024
+    title: getModelsByManufacturer('Other') returns empty to signal free-text mode
+    impl:
+      - IMP-AC-VIEW-001
+    files:
+      - frontend/src/modules/aircraft/__tests__/aircraft-model-catalogue.spec.ts
+
+AC View — AircraftModelSelector Component (Unit)
+  UT-AC-VIEW-025
+    title: renders manufacturer select with known manufacturers
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-026
+    title: renders 'Other' as the last manufacturer option
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-027
+    title: shows only Cessna models when manufacturer is Cessna
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-028
+    title: shows only Piper models when manufacturer is Piper
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-029
+    title: model select is disabled when no manufacturer is selected
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-030
+    title: renders a text input for model when manufacturer is 'Other' (REQ-UI-002)
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-031
+    title: does not render a model dropdown when manufacturer is 'Other'
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-032
+    title: emits 'update:model' when free-text model input changes
+    impl:
+      - IMP-AC-VIEW-002
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-033
+    title: emits 'update:icaoTypeDesignator' with C172 when C172S Skyhawk SP is selected (REQ-UI-003)
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-034
+    title: emits 'update:icaoTypeDesignator' with DA42 when DA42 Twin Star is selected
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-035
+    title: emits empty model and ICAO when manufacturer changes
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-036
+    title: shows lookup results when ICAO input has 2+ matching characters (REQ-UI-004)
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-037
+    title: shows no lookup results when ICAO input has fewer than 2 characters
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-038
+    title: emits manufacturer, model and ICAO when a lookup result is clicked
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+  UT-AC-VIEW-039
+    title: normalises ICAO input to uppercase before emitting
+    impl:
+      - IMP-AC-VIEW-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftModelSelector.spec.ts
+
+AC Store — Fleet Store Async Load State (Unit)
+  UT-AC-STORE-066
+    title: loadAll sets isLoading=true during fetch and false after completion (LOADING to READY)
+    impl:
+      - IMP-AC-STORE-005
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-067
+    title: loadAll sets isLoading=false even when IndexedDB throws (LOADING to ERROR)
+    impl:
+      - IMP-AC-STORE-005
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-068
+    title: loadAll populates profiles from IndexedDB (READY state)
+    impl:
+      - IMP-AC-STORE-005
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts

--- a/trace/unit_test/ad.yaml
+++ b/trace/unit_test/ad.yaml
@@ -307,3 +307,18 @@ AD Profile Schema (full AircraftProfile Zod validation)
       - IMP-AD-CORE-004
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+AD Schema — Wind Limits (Unit)
+  UT-AD-CORE-045
+    title: Accepts a valid windLimits entry (MaxCrosswind, Demonstrated)
+    impl:
+      - IMP-AD-CORE-009
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-046
+    title: Accepts a valid windLimits entry (MaxCrosswind, Advisory)
+    impl:
+      - IMP-AD-CORE-009
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts

--- a/trace/unit_test/sys.yaml
+++ b/trace/unit_test/sys.yaml
@@ -742,6 +742,20 @@ SYS Store — PWA Update (Unit)
     files:
       - frontend/src/stores/__tests__/pwa-update.store.spec.ts
 
+  UT-SYS-STORE-026
+    title: applyUpdate falls back to window.location.reload when no updateSW is set
+    impl:
+      - IMP-SYS-STORE-009
+    files:
+      - frontend/src/stores/__tests__/pwa-update.store.spec.ts
+
+  UT-SYS-STORE-027
+    title: silent auto-update is absent — needsUpdate stays false until onNeedsRefresh is called
+    impl:
+      - IMP-SYS-STORE-004
+    files:
+      - frontend/src/stores/__tests__/pwa-update.store.spec.ts
+
 SYS Store — App Version (Unit)
   UT-SYS-STORE-021
     title: exposes currentVersion and buildDate
@@ -775,5 +789,26 @@ SYS Store — App Version (Unit)
     title: checkMinSafeVersion skips when offline
     impl:
       - IMP-SYS-STORE-008
+    files:
+      - frontend/src/stores/__tests__/app-version.store.spec.ts
+
+  UT-SYS-STORE-028
+    title: isVersionBelow returns false when version is above minimum (major bump)
+    impl:
+      - IMP-SYS-STORE-007
+    files:
+      - frontend/src/stores/__tests__/app-version.store.spec.ts
+
+  UT-SYS-STORE-029
+    title: checkMinSafeVersion does NOT set versionBlocked when version meets minimum
+    impl:
+      - IMP-SYS-STORE-008
+    files:
+      - frontend/src/stores/__tests__/app-version.store.spec.ts
+
+  UT-SYS-STORE-030
+    title: exposes minSafeVersion as a non-empty string
+    impl:
+      - IMP-SYS-STORE-006
     files:
       - frontend/src/stores/__tests__/app-version.store.spec.ts

--- a/trace/unit_test/ui.yaml
+++ b/trace/unit_test/ui.yaml
@@ -1,0 +1,7 @@
+UI Routing — Route Table (Unit)
+  UT-UI-ROUTE-001
+    title: resolves named home route to / path
+    impl:
+      - IMP-UI-ROUTE-001
+    files:
+      - frontend/src/router/index.spec.ts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Closes implementation gaps across Aircraft UI, PWA/SYS, and supplementary data issues. Covers issues #158, #160, #161, #162, #163, #166, and #167.

**Aircraft Model Catalogue (#158):**
- `aircraft-model-catalogue.spec.ts` (new, 24 tests): manufacturer filter, ICAO auto-fill, reverse lookup, 'Other' mode, CATALOGUE_VERSION (UT-AC-VIEW-001..024)
- `AircraftModelSelector.spec.ts` (new, 15 tests): manufacturer dropdown, model filter, 'Other' free-text mode, ICAO auto-fill, bidirectional reverse lookup (UT-AC-VIEW-025..039)
- `fleet.store.spec.ts` extended: LOADING→READY, LOADING→ERROR, READY population tests for async IndexedDB load

**Exchange File Format (#160):**
- `docs/architecture/aircraft-exchange-file-format.md`: Full specification of exchange format

**Supplementary Fields (#161):**
- `fleet.repository.int.spec.ts` extended: round-trip tests for `costPerHour`, `referenceDatumDescription`, `checklistScaffold` (IT-AC-STORE-005..009)

**PWA Offline (#162):**
- Verified `useRegisterSW` wiring in `main.ts`; verified offline app shell caching

**PWA Update / Version Gate (#163):**
- `App.vue`: Added `checkMinSafeVersion()` in `onMounted`; added version-blocked banner (`role="alert"`)
- `app-version.store.spec.ts` extended: isVersionBelow, meets-minimum, non-empty minSafeVersion tests
- `pwa-update.store.spec.ts` extended: applyUpdate fallback, silent-update-absent test

**schemaVersion / Migration ADR (#166):**
- `fleet.repository.int.spec.ts` extended: 3 tests asserting `schemaVersion` persisted/preserved through create/update/findAll
- `docs/architecture/adr/008-indexeddb-migration-strategy.md`: Full ADR documenting detection logic, migration path per version delta, fallback/quarantine behavior

**Aircraft Data Update Pipeline ADR (#167):**
- `docs/architecture/adr/007-aircraft-data-update-pipeline.md` enhanced with versioning strategy, update path, and notification mechanism sections

### Related Issues

Closes #158
Closes #160
Closes #161
Closes #162
Closes #163
Closes #166
Closes #167

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-AC-004`, `REQ-AD-006`, `REQ-AD-007`, `REQ-AD-010`, `REQ-SYS-001`, `REQ-SYS-002`, `REQ-SYS-005`, `REQ-SYS-006`, `REQ-UI-001`, `REQ-UI-002`, `REQ-UI-003`, `REQ-UI-004`

### Documentation Updates

- [x] **Requirements:** N/A (requirements already defined)
- [x] **Architecture:** Created ADR-008 (`docs/architecture/adr/008-indexeddb-migration-strategy.md`); Updated ADR-007; Created exchange file format doc
- [x] **Risk Management:** N/A (no new hazards)
- [x] **Journeys:** N/A
- [x] **Code Docs:** Trace registries updated (`trace/unit_test/ac.yaml`, `trace/unit_test/sys.yaml`, `trace/unit_test/ui.yaml`, `trace/implementation/ad.yaml`, `trace/implementation/sys.yaml`, `trace/implementation/ui.yaml`)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`
- [x] **Unit Tests:** Added and passing — 598 unit tests, 0 failures
- [x] **Integration Tests:** Passing — 20 tests, 0 failures
- [x] **Manual Testing:** N/A (test additions + documentation)
- [x] **DoD:** All DoD items from all linked issues are met
- [x] **Review:** Self-reviewed
- [x] **ADR:** ADR-008 created for migration strategy; ADR-007 updated for data pipeline

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a759403b-6c5b-4261-b6d0-76782ba21078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a759403b-6c5b-4261-b6d0-76782ba21078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

