### PR TITLE
fix(repo): unblock dependabot PRs — patch transitive vulns, dedup config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 version: 2
 
 updates:
-  # Scan the pnpm workspace (npm ecosystem) in the frontend package
+  # Scan the pnpm workspace from the repo root (single shared pnpm-lock.yaml
+  # covers both the root dev tooling and the frontend workspace package).
   - package-ecosystem: npm
-    directory: /frontend
+    directory: /
     target-branch: develop
     schedule:
       interval: weekly
@@ -12,21 +13,6 @@ updates:
     open-pull-requests-limit: 10
     groups:
       # Bundle all minor and patch updates together to reduce PR noise
-      minor-and-patch:
-        update-types:
-          - minor
-          - patch
-
-  # Scan the root pnpm workspace
-  - package-ecosystem: npm
-    directory: /
-    target-branch: develop
-    schedule:
-      interval: weekly
-      day: monday
-      time: '06:00'
-    open-pull-requests-limit: 5
-    groups:
       minor-and-patch:
         update-types:
           - minor

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
       "brace-expansion@>=2.0.0 <2.0.3": "~2.0.3",
       "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5",
       "yaml": ">=2.8.3",
-      "smol-toml": ">=1.6.1"
+      "smol-toml": ">=1.6.1",
+      "basic-ftp": ">=5.3.0",
+      "serialize-javascript": ">=7.0.3"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,8 @@ overrides:
   brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
   yaml: '>=2.8.3'
   smol-toml: '>=1.6.1'
+  basic-ftp: '>=5.3.0'
+  serialize-javascript: '>=7.0.3'
 
 importers:
 
@@ -2340,8 +2342,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
     engines: {node: '>=10.0.0'}
 
   before-after-hook@4.0.0:
@@ -4335,9 +4337,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -4508,8 +4507,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -6884,7 +6884,7 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
     dependencies:
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       smob: 1.6.1
       terser: 5.46.1
     optionalDependencies:
@@ -7671,7 +7671,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.15: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.3.0: {}
 
   before-after-hook@4.0.0: {}
 
@@ -8568,7 +8568,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -9862,10 +9862,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.0: {}
 
   rc9@2.1.2:
@@ -10089,9 +10085,7 @@ snapshots:
 
   semver@7.7.4: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   serve-handler@6.1.7:
     dependencies:


### PR DESCRIPTION
### Summary

Two infrastructure fixes that together unblock the backlog of open dependabot PRs (#210, #200) and prevent a recurring duplication pattern:

1. **`.github/dependabot.yml`** — Collapsed the two npm ecosystem entries (`/` and `/frontend`) into a single root entry. The pnpm workspace has one shared `pnpm-lock.yaml` at the repo root, so scanning both directories was producing duplicate PRs for every update (e.g. #209 was a twin of #210; #202 was a twin of #206). Going forward, each update will open exactly one PR.

2. **Root `package.json` pnpm overrides** — Added:
   - `basic-ftp: ">=5.3.0"` (patches 4 high-severity GHSAs: `-6v7q-wjvx-w8wg`, `-chqc-8p9q-pq6q`, `-rp42-5vxx-qpwr`, plus the related 5.2.0 advisory) — reaches through `release-it → proxy-agent → pac-proxy-agent → get-uri`
   - `serialize-javascript: ">=7.0.3"` (patches GHSA-`5c6j-r48x-rmvq`) — reaches through `vite-plugin-pwa → workbox-build → @rollup/plugin-terser`

   Verified locally: `pnpm audit --audit-level high` returns **"No known vulnerabilities found"**. Without this, the Dependency Audit job fails on every open PR (including brand-new ones), because the vulns exist on `develop` itself.

### Context — open dependabot PRs

Closed as part of this cleanup:
- **#209, #202** — duplicates from the `/frontend` dependabot scan entry (now removed)
- **#206** — `vite 7.3.2 → 8.0.8` major bump; unsafe until Vitest, `@vitejs/plugin-vue`, and `vite-plugin-pwa` confirm Vite 8 support

Still open, with status comments posted:
- **#210** (13-pkg minor/patch group) — Audit passes after rebase; its Unit Tests failure is a genuine regression in the bundled update (likely `vitest` 4.1.2 → 4.1.4). Develop baseline is 681/681 passing.
- **#200** (`pnpm/action-setup` v5 → v6) — Audit passes after rebase; v6 breaks the "Install dependencies" step even though our `packageManager` field is pinned. Recommended either explicit `version: 10.32.1` in each workflow or waiting for `@v6.1+`.

### Related Issues

N/A — this is a repo/CI maintenance change. No requirement ticket.

### Affected Items

- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: CI/tooling-only change.)
- [x] **Architecture:** `N/A` (Reason: No architectural impact; does not touch P1/P2/P3 surface.)
- [x] **Risk Management:** `N/A` (Reason: No new hazards; improves supply-chain posture by patching transitive CVEs.)
- [x] **Journeys:** `N/A` (Reason: No user-visible behavior change.)
- [x] **Code Docs:** `N/A` (Reason: `CHANGELOG.md` not updated — standing practice for dependabot/CI housekeeping; can add an `### Engineering` entry on request.)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules — change is limited to root config files).

### Quality & Testing Checklist

- [x] **Target Branch:** Correctly targets `develop`.
- [x] **Unit Tests:** Ran `pnpm --filter frontend test:unit` locally — **681/681 passing** post-override.
- [x] **Integration Tests:** `N/A` (Reason: no runtime code changed — overrides affect only transitive CLI/build-tool deps.)
- [x] **Manual Testing:** Verified `pnpm install` succeeds and `pnpm audit --audit-level high` reports no vulnerabilities.
- [x] **DoD:** N/A — no linked ticket.
- [x] **Review:** Self-reviewed.
- [x] **ADR:** No — this is a non-architectural config/override change.

https://claude.ai/code/session_01Kh1iYU9ESyNSETVcxRrPWX