### PR TITLE
chore(repo): reduce dependabot PR noise via semantic grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,24 @@
 version: 2
 
+# ---------------------------------------------------------------------------
+# Dependabot configuration for AeroDash
+#
+# Goals (in priority order):
+#   1. Stay up-to-date on security-relevant versions (security PRs are always
+#      raised individually and are NOT affected by grouping or cooldown).
+#   2. Minimize PR noise by grouping semantically related packages so a single
+#      PR updates a cohesive slice of the toolchain (e.g. the Vue stack, the
+#      test runner stack, the lint stack).
+#   3. Keep breaking (major) bumps within their logical group so reviewers
+#      see compatible versions together, instead of N independent major PRs.
+#   4. Let fresh releases settle before opening a PR (cooldown) to avoid
+#      thrash on packages that publish multiple times per week.
+# ---------------------------------------------------------------------------
+
 updates:
-  # Scan the pnpm workspace from the repo root (single shared pnpm-lock.yaml
-  # covers both the root dev tooling and the frontend workspace package).
+  # -------------------------------------------------------------------------
+  # npm / pnpm workspace (root + frontend share one pnpm-lock.yaml)
+  # -------------------------------------------------------------------------
   - package-ecosystem: npm
     directory: /
     target-branch: develop
@@ -10,25 +26,120 @@ updates:
       interval: weekly
       day: monday
       time: '06:00'
-    open-pull-requests-limit: 10
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    # Use the allowed commitlint scope so commits match project standards.
+    commit-message:
+      prefix: 'chore(repo)'
+      prefix-development: 'chore(repo)'
+    # Wait for releases to stabilize before proposing a bump. Majors get a
+    # longer window to surface regressions before we spend reviewer time.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 1
     groups:
-      # Bundle all minor and patch updates together to reduce PR noise
-      minor-and-patch:
+      # Vue runtime + build-plugins + PWA + router + state. These versions
+      # track each other closely; bumping one in isolation usually breaks
+      # peer-dependency resolution.
+      vue-ecosystem:
+        patterns:
+          - 'vue'
+          - 'vue-*'
+          - '@vue/*'
+          - '@vitejs/plugin-vue'
+          - 'pinia'
+          - 'vite-plugin-vue-*'
+          - 'vite-plugin-pwa'
+          - 'workbox-*'
+          - 'eslint-plugin-vue'
+
+      # Test tooling: Vitest, Playwright, coverage, mutation testing,
+      # DOM/IndexedDB polyfills used by tests.
+      test-tooling:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - '@vue/test-utils'
+          - '@playwright/*'
+          - 'playwright'
+          - 'playwright-*'
+          - 'eslint-plugin-playwright'
+          - '@stryker-mutator/*'
+          - 'fake-indexeddb'
+          - 'jsdom'
+          - '@types/jsdom'
+
+      # Linters & formatters. Bumping eslint without its plugins usually
+      # breaks the config, so keep them together.
+      lint-tooling:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@vue/eslint-config-*'
+          - 'oxlint'
+          - 'prettier'
+          - 'markdownlint-cli2'
+
+      # Build + language toolchain.
+      build-tooling:
+        patterns:
+          - 'vite'
+          - 'typescript'
+          - '@tsconfig/*'
+          - '@types/node'
+          - 'npm-run-all2'
+
+      # Commit / release / husky pipeline. Bumping commitlint without its
+      # config package breaks pre-commit hooks.
+      repo-tooling:
+        patterns:
+          - '@commitlint/*'
+          - 'commitlint'
+          - 'husky'
+          - 'lint-staged'
+          - 'release-it'
+          - '@release-it/*'
+
+      # Catch-all for anything not matched above. Split prod vs. dev so the
+      # production-group PR is small and can be reviewed with higher care
+      # (shipped code) while dev-tooling bumps batch freely.
+      production-minor-and-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-minor-and-patch:
+        dependency-type: development
         update-types:
           - minor
           - patch
 
-  # Keep GitHub Actions up to date
+  # -------------------------------------------------------------------------
+  # GitHub Actions
+  # Actions change infrequently; monthly cadence + single group is enough.
+  # -------------------------------------------------------------------------
   - package-ecosystem: github-actions
     directory: /
     target-branch: develop
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: '06:00'
-    open-pull-requests-limit: 5
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: 'chore(repo)'
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
-      actions-minor-and-patch:
-        update-types:
-          - minor
-          - patch
+      github-actions-all:
+        patterns:
+          - '*'


### PR DESCRIPTION
### Summary

Optimize `.github/dependabot.yml` to cut PR noise without compromising security response time. The change applies Dependabot best practices rather than just minimizing PR count: semantically related packages are grouped so cohesive slices of the toolchain update together, and fresh releases get a cooldown window before a PR is opened.

### Related Issues

- Ref: repo maintenance (no issue filed)

### What changed

- **Semantic groups by concern** — `vue-ecosystem`, `test-tooling`, `lint-tooling`, `build-tooling`, `repo-tooling`. Coupled peer-deps (e.g. `eslint` + its plugins, `vitest` + `@vitest/*`, `vue` + `@vue/*` + `pinia`) now move together, preventing broken intermediate states and collapsing N PRs into one reviewable PR.
- **Majors stay inside their group** — groups intentionally don't filter by `update-type`, so a Vue major bump arrives with its plugins in a single PR instead of five independent breaking PRs.
- **Catch-all split prod vs. dev** — `production-minor-and-patch` gives shipped-code bumps a smaller, higher-scrutiny PR; `dev-minor-and-patch` batches dev tooling freely.
- **Cooldown window** — 7d default, 14d for majors, 3d minor, 1d patch. Lets regressions surface before reviewer time is spent.
- **GitHub Actions → monthly + single group** — actions rarely change; weekly was overkill.
- **Commit scope aligned with commitlint** — `chore(repo)` instead of default `chore(deps)`, matching `scope-enum` in `commitlint.config.cjs`.
- **Security PRs unaffected** — Dependabot always raises security updates individually, bypassing groups and cooldown, so vulnerability response time is preserved.

### Affected Items

- **Requirements Implemented/Affected:** `N/A` (repo meta tooling)

### Documentation Updates

- [x] **Requirements:** `N/A` (no product requirement changed)
- [x] **Architecture:** `N/A` (no architectural boundary changed; CI/meta tooling only)
- [x] **Risk Management:** `N/A` (no safety hazard introduced)
- [x] **Journeys:** `N/A` (no user-visible behavior)
- [x] **Code Docs:** `N/A` (config is self-documenting via inline comments)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no source code touched).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (config-only change, no executable code).
- [x] **Integration Tests:** `N/A` (config-only change).
- [x] **Manual Testing:** YAML validated; next weekly run will exercise the grouping.
- [x] **DoD:** Config follows Dependabot schema, aligns with project commit-scope policy, preserves security update behavior.
- [x] **Review:** Self-reviewed diff.
- [x] **ADR:** Not required — no architectural boundary changed.
