### PR TITLE
fix(ac): apply dark theme tokens to fleet management views

### DIFF
--- a/frontend/src/modules/aircraft/components/AircraftModelSelector.vue
+++ b/frontend/src/modules/aircraft/components/AircraftModelSelector.vue
@@ -188,23 +188,31 @@ watch(
 .field-group label {
   font-weight: 600;
   font-size: 0.875rem;
+  color: var(--color-text-primary, #212121);
 }
 
 .field-group select,
 .field-group input[type='text'] {
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border, #ccc);
   border-radius: 4px;
   font-size: 1rem;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #212121);
+}
+
+.field-group input[type='text']::placeholder {
+  color: var(--color-text-secondary, #9ca3af);
 }
 
 .icao-lookup-results {
   list-style: none;
   margin: 0;
   padding: 0;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border, #ccc);
   border-radius: 4px;
-  background: white;
+  background: var(--color-surface-raised, #ffffff);
+  color: var(--color-text-primary, #212121);
   max-height: 200px;
   overflow-y: auto;
 }
@@ -215,6 +223,6 @@ watch(
 }
 
 .icao-lookup-result:hover {
-  background: #f0f0f0;
+  background: var(--color-surface-hover, #f0f0f0);
 }
 </style>

--- a/frontend/src/modules/aircraft/components/FleetList.vue
+++ b/frontend/src/modules/aircraft/components/FleetList.vue
@@ -118,14 +118,14 @@ async function onDelete(id: string, registration: string): Promise<void> {
 .error-state {
   padding: 1rem;
   text-align: center;
-  color: #6b7280;
+  color: var(--color-text-secondary, #6b7280);
 }
 
 .error-state {
-  border: 1px solid #fecaca;
+  border: 1px solid var(--color-critical, #fecaca);
   border-radius: 6px;
-  background: #fef2f2;
-  color: #991b1b;
+  background: var(--color-critical-bg, #fef2f2);
+  color: var(--color-critical, #991b1b);
 }
 
 .error-state__detail {
@@ -142,8 +142,8 @@ async function onDelete(id: string, registration: string): Promise<void> {
   font-size: 0.875rem;
   cursor: pointer;
   font-weight: 500;
-  background: #dc2626;
-  color: white;
+  background: var(--color-critical, #dc2626);
+  color: var(--neutral-0, #ffffff);
 }
 
 .profiles-list {
@@ -160,15 +160,16 @@ async function onDelete(id: string, registration: string): Promise<void> {
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--color-border, #e5e7eb);
   border-radius: 6px;
-  background: white;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #212121);
   gap: 1rem;
 }
 
 .profile-item--active {
-  border-color: #3b82f6;
-  background: #eff6ff;
+  border-color: var(--color-primary, #3b82f6);
+  background: var(--color-primary-bg, #eff6ff);
 }
 
 .profile-item__info {
@@ -183,10 +184,11 @@ async function onDelete(id: string, registration: string): Promise<void> {
   font-weight: 700;
   font-size: 1rem;
   white-space: nowrap;
+  color: var(--color-text-primary, #212121);
 }
 
 .profile-item__model {
-  color: #6b7280;
+  color: var(--color-text-secondary, #6b7280);
   font-size: 0.875rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -214,22 +216,26 @@ async function onDelete(id: string, registration: string): Promise<void> {
 }
 
 .btn-primary {
-  background: #3b82f6;
-  color: white;
+  background: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #ffffff);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-primary-hover, #2563eb);
 }
 
 .btn-success {
-  background: #10b981;
-  color: white;
+  background: var(--color-success, #10b981);
+  color: var(--neutral-0, #ffffff);
 }
 
 .btn-secondary {
-  background: #6b7280;
-  color: white;
+  background: var(--color-text-secondary, #6b7280);
+  color: var(--neutral-0, #ffffff);
 }
 
 .btn-danger {
-  background: #ef4444;
-  color: white;
+  background: var(--color-critical, #ef4444);
+  color: var(--neutral-0, #ffffff);
 }
 </style>

--- a/frontend/src/modules/aircraft/components/ProfileStatusBadge.vue
+++ b/frontend/src/modules/aircraft/components/ProfileStatusBadge.vue
@@ -52,14 +52,14 @@ const ariaLabel = computed(() => `Profile status: ${statusLabel.value}`)
 }
 
 .status-verified {
-  background-color: #d1fae5;
-  color: #065f46;
-  border: 1px solid #6ee7b7;
+  background-color: var(--color-success-bg, #d1fae5);
+  color: var(--color-success, #065f46);
+  border: 1px solid var(--color-success, #6ee7b7);
 }
 
 .status-draft {
-  background-color: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fcd34d;
+  background-color: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning, #92400e);
+  border: 1px solid var(--color-warning, #fcd34d);
 }
 </style>

--- a/frontend/src/modules/aircraft/views/FleetManagementView.vue
+++ b/frontend/src/modules/aircraft/views/FleetManagementView.vue
@@ -279,36 +279,41 @@ async function onImportFile(event: Event): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  color: var(--color-text, #212121);
 }
 
 h1 {
   font-size: 1.75rem;
   font-weight: 700;
   margin: 0;
+  color: var(--color-text-primary, #212121);
 }
 
 h2 {
   font-size: 1.25rem;
   font-weight: 600;
   margin: 0 0 1rem 0;
+  color: var(--color-text-primary, #212121);
 }
 
 .fleet-section,
 .add-aircraft-section {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--color-border, #e5e7eb);
   border-radius: 8px;
   padding: 1.5rem;
-  background: #f9fafb;
+  background: var(--color-surface-card, #f9fafb);
+  color: var(--color-text, #212121);
 }
 
 .notifications-banner {
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
+  background: var(--color-warning-bg, #fef3c7);
+  border: 1px solid var(--color-warning, #fcd34d);
   border-radius: 8px;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  color: var(--color-warning, #92400e);
 }
 
 .notification {
@@ -316,14 +321,14 @@ h2 {
 }
 
 .notification--warning {
-  color: #92400e;
+  color: var(--color-warning, #92400e);
 }
 
 .btn-clear-notifications {
   align-self: flex-end;
   background: none;
-  border: 1px solid #d97706;
-  color: #92400e;
+  border: 1px solid var(--color-warning, #d97706);
+  color: var(--color-warning, #92400e);
   padding: 0.25rem 0.75rem;
   border-radius: 4px;
   cursor: pointer;
@@ -345,28 +350,41 @@ h2 {
 .field-group label {
   font-weight: 600;
   font-size: 0.875rem;
+  color: var(--color-text-primary, #212121);
 }
 
 .field-group input,
 .field-group select {
   padding: 0.5rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border, #d1d5db);
   border-radius: 4px;
   font-size: 1rem;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #212121);
+}
+
+.field-group input::placeholder {
+  color: var(--color-text-secondary, #9ca3af);
 }
 
 .field-error {
-  color: #dc2626;
+  color: var(--color-critical, #dc2626);
   font-size: 0.8rem;
 }
 
 .passenger-profiles-fieldset {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border, #d1d5db);
   border-radius: 6px;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  color: var(--color-text, #212121);
+}
+
+.passenger-profiles-fieldset legend {
+  color: var(--color-text-primary, #212121);
+  font-weight: 600;
 }
 
 .passenger-profile-row {
@@ -379,22 +397,24 @@ h2 {
 .passenger-profile-row select {
   flex: 1;
   padding: 0.375rem 0.5rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border, #d1d5db);
   border-radius: 4px;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #212121);
 }
 
 .btn-remove-pax {
   background: none;
   border: none;
-  color: #ef4444;
+  color: var(--color-critical, #ef4444);
   cursor: pointer;
   font-size: 1rem;
 }
 
 .btn-add-pax {
   background: none;
-  border: 1px dashed #9ca3af;
-  color: #6b7280;
+  border: 1px dashed var(--color-border, #9ca3af);
+  color: var(--color-text-secondary, #6b7280);
   padding: 0.375rem 0.75rem;
   border-radius: 4px;
   cursor: pointer;
@@ -411,6 +431,11 @@ h2 {
 .import-section label {
   font-weight: 600;
   font-size: 0.875rem;
+  color: var(--color-text-primary, #212121);
+}
+
+.import-section input[type='file'] {
+  color: var(--color-text, #212121);
 }
 
 .form-actions {
@@ -433,7 +458,11 @@ h2 {
 }
 
 .btn-primary {
-  background: #3b82f6;
-  color: white;
+  background: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #ffffff);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-primary-hover, #2563eb);
 }
 </style>


### PR DESCRIPTION
## Summary

The **Fleet Management** page did not honor the dark theme: section cards (`Your Fleet`, `Add New Aircraft`), the passenger-profiles fieldset, the profile list items, the ICAO lookup dropdown, and the verified/draft status badges all rendered with hardcoded light-mode hex colors. In dark mode this produced white cards on a dark page and low-contrast gray text (see issue screenshot).

This PR replaces hardcoded colors with the semantic design tokens already defined in `frontend/src/assets/theme.css` so the page flips correctly under `[data-theme="dark"]` on `<html>`.

## Changes

- `frontend/src/modules/aircraft/views/FleetManagementView.vue` — section cards, form fields (inputs/selects), notifications banner, passenger-profiles fieldset, import section, and primary button now use `--color-surface-card`, `--color-surface`, `--color-border`, `--color-text-primary`, `--color-text-secondary`, `--color-warning(-bg)`, `--color-critical`, `--color-primary(-hover/-text)`.
- `frontend/src/modules/aircraft/components/FleetList.vue` — profile list items, empty/error states, and action buttons (`primary`, `success`, `secondary`, `danger`, `retry`) now use theme tokens. The active-profile highlight uses `--color-primary` + `--color-primary-bg`.
- `frontend/src/modules/aircraft/components/AircraftModelSelector.vue` — labels, inputs/selects, and the ICAO lookup dropdown (+ hover state) use theme tokens.
- `frontend/src/modules/aircraft/components/ProfileStatusBadge.vue` — verified/draft variants use `--color-success(-bg)` and `--color-warning(-bg)`.

No behavioral or structural changes — styles only. Fallback colors preserved on every `var(...)` for defensive rendering.

## Tier / Coverage

All changes are in `src/modules/aircraft/` (**P2**). No changes to `src/core/` (P1).

## Test plan

- [x] `pnpm lint:eslint` — clean (no `[P1-ISOLATION]` violations; this PR doesn't touch P1)
- [x] `pnpm --filter frontend type-check` — passes
- [x] `pnpm --filter frontend exec vitest run src/modules/aircraft` — 149/149 tests pass
- [x] Manual: verify Fleet Management page renders correctly in both light and dark modes (toggle via moon icon in header) — cards, form, badges, buttons, active profile highlight

Closes the dark-theme rendering defect shown in the attached screenshot.

https://claude.ai/code/session_01NYFWCJR7mxVRfH81yoEinj