### PR TITLE
chore(repo): bump GitHub Actions to Node.js 24 runtime versions

### DIFF
--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -47,7 +47,7 @@ jobs:
     needs: [lint]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -70,7 +70,7 @@ jobs:
     needs: [lint]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -97,7 +97,7 @@ jobs:
     needs: [type-check, unit-tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -121,7 +121,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: frontend/playwright-report/
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload test results (traces, screenshots, videos)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-test-results
           path: frontend/test-results/

--- a/.github/workflows/deploy-reports.yml
+++ b/.github/workflows/deploy-reports.yml
@@ -30,7 +30,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -229,7 +229,7 @@ jobs:
 
       # ── Pages Deployment ──────────────────────────────────────────────────
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: reports/
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: frontend/playwright-report/
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload test results (traces, screenshots, videos)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-test-results
           path: frontend/test-results/

--- a/.github/workflows/publish-devcontainer.yml
+++ b/.github/workflows/publish-devcontainer.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           # Use the default security-and-quality query suite
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:javascript-typescript
 
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -242,7 +242,7 @@ jobs:
       # ── 8. Upload raw trace JSON as artifact ──────────────────────────────
       - name: Upload trace JSON artifact
         if: steps.json.outputs.json_ok == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: traceability-report
           path: /tmp/trace.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `FleetList.vue`, `ProfileStatusBadge.vue`, and additional `aircraft-model-catalogue` unit tests to bring `modules/aircraft` P2 coverage above the 80% threshold
 - Added `app-version-blocked.spec.ts` unit tests validating REQ-SYS-006 gate (version-blocked state renders blocked screen; content hidden when blocked; gate is reactive)
 - Offline E2E smoke test added for PWA offline-first DoD verification (refs #162)
+- Bumped GitHub Actions to Node.js 24 runtime versions (`actions/checkout@v5`, `actions/upload-artifact@v5`, `actions/upload-pages-artifact@v5`, `github/codeql-action@v4`) to eliminate Node.js 20 deprecation warnings ahead of the June 2, 2026 runner cutover
 
 ## [0.2.0-alpha] - 2026-04-03
 


### PR DESCRIPTION
### Summary

CI jobs were emitting the GitHub runner deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

This PR bumps every third-party action that was still bundled on Node.js 20 to the current major version that ships on Node.js 24, so the warnings disappear and CI keeps working past the June 2026 runner cutover.

Action upgrades (all workflows under `.github/workflows/`):

- `actions/checkout@v4` -> `@v5`
- `actions/upload-artifact@v4` -> `@v5`
- `actions/upload-pages-artifact@v4` -> `@v5`
- `github/codeql-action/init@v3` -> `@v4`
- `github/codeql-action/analyze@v3` -> `@v4`

Unchanged (already on Node.js 24): `actions/setup-node@v6`, `pnpm/action-setup@v5`, `actions/deploy-pages@v5`, `docker/login-action@v4`, `docker/setup-buildx-action@v4`, `docker/metadata-action@v6`, `docker/build-push-action@v7`.

No app code, no P1 Safety Core changes — tooling / CI plumbing only.

### Related Issues

- Ref: Node.js 20 deprecation warning on every CI run

### Affected Items

- **Requirements Implemented/Affected:** `N/A` (tooling change)

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: CI plumbing only, no requirement surface touched)
- [x] **Architecture:** `N/A` (Reason: no architectural change; action surface is equivalent)
- [x] **Risk Management:** `N/A` (Reason: no new hazards; keeps CI operational)
- [x] **Journeys:** `N/A` (Reason: no user-facing behavior change)
- [x] **Code Docs:** `CHANGELOG.md` updated under `[Unreleased] / ### Engineering`

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: CI action version bumps only, no source files changed).
- [x] **Integration Tests:** `N/A` (Reason: same as above).
- [x] **Manual Testing:** `N/A` (Reason: verification happens when CI runs on this PR — warning should disappear, jobs must stay green).
- [x] **DoD:** Warnings gone, all CI checks pass on this PR.
- [x] **Review:** Self-reviewed.
- [x] **ADR:** Not required — action version bumps are routine maintenance and do not alter the P1 interface surface.