### PR TITLE
fix(mb): wire session-persistence auto-save into Flight Preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-save of the active Mass & Balance session to `localStorage` — the `sessionPersistence` store was shipped in a prior milestone but never instantiated by the running app, so reloading the Flight Preparation page always dropped the pilot's aircraft selection, category, and station weights back to profile defaults. `MassBalanceView` now restores the payload on mount (after the fleet hydrates), re-applies it through the new `massBalance.applyRestoredSession(payload)` action, and starts the debounced auto-save watcher; stale payloads whose aircraft has since been removed from the fleet are discarded. `startWatching()` is now idempotent so view remounts don't stack watchers. (REQ-SYS-013)
+
 ### Added
 
 - Fleet editor / wizard: per-load-station **allowable-categories** selector — when an aircraft is certified in more than one category (e.g. Normal + Utility + Aerobatic), each seat, baggage area, or fuel tank can be restricted to the subset of categories in which it is approved (e.g. rear seats not approved in Aerobatic). Stations default to unrestricted (available in every category); the UI auto-prunes stale category references no longer present on the aircraft. Previously the `allowableCategories` field existed in the schema but was always persisted as `null`, forcing pilots with multi-category aircraft to ignore POH placards. (REQ-AD-012)

--- a/frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts
+++ b/frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts
@@ -1012,3 +1012,126 @@ describe('MassBalance Store', () => {
     expect(store.lastResult).toStrictEqual(expectedResult)
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════════
+// applyRestoredSession — persisted-session restore path (REQ-SYS-013)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Mass Balance Store - applyRestoredSession', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockedCalculate.mockReturnValue(buildSuccessResult())
+  })
+
+  // @UT-MB-STORE-051@ (FROM: @IMP-MB-STORE-019@)
+  it('restores station weights and interaction flags onto a freshly-loaded profile', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+
+    store.applyRestoredSession({
+      version: 1,
+      aircraftId: 'tecnam-p2008',
+      activeCategory: 'Normal',
+      stations: [
+        { index: 0, weight: 160, touched: true, verified: true },
+        { index: 1, weight: 50, touched: true, verified: false },
+      ],
+      savedAt: '2026-04-19T10:00:00.000Z',
+    })
+
+    expect(store.stations[0]!.weight).toBe(160)
+    expect(store.stations[0]!.touched).toBe(true)
+    expect(store.stations[0]!.verified).toBe(true)
+    expect(store.stations[1]!.weight).toBe(50)
+    expect(store.stations[1]!.verified).toBe(false)
+  })
+
+  // @UT-MB-STORE-052@ (FROM: @IMP-MB-STORE-019@)
+  it('is a no-op when no aircraft is loaded (guards against out-of-order restore)', () => {
+    const store = useMassBalanceStore()
+
+    store.applyRestoredSession({
+      version: 1,
+      aircraftId: 'tecnam-p2008',
+      activeCategory: 'Normal',
+      stations: [{ index: 0, weight: 160, touched: true, verified: true }],
+      savedAt: '2026-04-19T10:00:00.000Z',
+    })
+
+    expect(store.aircraft).toBeNull()
+    expect(store.stations).toHaveLength(0)
+  })
+
+  // @UT-MB-STORE-053@ (FROM: @IMP-MB-STORE-019@)
+  it('is a no-op when the payload aircraftId does not match the loaded profile', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+
+    store.applyRestoredSession({
+      version: 1,
+      aircraftId: 'not-this-aircraft',
+      activeCategory: 'Normal',
+      stations: [{ index: 0, weight: 999, touched: true, verified: true }],
+      savedAt: '2026-04-19T10:00:00.000Z',
+    })
+
+    // Default from loadProfile, untouched by the ignored payload.
+    expect(store.stations[0]!.weight).toBe(0)
+  })
+
+  // @UT-MB-STORE-054@ (FROM: @IMP-MB-STORE-019@)
+  it('silently skips station entries whose index is out of range', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+
+    expect(() => {
+      store.applyRestoredSession({
+        version: 1,
+        aircraftId: 'tecnam-p2008',
+        activeCategory: 'Normal',
+        stations: [
+          { index: 0, weight: 160, touched: true, verified: true },
+          { index: 99, weight: 12, touched: true, verified: true },
+        ],
+        savedAt: '2026-04-19T10:00:00.000Z',
+      })
+    }).not.toThrow()
+
+    expect(store.stations[0]!.weight).toBe(160)
+    expect(store.stations).toHaveLength(2) // profile's load points, unchanged
+  })
+
+  // @UT-MB-STORE-055@ (FROM: @IMP-MB-STORE-019@)
+  it('ignores an unknown activeCategory and keeps the profile default', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+    const defaultCategory = store.activeCategory
+
+    store.applyRestoredSession({
+      version: 1,
+      aircraftId: 'tecnam-p2008',
+      activeCategory: 'Aerobatic', // not in mockProfile
+      stations: [],
+      savedAt: '2026-04-19T10:00:00.000Z',
+    })
+
+    expect(store.activeCategory).toBe(defaultCategory)
+  })
+
+  // @UT-MB-STORE-056@ (FROM: @IMP-MB-STORE-019@)
+  it('re-runs the math core after applying the payload', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+    mockedCalculate.mockClear()
+
+    store.applyRestoredSession({
+      version: 1,
+      aircraftId: 'tecnam-p2008',
+      activeCategory: 'Normal',
+      stations: [{ index: 0, weight: 160, touched: true, verified: true }],
+      savedAt: '2026-04-19T10:00:00.000Z',
+    })
+
+    expect(mockedCalculate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+++ b/frontend/src/modules/mass-balance/stores/mass-balance.store.ts
@@ -27,6 +27,7 @@ import { calculateMassBalance } from '@/core/adapters/mass-balance.adapter'
 import { normalizeMassToKg, normalizeArmToM } from '@/core/logic/unit-normalization'
 import { normalizeFuelQuantityToKg, isFuelQuantityUnit } from '@/core/logic/fuel-mass'
 import type { MassUnit, ArmUnit } from '@/core/domain/units'
+import type { SessionPayload } from '@/core/domain/session.schema'
 import type {
   MassBalanceState,
   AircraftContext,
@@ -252,6 +253,47 @@ export const useMassBalanceStore = defineStore('massBalance', {
       for (const station of this.availableStations) {
         station.verified = true
       }
+      this.evaluateState()
+    },
+
+    /**
+     * Re-apply a persisted session payload to a freshly loaded aircraft profile.
+     *
+     * Callers must first invoke `loadProfile()` so the store holds the correct
+     * aircraft context; this action then overrides the default station weights
+     * and the active category with the pilot's last-entered values before
+     * re-running the math core.
+     *
+     * Defensive invariants:
+     *  - No-op when no aircraft is loaded.
+     *  - No-op when the payload's `aircraftId` does not match the loaded
+     *    profile (prevents cross-airframe pollution after a fleet edit).
+     *  - Station entries whose index is out of range are silently skipped so
+     *    a stale payload from an older profile revision does not corrupt the
+     *    current station array.
+     *  - An unknown `activeCategory` leaves the profile default in place.
+     */
+    // @IMP-MB-STORE-019@ (FROM: @REQ-SYS-013@)
+    applyRestoredSession(payload: SessionPayload): void {
+      if (!this.aircraft) return
+      if (this.aircraft.id !== payload.aircraftId) return
+
+      const categoryExists = this.aircraft.certificationCategories.some(
+        (c) => c.category === payload.activeCategory,
+      )
+      if (categoryExists) {
+        this.activeCategory = payload.activeCategory
+      }
+
+      for (const sp of payload.stations) {
+        const station = this.stations[sp.index]
+        if (!station) continue
+        station.weight = sp.weight
+        station.touched = sp.touched
+        station.verified = sp.verified
+      }
+
+      this._runCalculation()
       this.evaluateState()
     },
 

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -6,6 +6,8 @@ import { AircraftContextSchema } from '@/modules/mass-balance/data/aircraft-cont
 import { mapFleetProfileToContext } from '@/modules/mass-balance/services/fleet-profile.mapper'
 import { useFleetStore } from '@/modules/aircraft/stores/fleet.store'
 import { useActiveAircraftStore } from '@/modules/aircraft/stores/active-aircraft.store'
+import { useSessionPersistenceStore } from '@/stores/session-persistence.store'
+import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 import InputGroupCard from '@/modules/mass-balance/components/InputGroupCard.vue'
 import MassStationInput from '@/modules/mass-balance/components/MassStationInput.vue'
 import CGEnvelopeChart from '@/modules/mass-balance/components/CGEnvelopeChart.vue'
@@ -22,6 +24,7 @@ const catalogueError = ref<string | null>(null)
 const store = useMassBalanceStore()
 const fleetStore = useFleetStore()
 const activeAircraftStore = useActiveAircraftStore()
+const sessionPersistenceStore = useSessionPersistenceStore()
 const router = useRouter()
 
 // ---------------------------------------------------------------------------
@@ -221,6 +224,20 @@ function onStripTap(meta: CardMeta): void {
   smoothScrollTo(absTop - offsetFromTop)
 }
 
+/**
+ * Map + validate a fleet profile into an AircraftContext and load it into the
+ * M&B store. Returns true when the store was populated, false on validation
+ * failure (a corrupt profile leaves the store in INITIAL).
+ */
+function loadProfileIntoStore(profile: AircraftProfile): boolean {
+  const mapped = mapFleetProfileToContext(profile)
+  const validation = AircraftContextSchema.safeParse(mapped)
+  if (!validation.success) return false
+  store.loadProfile(validation.data)
+  return true
+}
+
+// @IMP-MB-UI-SESSION-001@ (FROM: @REQ-SYS-013@)
 onMounted(async () => {
   // Only auto-load on the first mount (initial LOADING state). If a previous
   // attempt errored, let the pilot retry explicitly via the Retry button.
@@ -232,15 +249,34 @@ onMounted(async () => {
     }
   }
 
-  // Restore active aircraft selection across reloads
-  const active = activeAircraftStore.activeProfile
-  if (active && !store.aircraft) {
-    const mapped = mapFleetProfileToContext(active)
-    const validation = AircraftContextSchema.safeParse(mapped)
-    if (validation.success) {
-      store.loadProfile(validation.data)
+  if (!store.aircraft) {
+    // In-memory active aircraft survives SPA navigation but not a full reload.
+    const active = activeAircraftStore.activeProfile
+    if (active) {
+      loadProfileIntoStore(active)
+    } else {
+      // Full-reload path: attempt to restore the pilot's last session from
+      // localStorage. An invalid/stale payload has already been cleared by
+      // `restoreSession()`, so a null result means "start clean".
+      const payload = sessionPersistenceStore.restoreSession()
+      if (payload) {
+        const fleetProfile = fleetStore.profiles.find((p) => p.id === payload.aircraftId)
+        if (fleetProfile && loadProfileIntoStore(fleetProfile)) {
+          activeAircraftStore.setActiveProfile(fleetProfile)
+          store.applyRestoredSession(payload)
+        } else {
+          // Aircraft no longer in the fleet (deleted between sessions) —
+          // discard the payload so it doesn't haunt future reloads.
+          sessionPersistenceStore.clearSession()
+        }
+      }
     }
   }
+
+  // Start the debounced auto-save watcher. Must run after any restoration is
+  // finished so the initial default-state mutation doesn't overwrite the
+  // payload we just applied. `startWatching()` is idempotent for remounts.
+  sessionPersistenceStore.startWatching()
 
   setupStickyStackObserver()
 })

--- a/frontend/src/stores/__tests__/session-persistence.store.spec.ts
+++ b/frontend/src/stores/__tests__/session-persistence.store.spec.ts
@@ -317,6 +317,35 @@ describe('useSessionPersistenceStore — startWatching() debounced auto-save', (
   })
 })
 
+describe('useSessionPersistenceStore — startWatching() idempotency', () => {
+  // @UT-SYS-STORE-018@ (FROM: @IMP-SYS-STORE-001@)
+  it('does not stack watchers when called multiple times', async () => {
+    loadProfile(MOCK_PROFILE_A)
+    const store = useSessionPersistenceStore()
+
+    // Simulate a view remount that calls startWatching again.
+    store.startWatching()
+    store.startWatching()
+    store.startWatching()
+
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+    const mbStore = useMassBalanceStore()
+    mbStore.updateStationWeight(0, 77)
+
+    await nextTick()
+    vi.runAllTimers()
+
+    // A single mutation must produce a single persisted write, not three.
+    const aerodashWrites = setItemSpy.mock.calls.filter(
+      ([key]) => key === 'aerodash:session:payload',
+    )
+    expect(aerodashWrites).toHaveLength(1)
+
+    setItemSpy.mockRestore()
+  })
+})
+
 describe('useSessionPersistenceStore — round-trip save → restore', () => {
   // @UT-SYS-STORE-016@ (FROM: @IMP-SYS-STORE-001@)
   it('restores all station fields correctly after a full save/restore cycle', () => {

--- a/frontend/src/stores/session-persistence.store.ts
+++ b/frontend/src/stores/session-persistence.store.ts
@@ -30,6 +30,7 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
   // ── Private state ─────────────────────────────────────────────────────────
 
   let _debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let _watching = false
 
   // ── Actions ───────────────────────────────────────────────────────────────
 
@@ -138,8 +139,13 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
    * Watch station weights and active category; schedule a debounced save on
    * any change.  Uses a lazy watch so the initial state is not saved before
    * the aircraft profile has been fully loaded.
+   *
+   * Idempotent — calling a second time (e.g. on view remount) is a no-op so
+   * watchers do not stack and trigger duplicate saves on every mutation.
    */
   function startWatching(): void {
+    if (_watching) return
+    _watching = true
     const mbStore = useMassBalanceStore()
 
     // Watch for aircraft switch → clear prior session data.


### PR DESCRIPTION
## Summary

- `sessionPersistence` was shipped in an earlier milestone but never instantiated by the running app — reloading the Flight Preparation page always dropped the pilot's aircraft selection, category, and station weights back to profile defaults, losing every preflight input (REQ-SYS-013).
- New `massBalance.applyRestoredSession(payload)` re-applies a persisted payload onto a freshly-loaded profile, with defensive no-ops for mismatched `aircraftId`, out-of-range indices, and unknown categories.
- `MassBalanceView.onMounted` now reads the payload after fleet hydration, loads the matching fleet profile, calls `applyRestoredSession`, and starts the debounced auto-save watcher. Stale payloads whose aircraft has since been removed are discarded. `startWatching()` is idempotent so view remounts don't stack watchers.

## Why this is a fix, not a feature

The `session-persistence.store.ts`, `SessionPayload` Zod schema, and ~17 unit tests already existed and passed — the bug was the missing call site. REQ-SYS-013 was marked "Implemented" but shipped dormant.

## Changed files

- `frontend/src/modules/mass-balance/stores/mass-balance.store.ts` — new `applyRestoredSession` action + `SessionPayload` type import.
- `frontend/src/modules/mass-balance/views/MassBalanceView.vue` — reload-path restore + `startWatching()` call, extracted `loadProfileIntoStore` helper.
- `frontend/src/stores/session-persistence.store.ts` — `startWatching()` idempotency guard.
- `frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts` — 6 new tests (`UT-MB-STORE-051..056`).
- `frontend/src/stores/__tests__/session-persistence.store.spec.ts` — 1 new test (`UT-SYS-STORE-018`).
- `CHANGELOG.md` — Fixed entry.

## Test plan

- [x] `pnpm --filter frontend type-check` — clean.
- [x] `pnpm --filter frontend run lint:ci:eslint` — clean (no `[P1-ISOLATION]` warnings).
- [x] `pnpm --filter frontend exec vitest run` — 837/837 pass (44 test files).
- [x] `pnpm --filter frontend test:p1` — 332/332 pass (P1 Safety Core still framework-free).
- [x] Manual: start a calculation, reload the page, confirm aircraft selection, category and weights are restored.
- [x] Manual: delete the active aircraft from the fleet in a second tab, reload the first — session should be discarded cleanly, no error.
- [x] Manual: switch to a different aircraft → prior payload cleared (existing behaviour preserved).

## P1 checklist

Not a P1 change — `applyRestoredSession` lives in the M&B Pinia store (P2). The only P1 touchpoint is the existing `SessionPayload` type import from `src/core/domain/session.schema.ts`, which remains a pure Zod schema with no Vue/Pinia/Router imports.

https://claude.ai/code/session_01MLgBDB4Vxcd9Q4mmhhseTS