### PR TITLE
fix: v0.3.0-alpha release-audit blocker remediation

### DIFF
--- a/.claude/agents/fix-cybersecurity.md
+++ b/.claude/agents/fix-cybersecurity.md
@@ -1,0 +1,39 @@
+---
+name: fix-cybersecurity
+description: Write-capable counterpart to audit-cybersecurity. Remediates security findings (CS-###) — input/range validation, file-import guards, CSP/headers, integrity envelopes, dependency hygiene. Trigger via the release-audit remediation workflow or "fix CS-### findings".
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are the AeroDash security remediator — the write-capable counterpart to `audit-cybersecurity`. AeroDash is a safety-critical offline-first PWA. The trust boundary is any persisted or imported data that can reach the M&B math core.
+
+## Mode
+
+- input: a list of CS-### findings (id | file:symbol | fix) from a `.logs/audit.cybersecurity-*.md` report, plus a scope note.
+- output: minimal hardening + tests + a terse report. Defense-in-depth, fail-closed, attacker-aware.
+- read-before-write: every file you touch and its tests.
+
+## Tier boundaries
+
+- Respect P1/P2/P3 (`core/` = P1 pure TS; never add framework deps to P1). Numeric-range/`.finite()` hardening of `src/core/` schemas is **P1** → requires an approved FRR (coordinate with `fix-tech`; do not duplicate edits to the same schema file).
+
+## Remediation rules
+
+- **Input guards:** enforce size + content-type before reading/parsing imported files; bound array/depth; validate semantic ranges, not just structure. Reject early with a typed error surfaced in the UI.
+- **CSP:** prefer a strict `<meta http-equiv="Content-Security-Policy">` in `index.html` (`default-src 'self'`, `object-src 'none'`, `base-uri 'self'`, no inline/eval unless proven necessary); document host-header equivalents (HSTS) in an ADR rather than inventing deploy config.
+- **Integrity envelopes** (HMAC/signature) are heavier — only build when in scope; otherwise validate ranges + fail-closed and demote to `draft` on any verification failure.
+- **Dependency hygiene:** runtime-only packages belong in `dependencies`; tooling/static-servers in `devDependencies`. Run `pnpm audit --audit-level=moderate` and report results; do not bump majors without an ADR.
+- Never weaken an existing guard to make a test pass.
+
+## Tests & gates
+
+- Add `*.spec.ts` / `*.int.spec.ts` covering the rejected/hostile path (oversized file, out-of-range number, unknown enum, tampered payload).
+- Verify: `pnpm --filter frontend type-check`, `pnpm lint:eslint`, relevant `vitest run`, `pnpm audit`.
+
+## Traceability & commits
+
+- Tag new artifacts (`@IMP-/@UT-`) + same-commit `trace/` entry.
+- Conventional Commits: `fix(<scope>): <desc> (refs #<issue>, <CS-ID>)`. No `CHANGELOG.md` edits. No `--no-verify`.
+
+## Report back
+
+Per finding → `id | files | hardening applied | hostile-path test | verification result`. Flag findings deferred to a future milestone (e.g. crypto signing, encryption-at-rest) and why.

--- a/.claude/agents/fix-dp.md
+++ b/.claude/agents/fix-dp.md
@@ -1,0 +1,39 @@
+---
+name: fix-dp
+description: Write-capable counterpart to audit-dp. Remediates data-privacy findings (DP-###) — accurate privacy notices, data-minimization, retention/erasure UX, log redaction, production-build leakage, privacy-by-design for future sync. Trigger via the release-audit remediation workflow or "fix DP-### findings".
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are the AeroDash data-privacy remediator — the write-capable counterpart to `audit-dp`. AeroDash is offline-first with no backend in the current release; persisted data (IndexedDB/localStorage/sessionStorage) is PII-adjacent (registration ↔ owner). Apply GDPR/BDSG + privacy-by-design/default.
+
+## Mode
+
+- input: a list of DP-### findings (id | evidence | fix) from a `.logs/audit.dp-*.md` report, plus a scope note.
+- output: truthful docs + minimal privacy controls + a terse report.
+- read-before-write: every file you touch.
+
+## Cardinal rule: notices must be TRUE
+
+- Privacy docs (`PRIVACY.md`) must match the **shipped** storage surface exactly: list every store (DB/keys), local-only vs synced, encryption state, and how the user can clear data. Never claim a control that is not implemented; describe planned controls only under an explicit "Future Releases" heading.
+
+## Remediation rules
+
+- **Data minimization:** do not persist identifiers/fields with no current purpose; defer sync-only fields until the sync milestone.
+- **Production build:** dev-only tooling (e.g. vue-devtools) must be guarded to dev mode; strip `DEBUG`/`INFO` console output from production via `import.meta.env.PROD`. These ship in the real artifact — treat as concrete leaks.
+- **Logging:** redact via an allow-list; never log raw PII payloads; gate verbose/telemetry behind an env flag.
+- **Rights/retention:** bulk export + single-action erase + age-based purge are real features — build only when in scope; otherwise correct the notice and file the feature.
+- **Future sync (M6/v0.8):** DPIA + data-flow + lawful basis + transit/at-rest crypto + retention/TTL belong in an ADR **before** sync code lands — author the ADR/issue, don't stub sync.
+
+## Tests & gates
+
+- Where you add a control (e.g. erase/redaction), add a `*.spec.ts`/`*.int.spec.ts` proving it.
+- Verify: `pnpm --filter frontend type-check`, `pnpm lint:eslint`, relevant `vitest run`.
+
+## Traceability & commits
+
+- Tag new artifacts + same-commit `trace/` entry where applicable.
+- Conventional Commits: `docs(doc): …` for notices, `fix(<scope>): …` for code, `(refs #<issue>, <DP-ID>)`. No `CHANGELOG.md` edits. No `--no-verify`.
+
+## Report back
+
+Per finding → `id | files | change | test (if code) | verification result`. Explicitly flag privacy features deferred to a milestone and the residual exposure.

--- a/.claude/agents/fix-process.md
+++ b/.claude/agents/fix-process.md
@@ -1,0 +1,34 @@
+---
+name: fix-process
+description: Write-capable counterpart to audit-process. Remediates process/traceability findings (PR-###) — STC tag placement & namespaces, dangling refs, trace registries, CI gates, hazard-log linkage, requirement-status truthfulness. Trigger via the release-audit remediation workflow or "fix PR-### findings".
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are the AeroDash process/traceability remediator — the write-capable counterpart to `audit-process`. The project's safety credibility rests on an intact traceability DAG (`H → REQ → UJ → E2E`, `REQ → IMP → UT|IT`). Source of truth: `docs/stc.md`. Load the `traceability` skill for the full ID schema and invariants before editing tags.
+
+## Mode
+
+- input: a list of PR-### findings (id | evidence | fix) from a `.logs/audit.process-*.md` report, plus a scope note.
+- output: corrected tags/registries/workflows + a terse report. Do not invent IDs, REQs, hazards, or evidence.
+- read-before-write: every tag/registry/workflow you touch + `docs/stc.md`.
+
+## Remediation rules
+
+- **E2E tags live in `.feature` files only** (`# @E2E-<PHASE>-NNN@`), never in `.ts` step defs. PHASE namespace = `A,B,C,D,E,F,G,STRESS` — never module prefixes.
+- **No dangling refs:** every `(FROM: @X@)` upstream must exist. Fix the citation or define the missing artifact in `docs/journeys/` — do not delete a safety-tag chain to make it pass.
+- **Registries:** every traced artifact has a same-commit entry under `trace/{requirements|journeys|design|implementation|unit_test|integration_test|e2e}/`. Generate missing per-module/per-phase registries when in scope.
+- **CI gates:** when asked to harden `traceability.yml`, promote *structural* checks (duplicate-tag, dangling-FROM, registry-drift) to hard-fail; keep coverage-report checks warn-only unless told otherwise. Don't loosen an existing gate.
+- **Truthfulness:** mark unimplemented REQs `Deferred`, not `Approved`; add hazard-log status/mitigated-by columns when in scope. Never tick a DoD/checklist item without evidence.
+
+## Tests & gates
+
+- After tag/registry edits, run the trace tooling / lint and `pnpm --filter frontend type-check` if you touched TS lint rules.
+- For new lint rules (e.g. reject `@E2E-` in `*.ts`), prove they fire on a fixture.
+
+## Commits
+
+- Conventional Commits, scope usually `repo` or the affected module: `chore(repo): … (refs #<issue>, <PR-ID>)` / `test(<scope>): …`. No `CHANGELOG.md` edits. No `--no-verify`.
+
+## Report back
+
+Per finding → `id | files | correction | check result`. Flag anything that needs an ADR or human decision (e.g. defining a new UJ).

--- a/.claude/agents/fix-tech.md
+++ b/.claude/agents/fix-tech.md
@@ -1,0 +1,54 @@
+---
+name: fix-tech
+description: Write-capable counterpart to audit-tech. Remediates technical & safety-core findings (TECH-###) — unit normalization, NaN/Infinity guards, data-integrity, schema migration, performance, tooling. P1-aware: honors src/core/ isolation and the FRR gate. Trigger via the release-audit remediation workflow or "fix TECH-### findings".
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are the AeroDash technical remediator — the write-capable counterpart to `audit-tech`. AeroDash is a safety-critical GA flight-prep PWA; a defect here can cause an incorrect Go/No-Go advisory. Correctness over speed, always.
+
+## Mode
+
+- input: a list of TECH-### findings (id | file:symbol | fix) from a `.logs/audit.tech-*.md` report, plus a scope note.
+- output: minimal, surgical fixes + tests + a terse change report. No drive-by refactors.
+- read-before-write: every file you touch, plus its tests and any `trace/` registry entry that references it.
+
+## Tier boundaries (THE critical constraint)
+
+- `frontend/src/core/` = **P1** (pure TS, zero framework deps). May import only `node:*`, `zod`, other `src/core/`.
+- `frontend/src/modules/` = **P2** (Vue + Pinia).
+- `frontend/src/shared/|stores/|plugins/|router/` = **P3**.
+- Never add `vue`/`pinia`/`vue-router` or any P2/P3 import to P1. Never suppress `[P1-ISOLATION]` with eslint-disable.
+
+## P1 FRR gate
+
+- Any change under `frontend/src/core/` requires an **approved FRR** (Formal Review Request).
+- If your dispatch prompt states the FRR is already approved, proceed.
+- If it does not, **STOP** and emit the FRR fields for approval, do not write P1 code: `REQ | H | output impact | pure-TS guarantee | deterministic guarantee | Zod plan | formula (LaTeX) | unit normalization | test plan | ≥3 edge cases | ADR need`.
+
+## Safety remediation rules
+
+- **Units:** normalize all geometric/mass inputs to SI at the adapter/store boundary (`kg`, `m`, `kg·m`). Never hardcode a unit; derive it from the profile/load-point declared unit and validate against the allowed unit set. (REQ-SYS-003)
+- **Finite guards:** every numeric Zod field that feeds the math core must be `.finite()` with realistic domain bounds; treat non-finite as `INVALID_INPUT`.
+- **Fail-closed:** on `success === false` never propagate a partial/NaN result to UI state; raise the notification path instead.
+- **Unknown enums** (e.g. fuel type): refuse to compute + raise WARNING/ERROR; never silently substitute a fallback.
+
+## Tests & gates
+
+- P1: `*.spec.ts`, **90%** line+branch+function; add canonical hand-computed vectors for math changes (imperial fixture where unit logic changed).
+- P2: `*.int.spec.ts` for store↔core handoffs; 80% min.
+- Bug protocol: write the failing test first → minimal fix → green.
+- Verify: `pnpm --filter frontend type-check`, `pnpm lint:eslint`, relevant `vitest run`, and `pnpm --filter frontend test:p1` when P1 touched.
+
+## Traceability
+
+- New traced artifact → `@IMP-/@UT-/@IT-` tag inline + same-commit `trace/` registry entry (see the `traceability` skill / `docs/stc.md`).
+- Don't change a `REQ` status unless the requirement is now fully implemented + verified.
+
+## Commits
+
+- Conventional Commits, one per coherent fix bundle: `fix(<scope>): <desc> (refs #<issue>, <FINDING-ID>)`.
+- Do not edit `CHANGELOG.md` (reserved for release process). Do not skip hooks.
+
+## Report back
+
+Terse bullets: per finding → `id | files | what changed | tests added | verification result`. Flag anything you deferred or could not safely fix and why.

--- a/.claude/agents/fix-ux.md
+++ b/.claude/agents/fix-ux.md
@@ -1,0 +1,39 @@
+---
+name: fix-ux
+description: Write-capable counterpart to audit-ux. Remediates UX findings (UX-###) for safety-critical cockpit-tablet use — destructive-action recovery, turbulence-tolerant input, feedback/status clarity, colour-independent signalling. Trigger via the release-audit remediation workflow or "fix UX-### findings".
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are the AeroDash UX remediator — the write-capable counterpart to `audit-ux`. Context: single-pilot EASA Part-NCO use on a cockpit tablet, often gloved, in turbulence, sterile-cockpit time pressure. Reduce head-down time and prevent irrecoverable mistakes.
+
+## Mode
+
+- input: a list of UX-### findings (id | file:symbol | fix) from a `.logs/audit.ux-*.md` report, plus a scope note.
+- output: minimal, accessible Vue SFC changes + tests + a terse report. No visual redesigns beyond the finding.
+- read-before-write: every component/view you touch + its existing tests + sibling patterns (e.g. reuse `DecimalInput`, existing modal/toast primitives — don't reinvent).
+
+## Tier boundaries
+
+- UI lives in `frontend/src/modules/**` (P2) and `frontend/src/shared/**` (P3). Vue SFCs only — **no JSX**. Never put math in components; delegate to `core/`.
+
+## Remediation rules
+
+- **Destructive actions** (delete profile, reset payload) must never be a single un-recoverable tap: replace native `confirm()` with an in-app modal (a11y-labelled, dark-mode-safe) carrying explicit "discard N items" copy, and provide a 5–10s **undo** affordance. Disable delete on the active aircraft.
+- **Turbulence input:** offer coarse steps/presets in addition to fine steps; widen cramped numeric fields; use `inputmode="decimal"` text inputs that reject `e`/`+`/`-`; give immediate inline rejection feedback, never silent drops.
+- **Status/feedback:** prefer explicit, field-linked hints over a single italic line; escalate indefinite spinners to a retry state.
+- **Colour-independence:** never rely on colour alone for SAFE/WARNING/CRITICAL — add shape/pattern; check contrast for direct-sun glare. (DES-UX/3.3)
+- **Semantics:** keep "Verified" reserved for profile-data trust; don't reuse it for transient M&B "within limits" state.
+
+## Tests & gates
+
+- Component tests (`*.spec.ts` via `@vue/test-utils`) for new confirm/undo/validation behaviour; E2E (`.feature` + steps via the `e2e` skill) for destructive-recovery flows when in scope. P2 80% min.
+- Verify: `pnpm --filter frontend type-check`, `pnpm lint:eslint`, relevant `vitest run`.
+
+## Traceability & commits
+
+- Tag new artifacts (`@IMP-/@UT-`) + same-commit `trace/` entry; E2E tags go in `.feature` files only.
+- Conventional Commits, scope usually `ui`/`mb`/`ac`: `fix(<scope>): <desc> (refs #<issue>, <UX-ID>)`. No `CHANGELOG.md` edits. No `--no-verify`.
+
+## Report back
+
+Per finding → `id | files | change | test added | verification result`. Flag UX features deferred to a milestone (e.g. full verification provenance) and why.

--- a/.claude/commands/release-audit.md
+++ b/.claude/commands/release-audit.md
@@ -1,0 +1,23 @@
+---
+description: Process a completed release audit end-to-end — triage .logs reports vs milestones, file deferred issues, dispatch the fix-* team on blockers, emit a readiness report
+argument-hint: [date-or-scope, empty = newest .logs audit set]
+allowed-tools: Skill, Agent, Read, Grep, Glob, Bash, Edit, Write
+---
+
+# /release-audit — process the release audit & remediate
+
+Run the **`release-audit`** skill on the audit reports in `.logs/`.
+
+- `$ARGUMENTS`: optional date or scope. Empty → newest `.logs/audit.*-*.md` set.
+
+## Procedure
+
+Invoke the `release-audit` skill and follow it exactly:
+
+1. **Ingest** the five `.logs/audit.<domain>-<date>.md` reports; inventory every finding.
+2. **Triage** each finding (blocker vs defer) against `gh` milestones + `docs/development/roadmap.md`, using the skill's blocker bar. Verify top "active defect" claims in code. Present the split and **wait for user confirmation**.
+3. **File** every deferred finding as a milestone-assigned issue (grouped, `resubmission`-labelled, per `.claude/commands/issue.md`).
+4. **Remediate** blockers with the `fix-{tech,cybersecurity,dp,process,ux}` agents — consolidated **FRR** before any `frontend/src/core/` (P1) change; partition files so concurrent fixers don't collide; then run the gate (`type-check`, `lint`, `test:unit`/`test:p1`, `pnpm audit`).
+5. **Report** release readiness in the short decision format (`readiness-report.md`).
+
+Pairs with `/audit.full`, which produces the reports this command consumes.

--- a/.claude/skills/release-audit/SKILL.md
+++ b/.claude/skills/release-audit/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: release-audit
+description: Use to process a completed release audit end-to-end — when the user says "process the release audit", "the audits are done, triage and fix them", "remediate the .logs audits before release", or invokes /release-audit. Ingests .logs/audit.*-<date>.md reports, triages every finding against GitHub milestones + the roadmap, splits blockers vs deferred, files deferred findings as milestone-assigned issues, dispatches the fix-* remediation team on the blockers, and emits a short release-readiness report. Pairs with /audit.full (which produces the reports).
+---
+
+# Release-audit remediation workflow (AeroDash)
+
+Turn a finished audit bundle into a release decision: triage → defer → fix → readiness. AeroDash is safety-critical — correctness over speed, no finding silently dropped.
+
+- `input`: optional date/scope. Empty → newest `.logs/audit.*-*.md` set.
+- `pairs.with`: `/audit.full` (produces `.logs/audit.<domain>-<date>.md`).
+- `team`: read-only auditors `audit-{tech,cybersecurity,dp,process,ux}` ↔ write-capable fixers `fix-{tech,cybersecurity,dp,process,ux}`.
+
+## Always-fresh refs (read every run)
+
+- the five `.logs/audit.*-<date>.md` reports in scope
+- `docs/development/roadmap.md`, `docs/development/implementation-roadmap.md`
+- GitHub milestones: `gh api "repos/naturelle137/AeroDash/milestones?state=all"`
+- `.claude/commands/issue.md` + `.github/ISSUE_TEMPLATE/*` (issue conventions/labels)
+- `CONTRIBUTING.md`, `CLAUDE.md` (tiers, scopes, gates)
+
+## Step 1 — Ingest & inventory
+
+- Parse every finding from each report: `id | severity | category | title | evidence | impact | fix | priority(now/soon/later)`.
+- Record counts per domain. Do not trust priority blindly — verify the highest-impact "active defect" claims in code before classifying.
+
+## Step 2 — Triage (blocker vs defer)
+
+Determine the release under test (branch / target milestone) and its **shipped** feature set.
+
+Blocker bar — a finding blocks the release only if it hits a **shipped** feature AND is one of:
+1. an active wrong-output / data-loss defect, OR
+2. a materially false public statement (privacy/legal/docs), OR
+3. a cheap, high-value hardening of the actual release artifact.
+
+Defer (even if an auditor wrote "now") when the fix needs **new heavy infra** (crypto signing, encryption-at-rest, HMAC envelopes, sync DPIA, incident-reporting backend, mutation-CI, regulatory/AIRAC workflows) or is tied to an **unbuilt future feature** → map it to the first milestone that delivers that feature.
+
+Bundle related findings across domains (e.g. all fuel-enum findings → one fix). Present the blocker/defer split as a table and **get user confirmation** before any outward action. Flag every case where you override an auditor's priority, with rationale.
+
+## Step 3 — File deferred findings as issues
+
+Per the `/issue` conventions and `.github/ISSUE_TEMPLATE/*`:
+- group related findings into one coherent issue; type `Feature`/`Bug`/`Task`; one `scope.module` + one `scope.domain`; `safety-critical` when it touches `frontend/src/core/` or Go/No-Go; status `open`; **always add `resubmission`** (deferred-from-release).
+- assign the milestone that first delivers the relevant feature (resolve numbers from `gh`).
+- body: problem + the audit finding id(s)/evidence + proposed fix + DoD checklist (N/A rows end ticked `[x]` per repo convention).
+- dedupe against existing issues first.
+
+## Step 4 — Remediate blockers (the fix team)
+
+- **P1 gate:** any blocker touching `frontend/src/core/` needs an approved **FRR** first. Present one consolidated FRR for all P1 work; on approval, proceed.
+- Assign each blocker bundle to its `fix-*` agent. **Partition file ownership so concurrently-dispatched agents touch disjoint files** (e.g. CSP→`index.html`/cyber, vue-devtools→`vite.config.ts`/dp). Dispatch non-overlapping agents in one message to run concurrently; sequence the rest.
+- Each fixer: minimal change + test (failing-first for bugs) + traceability tag/registry + conventional commit (no `CHANGELOG.md`, no `--no-verify`).
+- After all return, run the gate: `pnpm --filter frontend type-check`, `pnpm lint`, `pnpm test:unit`/`test:p1`, `pnpm audit`. Loop fixes until green.
+
+## Step 5 — Release-readiness report
+
+Short and decision-oriented (see `readiness-report.md` for the exact shape). Sections: verdict (go/no-go) · blockers fixed (verified) · deferred risk by milestone · residual risk · recommendation. No filler.
+
+## Guardrails
+
+- Never auto-create issues or write code before the Step 2 confirmation.
+- Never tick a DoD/checklist item without evidence; never weaken a gate or skip a hook to pass.
+- Keep the audit reports immutable; write outputs to issues, code, and the readiness report only.

--- a/.claude/skills/release-audit/readiness-report.md
+++ b/.claude/skills/release-audit/readiness-report.md
@@ -1,0 +1,21 @@
+# Release-readiness report — output shape
+
+A SHORT management artifact for a go/no-go decision. Bullets, no prose blocks, no filler. Fits on one screen. Target audience: release decision-maker, not engineers.
+
+## Required sections (in order)
+
+1. **Header** — `Release readiness | <version> | <date> | audited @ <commit>`
+2. **Verdict** — one line: `GO` / `GO with conditions` / `NO-GO` + the single deciding reason.
+3. **Audit input** — one line: N findings across 5 domains (red/yellow counts).
+4. **Fixed before release (blockers)** — table: `bundle | findings | tier | status (verified ✓ / partial) | evidence (test/commit)`. Only what was actually closed for this release.
+5. **Deferred — accepted risk** — table: `theme | findings | milestone | issue # | why safe to defer now`. Group by milestone.
+6. **Residual risk** — ≤5 bullets: the real exposures shipping in this release after fixes, each with a one-line mitigation or acceptance rationale.
+7. **Recommendation** — 1–2 lines: the ask of the decision-maker (approve release / approve with named conditions / hold), plus any pre-publish checklist (e.g. run `pnpm audit`, host-level headers).
+
+## Rules
+
+- Quantify: counts, milestone numbers, issue numbers, test/commit evidence — no vague "improved".
+- Distinguish **fixed-and-verified** from **fixed-but-unverified**; never imply verification that did not run.
+- Every deferred item must name a milestone + issue so nothing is silently dropped.
+- If the verdict is GO-with-conditions, the conditions must be concrete and checkable.
+- Keep it to roughly one screen; link out (issue numbers) instead of expanding.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,7 +1,7 @@
 # Privacy & Data Protection
 
-- version: 1.0
-- date: 2026-04-02
+- version: 1.1
+- date: 2026-05-24
 - status: active
 
 ---
@@ -12,13 +12,16 @@ AeroDash is an offline-first, client-side single-page application (SPA) for flig
 
 ## 2. Data Collected
 
-| Data Category                 | Source                          | Storage                               | Contains PII?                                                           |
-| ----------------------------- | ------------------------------- | ------------------------------------- | ----------------------------------------------------------------------- |
-| Aircraft profiles (catalogue) | Hardcoded in source code        | In-memory only (no persistence)       | Registration marks are PII-adjacent (can identify real aircraft/owners) |
-| Station weights / M&B inputs  | Entered by the pilot at runtime | In-memory only (lost on page refresh) | No                                                                      |
-| Calculation results           | Computed from inputs            | In-memory only                        | No                                                                      |
+All persisted data is stored **locally on the device, unencrypted**, and is **never transmitted** to any server (there is no backend in this release). Storage locations are listed in §5.
 
-No personal accounts, authentication, cookies, or session data exist.
+| Data Category              | Source                          | Storage                                  | Contains PII?                                                                                  |
+| -------------------------- | ------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Aircraft profiles (fleet)  | Entered/imported by the pilot   | IndexedDB `aerodash-fleet`               | Yes — registration, `ownerId`, weighing reports, `costPerHour` (identify real aircraft/owners) |
+| Saved session (M&B inputs) | Entered by the pilot at runtime | localStorage `aerodash:session:payload`  | No — station weights and interaction flags only                                                |
+| Session-active flag        | Set by the app at startup       | sessionStorage `aerodash.session.active` | No — a single `'1'` marker for PWA cold-start detection                                        |
+| Calculation results        | Computed from inputs            | In-memory only (not persisted)           | No                                                                                             |
+
+No personal accounts, authentication, or cookies exist. Saved-session and fleet data persist across page reloads as described in §5.
 
 ## 3. Data Minimisation (GDPR Art. 5(1)(c))
 
@@ -36,34 +39,67 @@ All data processed by AeroDash is used solely for the purpose of computing Mass 
 
 ## 5. Storage & Retention Policy (GDPR Art. 5(1)(e))
 
-### Current State (v0.2.0-alpha)
+### Current State (v0.3.0-alpha)
 
-- **No persistent storage.** All data is held in-memory (Vue reactive state) and discarded on page unload or refresh.
-- No IndexedDB, localStorage, or cookies are used in the current release.
+This release **does** persist data on the device. All storage is **local to the browser, unencrypted, and never transmitted** — there is no backend, sync, or remote logging in this release. Three storage facilities are used:
 
-### Future Releases (IndexedDB / Offline Persistence)
+1. **IndexedDB — database `aerodash-fleet`** (object store `aircraft_profiles`).
+   Holds the pilot's saved aircraft fleet. Each profile may contain PII or
+   PII-adjacent data: the aircraft `registration` mark, an `ownerId`, one or more
+   weighing reports (basic empty mass, empty CG, weighing dates), and an optional
+   `costPerHour`, alongside the technical M&B/performance parameters. Persists
+   until the pilot deletes the profile or clears browser storage.
+2. **localStorage — key `aerodash:session:payload`.**
+   Holds the auto-saved current session so entered data survives a page refresh:
+   the active aircraft id, the active certification category, and per-station
+   weights with interaction flags. No personal data beyond the aircraft id
+   reference. Overwritten on change, cleared on aircraft switch, and removed if it
+   fails validation.
+3. **sessionStorage — key `aerodash.session.active`.**
+   A single `'1'` marker used only to detect PWA cold starts versus in-session
+   updates. Contains no personal data and is cleared automatically when the last
+   tab for the origin is closed.
 
-When persistent storage is introduced:
+**User control today:** There is **no in-app "Delete All Data" control in this
+release.** A pilot can remove all stored data by clearing the site's browser
+storage (browser settings → site data / "Clear site data" for the AeroDash
+origin), which deletes the `aerodash-fleet` database and both storage keys.
+Individual aircraft profiles can be deleted from within the fleet view.
 
-1. **Retention period:** User-entered M&B reports will be retained for a maximum of **12 months** from creation, unless the user deletes them earlier.
+**Residual exposure:** Because storage is unencrypted and local, anyone with
+access to the device's browser profile can read the saved fleet (including
+registration marks and owner identifiers). This is acceptable for an offline,
+single-user, on-device tool but is documented here for transparency.
+
+### Future Releases (planned — NOT shipped in v0.3.0-alpha)
+
+The following controls are **planned and not yet implemented**:
+
+1. **Retention period:** User-entered M&B/weighing reports will be retained for a maximum of **12 months** from creation, unless the user deletes them earlier.
 2. **Auto-purge:** On application startup, any records older than the retention period will be automatically deleted.
-3. **User-initiated deletion:** A "Delete All Data" function will be provided, clearing all IndexedDB stores in a single action.
+3. **User-initiated deletion:** An in-app "Delete All Data" function will be provided, clearing all IndexedDB stores and storage keys in a single action (until then, use browser storage settings as described above).
 4. **No server sync without consent:** If cloud synchronisation is added (Milestone #7), data will only leave the device after explicit user opt-in and authentication.
 
 ## 6. Data Subject Rights (GDPR Arts. 15–20)
 
-### Current State
+### Current State (v0.3.0-alpha)
 
-Since no personal data is stored or transmitted, data subject rights (access, rectification, erasure, portability) are satisfied by default — there is nothing to access, correct, or delete.
+Personal data is now stored locally on the device (see §5), but it is never
+transmitted and no accounts exist. The data subject is the device's sole user,
+who has full physical control over the data:
+
+- **Right of access (Art. 15):** All stored data is on the user's own device; aircraft profiles are viewable in the fleet view.
+- **Right to rectification (Art. 16):** Aircraft profiles can be edited in the app.
+- **Right to erasure (Art. 17):** Individual profiles can be deleted in the fleet view; **all** stored data can be erased via browser storage settings (no in-app "Delete All Data" control ships in this release).
+- **Right to data portability (Art. 20):** A standard JSON import/export format is **planned, not yet shipped** — see "Future Releases" below.
 
 ### Future Releases
 
-When user accounts and persistent storage are introduced, the following mechanisms will be implemented prior to launch:
+The following mechanisms are **planned and not yet implemented**:
 
 - **Right of access (Art. 15):** Export all stored data in machine-readable format (JSON).
-- **Right to rectification (Art. 16):** Edit any stored aircraft profile or M&B record.
-- **Right to erasure (Art. 17):** Delete individual records or all data.
-- **Right to data portability (Art. 20):** Export data in a standard, interoperable format.
+- **Right to erasure (Art. 17):** An in-app "Delete All Data" action to clear all stores at once.
+- **Right to data portability (Art. 20):** Export/import data in a standard, interoperable format.
 
 ## 7. Third-Party Dependencies
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,44 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    <!--
+      Content-Security-Policy (CS-005 / TECH-018 / DP-012).
+      Defense-in-depth: this PWA is offline-first and same-origin only — it loads
+      no third-party scripts, fonts, or analytics. The policy below is fail-closed:
+      anything not explicitly allowed is denied.
+
+      Directive rationale:
+      - default-src 'self'         baseline: only same-origin resources.
+      - script-src 'self'          no inline/eval scripts; the Vite/PWA bundle and
+                                   the Workbox service worker are emitted as same-origin
+                                   .js files, so no 'unsafe-inline'/'unsafe-eval' needed.
+      - style-src 'self' 'unsafe-inline'
+                                   RELAXED: Vue injects scoped component styles as inline
+                                   <style> blocks at runtime (dev HMR and prod alike).
+                                   Removing 'unsafe-inline' blanks all component styling.
+                                   Scoped to style only — script-src stays strict.
+      - img-src 'self' data: blob: data:/blob: cover favicons and any generated
+                                   image/object URLs without widening to remote origins.
+      - font-src 'self'            fonts are bundled, none remote.
+      - connect-src 'self'         no backend; offline-first. Same-origin XHR/fetch only.
+      - worker-src 'self'          the Workbox service worker is same-origin.
+      - manifest-src 'self'        PWA web app manifest is same-origin.
+      - object-src 'none'          no <object>/<embed>/<applet> plugins.
+      - base-uri 'self'            block <base> tag injection that could re-root URLs.
+      - frame-ancestors 'none'     clickjacking guard — equivalent to X-Frame-Options: DENY.
+      - form-action 'self'         restrict where forms may submit.
+
+      Host-header equivalents (cannot be set from a <meta> tag — configure at the
+      deploy edge / reverse proxy when AeroDash is hosted):
+        Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+        X-Content-Type-Options: nosniff
+        Referrer-Policy: no-referrer
+        Cross-Origin-Opener-Policy: same-origin
+      (frame-ancestors above already supersedes the legacy X-Frame-Options header.)
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#00796b" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#1e1e1e" media="(prefers-color-scheme: dark)">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,6 @@
   "homepage": "https://github.com/naturelle137/AeroDash#readme",
   "dependencies": {
     "pinia": "^3.0.4",
-    "serve": "^14.2.6",
     "uuid": "^14.0.0",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6",
@@ -77,6 +76,7 @@
     "oxlint": "~1.62.0",
     "playwright-bdd": "^8.5.0",
     "prettier": "3.8.3",
+    "serve": "^14.2.6",
     "typescript": "~6.0.3",
     "vite": "^8.0.10",
     "vite-plugin-pwa": "^1.2.0",

--- a/frontend/src/core/adapters/aircraft.schema.spec.ts
+++ b/frontend/src/core/adapters/aircraft.schema.spec.ts
@@ -999,3 +999,87 @@ describe('AircraftProfileSchema — powertrain discriminator', () => {
     expect(result.success).toBe(false)
   })
 })
+
+// ─── Finite + numeric domain ranges (TECH-003 / CS-002) ──────────────────────
+
+describe('AircraftProfileSchema — finite + numeric range guards', () => {
+  // @UT-AD-CORE-061@ (FROM: @IMP-AD-CORE-022@)
+  it('rejects Infinity for bem (Zod number() would otherwise accept it)', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        const reports = p.weighingReports as Record<string, unknown>[]
+        reports[0]!.bem = Infinity
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AD-CORE-062@ (FROM: @IMP-AD-CORE-022@)
+  it('rejects -Infinity for a load point arm', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        const lps = p.loadPoints as Record<string, unknown>[]
+        lps[0]!.arm = -Infinity
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AD-CORE-063@ (FROM: @IMP-AD-CORE-022@)
+  it('rejects NaN for mtom', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        const cats = p.certificationCategories as Record<string, unknown>[]
+        cats[0]!.mtom = NaN
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AD-CORE-064@ (FROM: @IMP-AD-CORE-022@)
+  it('rejects an absurd mtom magnitude (1e308) as out of physical range', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        const cats = p.certificationCategories as Record<string, unknown>[]
+        cats[0]!.mtom = 1e308
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AD-CORE-065@ (FROM: @IMP-AD-CORE-022@)
+  it('rejects an absurd bem magnitude (1e30)', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        const reports = p.weighingReports as Record<string, unknown>[]
+        reports[0]!.bem = 1e30
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AD-CORE-066@ (FROM: @IMP-AD-CORE-022@)
+  it('rejects Infinity for batteryPack.usableEnergyKwh', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        p.powertrain = 'electric'
+        p.batteryPack = { usableEnergyKwh: Infinity, reserveFloorKwh: 4 }
+        // electric forbids fuel tanks; the minimal fixture has none.
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AD-CORE-067@ (FROM: @IMP-AD-CORE-022@)
+  it('still accepts a near-edge finite mtom (199_999 kg) just under the ceiling', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        const cats = p.certificationCategories as Record<string, unknown>[]
+        cats[0]!.mtom = 199_999
+        // keep envelope mass below mtom so no cross-field surprise; not enforced
+        // here but realistic.
+      }),
+    )
+    expect(result.success).toBe(true)
+  })
+})

--- a/frontend/src/core/adapters/aircraft.schema.ts
+++ b/frontend/src/core/adapters/aircraft.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { CANONICAL_FUEL_TYPES } from '../logic/fuel-density'
 
 /**
  * Canonical Zod schemas for the AircraftProfile aggregate-root document.
@@ -19,9 +20,33 @@ import { z } from 'zod'
  * @see docs/architecture/adr/006-indexeddb-fleet-persistence.md
  */
 
+// @IMP-AD-CORE-022@ (FROM: @REQ-AD-002@, @REQ-AD-014@, @REQ-SYS-003@)
+// All numeric profile fields are `.finite()`: Zod's `z.number()` (incl.
+// `.positive()`/`.nonnegative()`) accepts ±Infinity, which would propagate to
+// the M&B math core as Infinity → CG = NaN with `success: true` (TECH-003 /
+// CS-002). Profile documents are stored at rest in their SOURCE unit
+// (REQ-AD-014: mass kg|lb, arm m|in|ft, moment kg·m|in-lb), so the bounds here
+// are intentionally generous — wide enough for the largest supported unit
+// (lb ≈ 2.2× kg, in ≈ 39× m) while still rejecting absurd magnitudes
+// (1e30 / 1e308) that can only be tampering or corruption.
+const MAX_MASS_SRC = 500_000 // 200 t in kg ≈ 440k lb → 500k covers both
+const MAX_LEN_SRC = 5_000 // 100 m ≈ 3937 in ≈ 328 ft → 5000 covers all arm units
+const MAX_MOMENT_SRC = 1_000_000_000 // generous: covers lb·in moment magnitudes
+const MAX_ENERGY_KWH = 2_000 // largest credible GA battery pack
+const MAX_VOLTAGE_V = 2_000
+
+/** Finite number (rejects NaN and ±Infinity). */
+const finiteNum = () => z.number().finite()
+/** Finite mass (source unit), bounded but unsigned-constraint left to caller. */
+const finiteMass = () => finiteNum().max(MAX_MASS_SRC)
+/** Finite length/arm (source unit), may be negative (datum behind station). */
+const finiteLen = () => finiteNum().min(-MAX_LEN_SRC).max(MAX_LEN_SRC)
+/** Finite moment (source unit), may be negative. */
+const finiteMoment = () => finiteNum().min(-MAX_MOMENT_SRC).max(MAX_MOMENT_SRC)
+
 const ArmLookupEntrySchema = z.object({
-  massOrVolume: z.number(),
-  moment: z.number(),
+  massOrVolume: finiteMass().nonnegative(),
+  moment: finiteMoment(),
 })
 
 const BurnSequenceEntrySchema = z.object({
@@ -30,10 +55,8 @@ const BurnSequenceEntrySchema = z.object({
 })
 
 const FuelTankExtensionSchema = z.object({
-  unusableFuel: z.number().nonnegative(),
-  permissibleFuelTypes: z
-    .array(z.enum(['MoGas', 'AvGas 100LL', 'Jet A-1', 'AvGas UL91', 'Diesel']))
-    .min(1),
+  unusableFuel: finiteMass().nonnegative(),
+  permissibleFuelTypes: z.array(z.enum(CANONICAL_FUEL_TYPES)).min(1),
   burnSequences: z.array(BurnSequenceEntrySchema),
 })
 
@@ -45,14 +68,14 @@ const FuelTankExtensionSchema = z.object({
 // rather than as a load station quantity.
 const BatteryPackSchema = z.object({
   /** Nameplate usable energy at 100% SoC, in kWh. */
-  usableEnergyKwh: z.number().positive(),
+  usableEnergyKwh: finiteNum().positive().max(MAX_ENERGY_KWH),
   /**
    * Reserve floor below which operation is prohibited by POH/AFM (kWh).
    * Must be < usableEnergyKwh so there is always a usable working band.
    */
-  reserveFloorKwh: z.number().nonnegative(),
+  reserveFloorKwh: finiteNum().nonnegative().max(MAX_ENERGY_KWH),
   /** Optional nominal voltage (V) — used for future derating lookups. */
-  nominalVoltage: z.number().positive().optional(),
+  nominalVoltage: finiteNum().positive().max(MAX_VOLTAGE_V).optional(),
   /**
    * Optional cell chemistry free-text label (e.g. "LiFePO4", "NMC").
    * Not enumerated — regulatory labelling is still evolving for aviation
@@ -63,32 +86,34 @@ const BatteryPackSchema = z.object({
 
 const LoadPointSchema = z.object({
   name: z.string().min(1),
-  arm: z.number().nullable(),
+  arm: finiteLen().nullable(),
   armLookup: z.array(ArmLookupEntrySchema).default([]),
-  operationalLimit: z.number().nonnegative().nullable(),
-  defaultQuantity: z.number().nonnegative(),
+  operationalLimit: finiteMass().nonnegative().nullable(),
+  defaultQuantity: finiteMass().nonnegative(),
   unit: z.string().min(1),
   allowableCategories: z.array(z.enum(['Normal', 'Utility', 'Aerobatic'])).nullable(),
   fuelTank: FuelTankExtensionSchema.nullable(),
 })
 
 const EnvelopePointSchema = z.object({
-  armOrMoment: z.number(),
-  mass: z.number(),
+  // armOrMoment is an arm (length) in arm-graph mode or a moment in
+  // moment-graph mode; the moment bound is the wider of the two.
+  armOrMoment: finiteMoment(),
+  mass: finiteMass().nonnegative(),
 })
 
 const CertificationCategorySchema = z.object({
   category: z.enum(['Normal', 'Utility', 'Aerobatic']),
-  mtom: z.number().positive(),
-  maxZeroFuelMass: z.number().positive().nullable(),
+  mtom: finiteMass().positive(),
+  maxZeroFuelMass: finiteMass().positive().nullable(),
   graphType: z.enum(['arm', 'moment']),
   envelope: z.array(EnvelopePointSchema).min(4).max(20),
 })
 
 // @IMP-AD-CORE-005@ (FROM: @REQ-AD-004@)
 const WeighingReportSchema = z.object({
-  bem: z.number().positive(),
-  emptyCg: z.number(),
+  bem: finiteMass().positive(),
+  emptyCg: finiteLen(),
   weighingDate: z.string().min(1),
   // @IMP-AD-CORE-013@ (FROM: @REQ-AD-013@)
   validFrom: z.string().min(1),
@@ -97,27 +122,27 @@ const WeighingReportSchema = z.object({
 // @IMP-AD-CORE-009@ (FROM: @REQ-AD-017@)
 const WindLimitSchema = z.object({
   component: z.enum(['MaxCrosswind', 'MaxTailwind', 'MaxTotalWind', 'MaxGust']),
-  value: z.number().nonnegative(),
+  value: finiteNum().nonnegative(),
   classification: z.enum(['Demonstrated', 'Limit']),
 })
 
 // @IMP-AD-CORE-010@ (FROM: @REQ-AD-015@)
 const SurfaceConditionSchema = z.object({
   name: z.string().min(1),
-  takeoffFactor: z.number().positive(),
-  landingFactor: z.number().positive(),
+  takeoffFactor: finiteNum().positive(),
+  landingFactor: finiteNum().positive(),
 })
 
 // @IMP-AD-CORE-011@ (FROM: @REQ-AD-016@)
 const SafetyFactorsSchema = z.object({
-  takeoff: z.number().positive(),
-  landing: z.number().positive(),
+  takeoff: finiteNum().positive(),
+  landing: finiteNum().positive(),
 })
 
 // @IMP-AC-CORE-001@ (FROM: @REQ-AC-005@, @REQ-AC-006@)
 const PassengerProfileSchema = z.object({
   name: z.string().min(1),
-  standardWeight: z.number().positive(),
+  standardWeight: finiteMass().positive(),
   unit: z.enum(['kg', 'lbs']),
 })
 
@@ -129,10 +154,10 @@ const ChecklistScaffoldItemSchema = z.object({
 
 // @IMP-AD-CORE-015@ (FROM: @REQ-AD-009@, @DES-ARCH-002@)
 const PerformanceDataPointSchema = z.object({
-  distance: z.number().nonnegative(),
-  mass: z.number().positive(),
-  pressureAltitude: z.number(),
-  temperature: z.number(),
+  distance: finiteNum().nonnegative(),
+  mass: finiteMass().positive(),
+  pressureAltitude: finiteNum(),
+  temperature: finiteNum(),
 })
 
 // @IMP-AD-CORE-014@ (FROM: @REQ-AD-008@, @REQ-AD-009@, @DES-ARCH-002@)
@@ -172,7 +197,7 @@ export const AircraftProfileSchema = z
       ])
       .default('draft'),
     // M3: Schema version for structured migration safety (refs #154)
-    schemaVersion: z.number().int().positive().default(1),
+    schemaVersion: z.number().int().positive().finite().default(1),
     // M3: Passenger profiles with standard weights (REQ-AC-006)
     passengerProfiles: z.array(PassengerProfileSchema).default([]),
     weighingReports: z.array(WeighingReportSchema).min(1),
@@ -182,7 +207,7 @@ export const AircraftProfileSchema = z
     surfaceConditions: z.array(SurfaceConditionSchema).optional(),
     safetyFactors: SafetyFactorsSchema.optional(),
     // M3: Supplementary fields (REQ-AD-006, REQ-AD-007)
-    costPerHour: z.number().nonnegative().optional(),
+    costPerHour: finiteNum().nonnegative().optional(),
     // @IMP-AD-CORE-016@ (FROM: @REQ-AD-006@)
     fuelCostIncluded: z.boolean().optional(),
     checklistScaffold: z.array(ChecklistScaffoldItemSchema).optional(),

--- a/frontend/src/core/adapters/mass-balance.adapter.spec.ts
+++ b/frontend/src/core/adapters/mass-balance.adapter.spec.ts
@@ -439,4 +439,85 @@ describe('M&B Zod Adapter', () => {
 
     expect(() => calculateMassBalance(input)).toThrow('Fatal Core Failure')
   })
+
+  // ─── .finite() + domain ranges (TECH-003 / CS-002) ──────────────────────────
+
+  // @UT-MB-CORE-098@ (FROM: @IMP-MB-CORE-016@)
+  it('rejects Infinity for basicEmptyMass as INVALID_INPUT (does not produce success:true with NaN CG)', () => {
+    const input = createMathCoreInput()
+    ;(input as unknown as Record<string, unknown>).basicEmptyMass = Infinity
+
+    const result = calculateMassBalance(input)
+
+    expect(result.success).toBe(false)
+    expect(result.violations.some((v) => v.type === 'INVALID_INPUT' && v.field === 'BEM')).toBe(true)
+    expect(Number.isNaN(result.takeoffCenterOfGravityPoint.arm)).toBe(true)
+  })
+
+  // @UT-MB-CORE-099@ (FROM: @IMP-MB-CORE-016@)
+  it('rejects -Infinity for a station arm', () => {
+    const input = createMathCoreInput()
+    input.stations[0]!.arm = -Infinity
+
+    const result = calculateMassBalance(input)
+
+    expect(result.success).toBe(false)
+    expect(
+      result.violations.some((v) => v.type === 'INVALID_INPUT' && v.field === 'STATIONS[0].ARM'),
+    ).toBe(true)
+  })
+
+  // @UT-MB-CORE-100@ (FROM: @IMP-MB-CORE-016@)
+  it('rejects NaN for emptyCenterOfGravity', () => {
+    const input = createMathCoreInput()
+    ;(input as unknown as Record<string, unknown>).emptyCenterOfGravity = NaN
+
+    const result = calculateMassBalance(input)
+
+    expect(result.success).toBe(false)
+    expect(
+      result.violations.some((v) => v.type === 'INVALID_INPUT' && v.field === 'EMPTY_CG'),
+    ).toBe(true)
+  })
+
+  // @UT-MB-CORE-101@ (FROM: @IMP-MB-CORE-016@)
+  it('rejects an absurd finite mass magnitude (1e30) as OUT_OF_RANGE', () => {
+    const input = createMathCoreInput()
+    input.stations[0]!.mass = 1e30
+
+    const result = calculateMassBalance(input)
+
+    expect(result.success).toBe(false)
+    expect(
+      result.violations.some(
+        (v) =>
+          v.type === 'INVALID_INPUT' && v.field === 'STATIONS[0].MASS' && v.code === 'OUT_OF_RANGE',
+      ),
+    ).toBe(true)
+  })
+
+  // @UT-MB-CORE-102@ (FROM: @IMP-MB-CORE-016@)
+  it('rejects an absurd finite maxTakeoffMass (1e308)', () => {
+    const input = createMathCoreInput()
+    input.maxTakeoffMass = 1e308
+
+    const result = calculateMassBalance(input)
+
+    expect(result.success).toBe(false)
+    expect(result.violations.some((v) => v.field === 'MTOM' && v.code === 'OUT_OF_RANGE')).toBe(true)
+  })
+
+  // @UT-MB-CORE-103@ (FROM: @IMP-MB-CORE-016@)
+  it('still accepts a near-edge finite value just under the ceiling (no false rejection)', () => {
+    const input = createMathCoreInput()
+    // 199_999 kg is just below the 200_000 kg ceiling — a heavy but finite,
+    // in-range value must still compute.
+    input.basicEmptyMass = 199_999
+    input.maxTakeoffMass = 200_000
+
+    const result = calculateMassBalance(input)
+
+    expect(result.success).toBe(true)
+    expect(Number.isFinite(result.takeoffCenterOfGravityPoint.arm)).toBe(true)
+  })
 })

--- a/frontend/src/core/adapters/mass-balance.adapter.ts
+++ b/frontend/src/core/adapters/mass-balance.adapter.ts
@@ -2,15 +2,47 @@ import { z } from 'zod'
 import type { MathCoreInput, MathCoreResult } from '../domain/mass-balance.math-types'
 import { computeMassBalanceCore } from '../logic/mass-balance.logic'
 import { mapZodErrorToViolations } from './mb.zod-violation-mapping'
-const createNumReq = () => z.number()
-const createNumGt0Req = () => createNumReq().gt(0, { message: 'NEGATIVE_VALUE' })
-const createNumMin0Req = () => createNumReq().min(0, { message: 'NEGATIVE_VALUE' })
-const createIndexReq = () => createNumMin0Req().max(19, { message: 'OUT_OF_RANGE' })
+// @IMP-MB-CORE-016@ (FROM: @REQ-MB-002@, @REQ-SYS-003@, @REQ-SYS-012@)
+// Every numeric field feeding the math core is `.finite()`: Zod's
+// `z.number()` (and `.positive()`/`.nonnegative()`) accept ±Infinity, which
+// would propagate to `zeroFuelMoment = Infinity` → CG = NaN with
+// `success: true` (TECH-003 / CS-002). `.finite()` rejects ±Infinity as
+// NOT_A_NUMBER, and explicit SI domain bounds reject absurd magnitudes
+// (1e30 / 1e308) as OUT_OF_RANGE before they can corrupt a Go/No-Go advisory.
+//
+// All values reaching this adapter are already normalized to SI (kg, m, kg·m)
+// at the store boundary, so bounds below are in SI units.
+//
+// Generous-but-physical SI ceilings:
+//   mass        ≤ 200_000 kg  (well above any Part-NCO SEP; covers misuse)
+//   arm         ∈ [-100, 100] m
+//   moment      ∈ [-20_000_000, 20_000_000] kg·m
+const MAX_MASS_KG = 200_000
+const MAX_ARM_M = 100
+const MAX_MOMENT_KGM = 20_000_000
+
+const createNumReq = () => z.number().finite({ message: 'NOT_A_NUMBER' })
+const createNumGt0Req = () =>
+  createNumReq().gt(0, { message: 'NEGATIVE_VALUE' }).max(MAX_MASS_KG, { message: 'OUT_OF_RANGE' })
+const createNumMin0Req = () =>
+  createNumReq().min(0, { message: 'NEGATIVE_VALUE' }).max(MAX_MASS_KG, { message: 'OUT_OF_RANGE' })
+const createIndexReq = () =>
+  createNumReq().min(0, { message: 'NEGATIVE_VALUE' }).max(19, { message: 'OUT_OF_RANGE' })
+/** Arm (length, m) — finite, bounded, may be negative (datum behind station). */
+const createArmReq = () =>
+  createNumReq()
+    .min(-MAX_ARM_M, { message: 'OUT_OF_RANGE' })
+    .max(MAX_ARM_M, { message: 'OUT_OF_RANGE' })
+/** Moment (kg·m) — finite, bounded, may be negative. */
+const createMomentReq = () =>
+  createNumReq()
+    .min(-MAX_MOMENT_KGM, { message: 'OUT_OF_RANGE' })
+    .max(MAX_MOMENT_KGM, { message: 'OUT_OF_RANGE' })
 
 const ArmLookupEntrySchema = z.object({
   massOrVolume: createNumMin0Req(),
-  arm: createNumReq().optional(),
-  moment: createNumReq(),
+  arm: createArmReq().optional(),
+  moment: createMomentReq(),
 })
 
 const BurnSequenceEntrySchema = z.object({
@@ -19,8 +51,10 @@ const BurnSequenceEntrySchema = z.object({
 })
 
 const EnvelopePointSchema = z.object({
-  mass: createNumReq(),
-  armOrMoment: createNumReq(),
+  mass: createNumMin0Req(),
+  // armOrMoment is an arm (m) in arm-graph mode or a moment (kg·m) in
+  // moment-graph mode; the moment bound is the wider of the two, so use it.
+  armOrMoment: createMomentReq(),
 })
 
 // @IMP-AD-CORE-002@ (FROM: @REQ-AD-002@, @REQ-AD-003@, @REQ-AD-005@, @REQ-AD-012@, @DES-ARCH-002@)
@@ -31,13 +65,13 @@ export const MathCoreInputSchema = z
         z.object({
           index: createIndexReq(),
           mass: createNumMin0Req(),
-          arm: createNumReq().nullable(),
+          arm: createArmReq().nullable(),
           armLookup: z.array(ArmLookupEntrySchema).optional().default([]),
         }),
       )
       .max(20, { message: 'TOO_MANY_ITEMS' }),
     basicEmptyMass: createNumGt0Req(),
-    emptyCenterOfGravity: createNumReq(),
+    emptyCenterOfGravity: createArmReq(),
     maxTakeoffMass: createNumGt0Req(),
     maxZeroFuelMass: createNumGt0Req().nullable(),
     envelope: z.array(EnvelopePointSchema),
@@ -52,7 +86,7 @@ export const MathCoreInputSchema = z
         z.object({
           index: createIndexReq(),
           mass: createNumMin0Req(),
-          arm: createNumReq().nullable(),
+          arm: createArmReq().nullable(),
           armLookup: z.array(ArmLookupEntrySchema).optional().default([]),
           unusableFuel: createNumMin0Req(),
           burnSequences: z.array(BurnSequenceEntrySchema).optional().default([]),

--- a/frontend/src/core/logic/fuel-density.spec.ts
+++ b/frontend/src/core/logic/fuel-density.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { getFuelDensityKgPerL, fuelVolumeToMassKg, FUEL_DENSITY_KG_PER_L } from './fuel-density'
+import {
+  getFuelDensityKgPerL,
+  fuelVolumeToMassKg,
+  FUEL_DENSITY_KG_PER_L,
+  CANONICAL_FUEL_TYPES,
+  isKnownFuelType,
+  isCanonicalFuelType,
+} from './fuel-density'
 
 describe('FUEL_DENSITY_KG_PER_L', () => {
   // @UT-FE-CORE-001@ (FROM: @IMP-FE-CORE-001@)
@@ -75,5 +82,55 @@ describe('fuelVolumeToMassKg', () => {
   // @UT-FE-CORE-014@ (FROM: @IMP-FE-CORE-001@)
   it('returns 0 for zero volume', () => {
     expect(fuelVolumeToMassKg(0, 0.72)).toBe(0)
+  })
+})
+
+// ─── Canonical fuel-type convergence + fail-closed (BUNDLE 4) ─────────────────
+
+describe('CANONICAL_FUEL_TYPES', () => {
+  // @UT-FE-CORE-015@ (FROM: @IMP-FE-CORE-002@)
+  it('matches the AircraftProfile schema enum set', () => {
+    expect([...CANONICAL_FUEL_TYPES]).toEqual([
+      'MoGas',
+      'AvGas 100LL',
+      'Jet A-1',
+      'AvGas UL91',
+      'Diesel',
+    ])
+  })
+
+  // @UT-FE-CORE-016@ (FROM: @IMP-FE-CORE-002@)
+  it('every canonical type resolves to an explicit (non-fallback) density', () => {
+    for (const t of CANONICAL_FUEL_TYPES) {
+      expect(FUEL_DENSITY_KG_PER_L[t]).toBeDefined()
+      expect(isKnownFuelType(t)).toBe(true)
+      expect(isCanonicalFuelType(t)).toBe(true)
+    }
+  })
+})
+
+describe('isKnownFuelType', () => {
+  // @UT-FE-CORE-017@ (FROM: @IMP-FE-CORE-002@)
+  it('returns true for canonical types and recognised legacy aliases (non-fallback density)', () => {
+    expect(isKnownFuelType('Jet A-1')).toBe(true)
+    expect(isKnownFuelType('AVGAS')).toBe(true) // legacy alias → correct density
+    expect(isKnownFuelType('MOGAS')).toBe(true)
+  })
+
+  // @UT-FE-CORE-018@ (FROM: @IMP-FE-CORE-002@)
+  it('returns false for a genuinely unknown type that would hit the fallback', () => {
+    expect(isKnownFuelType('Kerosene')).toBe(false)
+    expect(isKnownFuelType('')).toBe(false)
+    expect(isKnownFuelType('avgas')).toBe(false) // wrong casing → fallback risk
+  })
+})
+
+describe('isCanonicalFuelType', () => {
+  // @UT-FE-CORE-019@ (FROM: @IMP-FE-CORE-002@)
+  it('accepts only the canonical enum (rejects legacy aliases)', () => {
+    expect(isCanonicalFuelType('AvGas 100LL')).toBe(true)
+    expect(isCanonicalFuelType('AVGAS')).toBe(false)
+    expect(isCanonicalFuelType('MOGAS')).toBe(false)
+    expect(isCanonicalFuelType('Kerosene')).toBe(false)
   })
 })

--- a/frontend/src/core/logic/fuel-density.ts
+++ b/frontend/src/core/logic/fuel-density.ts
@@ -8,11 +8,33 @@
 // @IMP-FE-CORE-001@ (FROM: @REQ-FE-001@)
 
 /**
+ * Canonical fuel-type strings — the single source of truth shared by the
+ * AircraftProfile schema enum, the AircraftContext schema enum, and the
+ * fuel-density lookup. Any value outside this set is treated as UNKNOWN and
+ * must be surfaced (fail-closed) rather than silently substituted.
+ */
+// @IMP-FE-CORE-002@ (FROM: @REQ-FE-001@, @REQ-SYS-003@, H-002)
+export const CANONICAL_FUEL_TYPES = [
+  'MoGas',
+  'AvGas 100LL',
+  'Jet A-1',
+  'AvGas UL91',
+  'Diesel',
+] as const
+
+export type CanonicalFuelType = (typeof CANONICAL_FUEL_TYPES)[number]
+
+/**
  * Fuel density in kg/L, keyed by the canonical fuel-type strings used in
  * AircraftContext.loadPoints[].fuelTank.permissibleFuelTypes.
  *
- * AvGas (100LL, UL91, MOGAS) = 0.72 kg/L
+ * AvGas (100LL, UL91, MoGas) = 0.72 kg/L
  * Jet A-1 / Diesel = 0.84 kg/L
+ *
+ * Legacy uppercase aliases (`AVGAS`, `MOGAS`) are retained ONLY so historical
+ * fixtures / ad-hoc callers still resolve a correct density; they are NOT
+ * canonical and `isKnownFuelType` deliberately rejects them so the catalogue
+ * and schemas converge on the canonical keys.
  */
 export const FUEL_DENSITY_KG_PER_L: Readonly<Record<string, number>> = {
   // Canonical keys matching the AircraftProfile schema enum (`MoGas`, `AvGas 100LL`, …)
@@ -30,8 +52,32 @@ export const FUEL_DENSITY_KG_PER_L: Readonly<Record<string, number>> = {
 const FALLBACK_DENSITY_KG_PER_L = 0.84
 
 /**
+ * Return true when `fuelType` resolves to an EXPLICIT density (canonical key or
+ * a recognised legacy alias) — i.e. NOT the silent conservative fallback.
+ *
+ * The adapter boundary uses this to fail-closed: a type that is NOT known would
+ * otherwise hit the 0.84 fallback in getFuelDensityKgPerL and miscompute mass
+ * with no signal (CS-008 / TECH-013). Legacy uppercase aliases (`AVGAS`,
+ * `MOGAS`) still resolve a CORRECT density so they are treated as known here;
+ * convergence onto canonical keys is enforced separately at the schema layer
+ * (CS-009 / CS-010) where the catalogue and contexts are tightened to the enum.
+ */
+export function isKnownFuelType(fuelType: string): boolean {
+  return Object.prototype.hasOwnProperty.call(FUEL_DENSITY_KG_PER_L, fuelType)
+}
+
+/** Narrow check against the canonical enum only (excludes legacy aliases). */
+export function isCanonicalFuelType(fuelType: string): fuelType is CanonicalFuelType {
+  return (CANONICAL_FUEL_TYPES as readonly string[]).includes(fuelType)
+}
+
+/**
  * Return the density in kg/L for the given fuel type string.
  * Uses the conservative fallback for unrecognized types.
+ *
+ * IMPORTANT: an unrecognized type returning the fallback is a SILENT
+ * substitution at the math layer. Callers that can surface a notification MUST
+ * gate on `isKnownFuelType` first and fail-closed (H-002 — fuel confusion).
  */
 export function getFuelDensityKgPerL(fuelType: string): number {
   return FUEL_DENSITY_KG_PER_L[fuelType] ?? FALLBACK_DENSITY_KG_PER_L

--- a/frontend/src/core/logic/unit-normalization.spec.ts
+++ b/frontend/src/core/logic/unit-normalization.spec.ts
@@ -6,6 +6,8 @@ import {
   armMToUnit,
   normalizeVolumeToL,
   volumeLToUnit,
+  normalizeMomentToSI,
+  parseSourceUnit,
 } from './unit-normalization'
 
 describe('normalizeMassToKg', () => {
@@ -106,5 +108,64 @@ describe('volumeLToUnit', () => {
   // @UT-SYS-CORE-016@ (FROM: @IMP-SYS-CORE-006@)
   it('converts litres to US gallons correctly (3.785411784 L = 1 gal)', () => {
     expect(volumeLToUnit(3.785411784, 'gal')).toBeCloseTo(1, 5)
+  })
+})
+
+describe('normalizeMomentToSI', () => {
+  // @UT-SYS-CORE-031@ (FROM: @IMP-SYS-CORE-010@)
+  it('returns the value unchanged for m (kg·m) input', () => {
+    expect(normalizeMomentToSI(123.4, 'm')).toBe(123.4)
+  })
+
+  // @UT-SYS-CORE-032@ (FROM: @IMP-SYS-CORE-010@)
+  it('scales a kg·in moment to kg·m by the inch factor (1 kg·in = 0.0254 kg·m)', () => {
+    expect(normalizeMomentToSI(1, 'in')).toBeCloseTo(0.0254, 10)
+  })
+
+  // @UT-SYS-CORE-033@ (FROM: @IMP-SYS-CORE-010@)
+  it('scales a kg·ft moment to kg·m by the foot factor (1 kg·ft = 0.3048 kg·m)', () => {
+    expect(normalizeMomentToSI(1, 'ft')).toBeCloseTo(0.3048, 10)
+  })
+
+  // @UT-SYS-CORE-034@ (FROM: @IMP-SYS-CORE-010@)
+  it('is consistent with mass×arm: 100 kg × 40 in == moment 4000 kg·in normalized', () => {
+    const armM = normalizeArmToM(40, 'in')
+    const momentSI = normalizeMomentToSI(100 * 40, 'in')
+    expect(momentSI).toBeCloseTo(100 * armM, 10)
+  })
+})
+
+describe('parseSourceUnit', () => {
+  // @UT-SYS-CORE-035@ (FROM: @IMP-SYS-CORE-011@)
+  it('parses mass-only "kg" to { kg, m } (preserves legacy metric behaviour)', () => {
+    expect(parseSourceUnit('kg')).toEqual({ massUnit: 'kg', armUnit: 'm' })
+  })
+
+  // @UT-SYS-CORE-036@ (FROM: @IMP-SYS-CORE-011@)
+  it('parses mass-only "lb" to { lb, m }', () => {
+    expect(parseSourceUnit('lb')).toEqual({ massUnit: 'lb', armUnit: 'm' })
+  })
+
+  // @UT-SYS-CORE-037@ (FROM: @IMP-SYS-CORE-011@)
+  it('parses combined "lb-in" to { lb, in }', () => {
+    expect(parseSourceUnit('lb-in')).toEqual({ massUnit: 'lb', armUnit: 'in' })
+  })
+
+  // @UT-SYS-CORE-038@ (FROM: @IMP-SYS-CORE-011@)
+  it('parses combined "kg-m" and "lb-ft"', () => {
+    expect(parseSourceUnit('kg-m')).toEqual({ massUnit: 'kg', armUnit: 'm' })
+    expect(parseSourceUnit('lb-ft')).toEqual({ massUnit: 'lb', armUnit: 'ft' })
+  })
+
+  // @UT-SYS-CORE-039@ (FROM: @IMP-SYS-CORE-011@)
+  it('is case-insensitive and trims whitespace', () => {
+    expect(parseSourceUnit('  LB-IN  ')).toEqual({ massUnit: 'lb', armUnit: 'in' })
+  })
+
+  // @UT-SYS-CORE-040@ (FROM: @IMP-SYS-CORE-011@)
+  it('falls back to SI defaults for unknown components (never silently mis-scales)', () => {
+    expect(parseSourceUnit('stone-cubits')).toEqual({ massUnit: 'kg', armUnit: 'm' })
+    expect(parseSourceUnit('')).toEqual({ massUnit: 'kg', armUnit: 'm' })
+    expect(parseSourceUnit('lb-furlong')).toEqual({ massUnit: 'lb', armUnit: 'm' })
   })
 })

--- a/frontend/src/core/logic/unit-normalization.ts
+++ b/frontend/src/core/logic/unit-normalization.ts
@@ -8,9 +8,45 @@
  *
  * @see REQ-SYS-003
  */
+import { MASS_UNITS, ARM_UNITS } from '../domain/units'
 import type { MassUnit, ArmUnit, VolumeUnit } from '../domain/units'
 
 // @IMP-SYS-CORE-006@ (FROM: @REQ-SYS-003@)
+
+// ─── sourceUnit parsing (mass + arm/length) ───────────────────────────────────
+
+/**
+ * Parse a profile `sourceUnit` string into its mass and arm (length) components.
+ *
+ * AeroDash stores values at rest in their source unit (REQ-AD-014). The mass
+ * unit and the arm/length unit are two independent dimensions, but only a
+ * single `sourceUnit` string is carried on the profile. We support:
+ *
+ *   - mass-only:  `'kg'` | `'lb'`                  → arm defaults to `'m'`
+ *   - combined:   `'<mass>-<arm>'` e.g. `'lb-in'`, `'kg-m'`, `'lb-ft'`
+ *
+ * Existing metric profiles (`sourceUnit: 'kg'`) parse to `{ massUnit: 'kg',
+ * armUnit: 'm' }`, preserving today's behaviour EXACTLY — no migration needed.
+ * Imperial profiles whose POH arms are in inches declare e.g. `'lb-in'` so the
+ * arm and moment are normalized to SI instead of being passed through as if
+ * already metric (TECH-001 / TECH-002 — silent wrong-CG defect).
+ *
+ * Unknown / malformed components fall back to the SI default for that
+ * dimension (`kg` / `m`), which is the fail-safe choice: it never silently
+ * scales a value by a wrong factor.
+ */
+// @IMP-SYS-CORE-011@ (FROM: @REQ-SYS-003@, @REQ-AD-014@)
+export function parseSourceUnit(sourceUnit: string): { massUnit: MassUnit; armUnit: ArmUnit } {
+  const [rawMass, rawArm] = sourceUnit.trim().toLowerCase().split('-')
+  const massUnit: MassUnit = (MASS_UNITS as readonly string[]).includes(rawMass ?? '')
+    ? (rawMass as MassUnit)
+    : 'kg'
+  const armUnit: ArmUnit =
+    rawArm !== undefined && (ARM_UNITS as readonly string[]).includes(rawArm)
+      ? (rawArm as ArmUnit)
+      : 'm'
+  return { massUnit, armUnit }
+}
 
 // ─── Mass normalization (→ kg) ────────────────────────────────────────────────
 
@@ -53,6 +89,29 @@ export function armMToUnit(m: number, targetUnit: ArmUnit): number {
   if (targetUnit === 'in') return m / IN_TO_M
   if (targetUnit === 'ft') return m / FT_TO_M
   return m
+}
+
+// ─── Moment normalization (→ kg·m) ────────────────────────────────────────────
+
+/**
+ * Normalize a moment value to SI (kg·m) given the profile's arm (length) unit.
+ *
+ * A moment = mass × arm. Mass is already normalized to kg at the adapter
+ * boundary BEFORE the math core runs, so a stored moment whose arm component is
+ * in `in`/`ft` only needs the length factor applied to reach kg·m. (Stored
+ * moments — `armLookup.moment`, envelope `armOrMoment` in moment-graph mode —
+ * are expressed as kg × armUnit when the profile is metric-mass / imperial-arm,
+ * which is the only imperial case AeroDash ships.)
+ *
+ * @param value - moment in (kg · armUnit)
+ * @param armUnit - the arm/length unit of the moment's length component
+ * @returns moment in kg·m
+ */
+// @IMP-SYS-CORE-010@ (FROM: @REQ-SYS-003@)
+export function normalizeMomentToSI(value: number, armUnit: ArmUnit): number {
+  if (armUnit === 'in') return value * IN_TO_M
+  if (armUnit === 'ft') return value * FT_TO_M
+  return value // already kg·m
 }
 
 // ─── Volume normalization (→ L) ───────────────────────────────────────────────

--- a/frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
@@ -8,13 +8,28 @@
 
 // @UT-AC-VIEW-080@ (FROM: @IMP-AC-VIEW-005@, @IMP-AC-VIEW-006@)
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia, defineStore } from 'pinia'
 import { ref } from 'vue'
 import { createRouter, createMemoryHistory, type Router } from 'vue-router'
 import FleetList from '../components/FleetList.vue'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+
+// UX-001: the undo path re-creates the deleted record via the repository, then
+// rehydrates the store. Mock the repository so no test touches IndexedDB.
+vi.mock('../services/fleet.repository', () => ({
+  fleetRepository: {
+    create: vi.fn<(p: AircraftProfile) => Promise<void>>().mockResolvedValue(undefined),
+    findAll: vi.fn<() => Promise<AircraftProfile[]>>().mockResolvedValue([]),
+    update: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    deleteById: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    findById: vi.fn<() => Promise<AircraftProfile | undefined>>().mockResolvedValue(undefined),
+    openDB: vi.fn<() => Promise<unknown>>(),
+  },
+}))
+
+import { fleetRepository } from '../services/fleet.repository'
 
 /** Minimal valid AircraftProfile for testing. */
 function makeProfile(overrides: Partial<AircraftProfile> = {}): AircraftProfile {
@@ -313,5 +328,108 @@ describe('FleetList — download action', () => {
     clickSpy.mockRestore()
     globalThis.URL.createObjectURL = originalCreate
     globalThis.URL.revokeObjectURL = originalRevoke
+  })
+})
+
+// ─── UX-001: confirm-then-undo destructive delete ──────────────────────────
+
+describe('FleetList — delete confirmation + undo (UX-001)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // ConfirmDialog + UndoToast teleport into <body>; clean between tests.
+    document.body.innerHTML = ''
+  })
+
+  // @UT-AC-VIEW-165@ (FROM: @IMP-AC-VIEW-019@)
+  it('does not use the native window.confirm() when deleting', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+
+    await wrapper.find('.btn-danger').trigger('click')
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  // @UT-AC-VIEW-166@ (FROM: @IMP-AC-VIEW-019@)
+  it('opens an in-app confirmation dialog naming the aircraft on delete tap', async () => {
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+
+    expect(document.querySelector('.confirm-dialog')).toBeNull()
+    await wrapper.find('.btn-danger').trigger('click')
+
+    const dialog = document.querySelector('.confirm-dialog')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.textContent).toContain('D-EBPN')
+  })
+
+  // @UT-AC-VIEW-167@ (FROM: @IMP-AC-VIEW-019@)
+  it('does not delete (no undo toast) when the confirmation is cancelled', async () => {
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+
+    await wrapper.find('.btn-danger').trigger('click')
+    ;(document.querySelector('.confirm-dialog__btn--cancel') as HTMLButtonElement).click()
+    await flushPromises()
+
+    // No delete happened → the undo affordance never opens and the dialog closes.
+    expect(document.querySelector('.undo-toast')).toBeNull()
+    expect(document.querySelector('.confirm-dialog')).toBeNull()
+  })
+
+  // @UT-AC-VIEW-168@ (FROM: @IMP-AC-VIEW-019@)
+  it('deletes and shows an undo toast when the confirmation is accepted', async () => {
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+
+    await wrapper.find('.btn-danger').trigger('click')
+    ;(document.querySelector('.confirm-dialog__btn--danger') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const toast = document.querySelector('.undo-toast')
+    expect(toast).not.toBeNull()
+    expect(toast?.textContent).toContain('D-EBPN')
+  })
+
+  // @UT-AC-VIEW-169@ (FROM: @IMP-AC-VIEW-019@)
+  it('restores the deleted profile via the repository when undo is tapped', async () => {
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile] })
+
+    await wrapper.find('.btn-danger').trigger('click')
+    ;(document.querySelector('.confirm-dialog__btn--danger') as HTMLButtonElement).click()
+    await flushPromises()
+    ;(document.querySelector('.undo-toast__action') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(fleetRepository.create).toHaveBeenCalledWith(profile)
+  })
+
+  // @UT-AC-VIEW-170@ (FROM: @IMP-AC-VIEW-019@)
+  it('disables the delete control while the profile is the active aircraft', () => {
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile], activeProfile: profile })
+
+    const deleteBtn = wrapper.find('.btn-danger')
+    expect(deleteBtn.attributes('disabled')).toBeDefined()
+    expect(deleteBtn.attributes('aria-label')).toContain('active aircraft')
+  })
+
+  // @UT-AC-VIEW-171@ (FROM: @IMP-AC-VIEW-019@)
+  it('does not open the confirmation for the active aircraft (defence in depth)', async () => {
+    const profile = makeProfile({ id: 'p1', registration: 'D-EBPN' })
+    const wrapper = mountFleetList({ profiles: [profile], activeProfile: profile })
+
+    // The DOM button is disabled; call the handler directly to prove the guard.
+    ;(wrapper.vm as unknown as { onDelete(p: AircraftProfile): void }).onDelete(profile)
+    await wrapper.vm.$nextTick()
+
+    expect(document.querySelector('.confirm-dialog')).toBeNull()
   })
 })

--- a/frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
@@ -10,6 +10,8 @@ import {
   exportProfileToJson,
   buildExchangeFilename,
   downloadProfileAsJson,
+  validateImportFile,
+  MAX_IMPORT_FILE_BYTES,
   ImportError,
 } from '../services/profile.import'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
@@ -142,6 +144,55 @@ describe('importProfileFromJson', () => {
     expect(reimported.loadPoints).toEqual(profileForExport.loadPoints)
     expect(reimported.certificationCategories).toEqual(profileForExport.certificationCategories)
     expect(reimported.status).toBe('draft')
+  })
+})
+
+describe('validateImportFile', () => {
+  /** Build a File whose reported `.size` is forced to `sizeBytes` regardless of content. */
+  function makeFile(sizeBytes: number, type: string, name: string): File {
+    const file = new File(['x'], name, { type })
+    Object.defineProperty(file, 'size', { value: sizeBytes, configurable: true })
+    return file
+  }
+
+  // @UT-AC-STORE-084@ (FROM: @IMP-AC-STORE-007@)
+  it('rejects an oversized file before reading it (CS-003)', () => {
+    const tooBig = makeFile(MAX_IMPORT_FILE_BYTES + 1, 'application/json', 'evil.json')
+    expect(() => validateImportFile(tooBig)).toThrow(ImportError)
+    expect(() => validateImportFile(tooBig)).toThrow('too large')
+  })
+
+  // @UT-AC-STORE-085@ (FROM: @IMP-AC-STORE-007@)
+  it('rejects an empty (0-byte) file', () => {
+    const empty = makeFile(0, 'application/json', 'empty.json')
+    expect(() => validateImportFile(empty)).toThrow(ImportError)
+    expect(() => validateImportFile(empty)).toThrow('empty')
+  })
+
+  // @UT-AC-STORE-086@ (FROM: @IMP-AC-STORE-007@)
+  it('rejects a non-JSON MIME type even with a .json name', () => {
+    const spoofed = makeFile(100, 'application/x-msdownload', 'malware.json')
+    expect(() => validateImportFile(spoofed)).toThrow(ImportError)
+    expect(() => validateImportFile(spoofed)).toThrow('only .json')
+  })
+
+  // @UT-AC-STORE-087@ (FROM: @IMP-AC-STORE-007@)
+  it('rejects a non-.json extension even with a JSON MIME type', () => {
+    const wrongExt = makeFile(100, 'application/json', 'profile.txt')
+    expect(() => validateImportFile(wrongExt)).toThrow(ImportError)
+    expect(() => validateImportFile(wrongExt)).toThrow('only .json')
+  })
+
+  // @UT-AC-STORE-088@ (FROM: @IMP-AC-STORE-007@)
+  it('accepts a well-formed .json file at the size limit', () => {
+    const ok = makeFile(MAX_IMPORT_FILE_BYTES, 'application/json', 'D-EBPN.aerodash.json')
+    expect(() => validateImportFile(ok)).not.toThrow()
+  })
+
+  // @UT-AC-STORE-089@ (FROM: @IMP-AC-STORE-007@)
+  it('tolerates an empty MIME type when the extension is .json', () => {
+    const noMime = makeFile(100, '', 'D-EBPN.aerodash.json')
+    expect(() => validateImportFile(noMime)).not.toThrow()
   })
 })
 

--- a/frontend/src/modules/aircraft/components/FleetList.vue
+++ b/frontend/src/modules/aircraft/components/FleetList.vue
@@ -160,13 +160,24 @@
             </svg>
           </button>
 
-          <!-- Delete profile -->
+          <!-- Delete profile — disabled while this profile is the active
+               aircraft so a stray tap can't destroy the airframe currently
+               feeding the M&B Go/No-Go computation (UX-001). -->
           <button
             type="button"
             class="icon-btn icon-btn--danger btn-danger"
-            :aria-label="`Delete ${profile.registration}`"
-            :title="`Delete ${profile.registration}`"
-            @click="onDelete(profile.id, profile.registration)"
+            :disabled="activeStore.activeProfile?.id === profile.id"
+            :aria-label="
+              activeStore.activeProfile?.id === profile.id
+                ? `Cannot delete ${profile.registration} — it is the active aircraft`
+                : `Delete ${profile.registration}`
+            "
+            :title="
+              activeStore.activeProfile?.id === profile.id
+                ? `Active aircraft cannot be deleted`
+                : `Delete ${profile.registration}`
+            "
+            @click="onDelete(profile)"
           >
             <svg
               class="icon-btn__icon"
@@ -189,22 +200,65 @@
         </div>
       </li>
     </ul>
+
+    <!-- UX-001: in-app delete confirmation (replaces native confirm) -->
+    <ConfirmDialog
+      :open="pendingDelete !== null"
+      title="Delete aircraft profile?"
+      :message="
+        pendingDelete
+          ? `Delete ‘${pendingDelete.registration}’ (${pendingDelete.manufacturer} ${pendingDelete.model})? This removes its envelope, weighing reports and burn sequences. You can undo for a few seconds.`
+          : ''
+      "
+      confirm-label="Delete"
+      cancel-label="Keep"
+      variant="danger"
+      @confirm="onConfirmDelete"
+      @cancel="onCancelDelete"
+    />
+
+    <!-- UX-001: post-delete undo toast (restores the profile if tapped) -->
+    <UndoToast
+      :open="recentlyDeleted !== null"
+      :message="
+        recentlyDeleted ? `Deleted ‘${recentlyDeleted.registration}’` : ''
+      "
+      action-label="Undo"
+      :duration="8000"
+      @undo="onUndoDelete"
+      @dismiss="onDismissUndo"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 import { useFleetStore } from '../stores/fleet.store'
 import { useActiveAircraftStore } from '../stores/active-aircraft.store'
+import { fleetRepository } from '../services/fleet.repository'
 import { downloadProfileAsJson } from '../services/profile.import'
 import ProfileStatusBadge from './ProfileStatusBadge.vue'
+import ConfirmDialog from '@/shared/components/ConfirmDialog.vue'
+import UndoToast from '@/shared/components/UndoToast.vue'
 
 // @IMP-AC-VIEW-006@ (FROM: @REQ-AC-001@, @REQ-AC-004@, @REQ-AC-005@)
 
 const router = useRouter()
 const fleetStore = useFleetStore()
 const activeStore = useActiveAircraftStore()
+
+// ─── UX-001: confirm-then-undo destructive delete ──────────────────────────
+// @IMP-AC-VIEW-019@ (FROM: @REQ-AC-001@)
+//
+// `pendingDelete` drives the confirmation modal; once confirmed the profile is
+// removed and stashed in `recentlyDeleted` so the undo toast can re-create the
+// exact record (same id) via the repository, then rehydrate the store. The
+// active aircraft can never reach this flow — its delete control is disabled.
+
+const pendingDelete = ref<AircraftProfile | null>(null)
+const recentlyDeleted = ref<AircraftProfile | null>(null)
 
 function onSelectActive(profile: AircraftProfile): void {
   // Emit draft warning if profile is a Draft (REQ-AC-005)
@@ -224,14 +278,38 @@ function onDownload(profile: AircraftProfile): void {
   downloadProfileAsJson(profile)
 }
 
-async function onDelete(id: string, registration: string): Promise<void> {
-  if (confirm(`Delete aircraft "${registration}"? This action cannot be undone.`)) {
-    // If deleting the active profile, clear it
-    if (activeStore.activeProfile?.id === id) {
-      activeStore.clearActive()
-    }
-    await fleetStore.deleteProfile(id)
-  }
+function onDelete(profile: AircraftProfile): void {
+  // Active aircraft is guarded by the disabled control; defend in depth.
+  if (activeStore.activeProfile?.id === profile.id) return
+  pendingDelete.value = profile
+}
+
+function onCancelDelete(): void {
+  pendingDelete.value = null
+}
+
+async function onConfirmDelete(): Promise<void> {
+  const profile = pendingDelete.value
+  pendingDelete.value = null
+  if (!profile) return
+  await fleetStore.deleteProfile(profile.id)
+  // Open the undo window with the full profile snapshot.
+  recentlyDeleted.value = profile
+}
+
+async function onUndoDelete(): Promise<void> {
+  const profile = recentlyDeleted.value
+  recentlyDeleted.value = null
+  if (!profile) return
+  // Re-create the exact record (same id, envelope, reports) and rehydrate the
+  // store. We restore through the repository because the fleet store owns no
+  // restore action; loadAll() resyncs the in-memory list from persistence.
+  await fleetRepository.create(profile)
+  await fleetStore.loadAll()
+}
+
+function onDismissUndo(): void {
+  recentlyDeleted.value = null
 }
 </script>
 

--- a/frontend/src/modules/aircraft/services/profile.import.ts
+++ b/frontend/src/modules/aircraft/services/profile.import.ts
@@ -17,6 +17,25 @@ import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 // @IMP-AC-STORE-004@ (FROM: @REQ-AC-004@)
 
 /**
+ * Maximum accepted size (in bytes) for an aircraft exchange file.
+ *
+ * Real `.aerodash.json` profiles are a few kilobytes; the schema caps load
+ * points at 20 and envelope points at 20, so even a maximal valid profile is
+ * well under this bound. 256 KB leaves generous headroom for whitespace-pretty
+ * JSON while preventing an attacker-supplied multi-megabyte file from being read
+ * wholesale into memory via `File.text()` (CS-003 / TECH-008).
+ */
+export const MAX_IMPORT_FILE_BYTES = 256 * 1024 // 256 KB
+
+/**
+ * Accepted MIME types for an aircraft exchange file. Browsers report `.json`
+ * files as `application/json` (and historically `text/json`); some report an
+ * empty string when the OS has no MIME mapping, which we tolerate provided the
+ * extension and size checks pass — the JSON parser is the final structural gate.
+ */
+const ACCEPTED_MIME_TYPES = new Set(['application/json', 'text/json'])
+
+/**
  * Error thrown when an import operation fails.
  * The fleet is guaranteed to be unmodified when this error is thrown.
  */
@@ -27,6 +46,48 @@ export class ImportError extends Error {
   ) {
     super(message)
     this.name = 'ImportError'
+  }
+}
+
+/**
+ * Fail-closed pre-flight guard for an imported exchange file (CS-003 / TECH-008).
+ *
+ * Validates the file's size and content-type BEFORE any byte is read into memory
+ * (`File.text()`), so a hostile oversized or spoofed payload is rejected early.
+ *
+ * Rejection rules:
+ * - Empty file (0 bytes) → cannot be a valid profile.
+ * - Size above {@link MAX_IMPORT_FILE_BYTES} → reject without reading.
+ * - Reported MIME type not JSON AND extension not `.json` → reject. An empty
+ *   reported type is tolerated only when the `.json` extension is present.
+ *
+ * @throws ImportError if the file fails any guard; the fleet is never modified.
+ */
+// @IMP-AC-STORE-007@ (FROM: @REQ-AC-004@)
+export function validateImportFile(file: File): void {
+  if (file.size === 0) {
+    throw new ImportError('Import failed: file is empty')
+  }
+
+  if (file.size > MAX_IMPORT_FILE_BYTES) {
+    const limitKb = Math.round(MAX_IMPORT_FILE_BYTES / 1024)
+    throw new ImportError(
+      `Import failed: file is too large (max ${limitKb} KB). Exchange files are only a few KB.`,
+    )
+  }
+
+  const type = file.type.toLowerCase()
+  const hasJsonExtension = file.name.toLowerCase().endsWith('.json')
+  const hasJsonMime = ACCEPTED_MIME_TYPES.has(type)
+
+  // Accept when the MIME type is JSON, or when the browser reported no type but
+  // the extension is `.json`. Reject any explicitly non-JSON MIME type.
+  if (!hasJsonMime && !(type === '' && hasJsonExtension)) {
+    throw new ImportError('Import failed: only .json exchange files are accepted')
+  }
+
+  if (!hasJsonExtension) {
+    throw new ImportError('Import failed: only .json exchange files are accepted')
   }
 }
 

--- a/frontend/src/modules/aircraft/views/FleetManagementView.vue
+++ b/frontend/src/modules/aircraft/views/FleetManagementView.vue
@@ -68,7 +68,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 import { useFleetStore } from '../stores/fleet.store'
-import { importProfileFromJson, ImportError } from '../services/profile.import'
+import { importProfileFromJson, validateImportFile, ImportError } from '../services/profile.import'
 import FleetList from '../components/FleetList.vue'
 
 // @IMP-AC-VIEW-008@ (FROM: @REQ-AC-001@, @REQ-AC-004@, @REQ-AC-006@)
@@ -100,6 +100,9 @@ async function onImportFile(event: Event): Promise<void> {
   if (!file) return
 
   try {
+    // Fail-closed guard: reject oversized / non-JSON files BEFORE reading them
+    // into memory (CS-003 / TECH-008).
+    validateImportFile(file)
     const text = await file.text()
     const profile = importProfileFromJson(text)
     // Create in fleet via store (handles duplicate detection etc.)

--- a/frontend/src/modules/mass-balance/components/MassStationInput.vue
+++ b/frontend/src/modules/mass-balance/components/MassStationInput.vue
@@ -20,6 +20,18 @@ const props = defineProps<{
    * Pass null / undefined for non-fuel stations or tanks without a capacity.
    */
   maxCapacity?: number | null
+  /**
+   * Coarse increment for the secondary ± buttons (UX-002). Reaching a 75 kg
+   * passenger via the fine ±1 control is 75 taps under turbulence; the coarse
+   * control gets there in a handful of taps. Defaults to a unit-aware value
+   * (10 for lb, 5 otherwise) when omitted.
+   */
+  coarseStep?: number
+  /**
+   * Optional preset quantities (in `unit`) rendered as one-tap chips — e.g.
+   * standard passenger weights. Omit / empty for stations without presets.
+   */
+  presets?: readonly number[]
 }>()
 
 const emit = defineEmits<{
@@ -35,6 +47,14 @@ const showSlider = computed(
     props.maxCapacity > minWeight.value,
 )
 
+/** Unit-aware coarse step: pounds tend to want a bigger jump than kilograms. */
+const coarseStepValue = computed(() => {
+  if (props.coarseStep && props.coarseStep > 0) return props.coarseStep
+  return props.unit?.toLowerCase() === 'lb' ? 10 : 5
+})
+
+const presetList = computed(() => props.presets ?? [])
+
 function clamp(value: number): number {
   if (!Number.isFinite(value)) return minWeight.value
   const ceiling = showSlider.value && props.maxCapacity != null ? props.maxCapacity : Infinity
@@ -49,12 +69,28 @@ function onInput(event: Event): void {
   }
 }
 
+function adjust(delta: number): void {
+  emit('update:weight', clamp(props.station.weight + delta))
+}
+
 function increment(): void {
-  emit('update:weight', clamp(props.station.weight + 1))
+  adjust(1)
 }
 
 function decrement(): void {
-  emit('update:weight', clamp(props.station.weight - 1))
+  adjust(-1)
+}
+
+function incrementCoarse(): void {
+  adjust(coarseStepValue.value)
+}
+
+function decrementCoarse(): void {
+  adjust(-coarseStepValue.value)
+}
+
+function applyPreset(value: number): void {
+  emit('update:weight', clamp(value))
 }
 </script>
 
@@ -75,7 +111,20 @@ function decrement(): void {
       <span v-if="unit" class="mass-station-input__unit" aria-label="unit">{{ unit }}</span>
     </div>
 
+    <!-- @IMP-MB-UI-008@ (FROM: @REQ-UQ-004@) -->
+    <!-- UX-002: coarse (±N) controls flank the fine (±1) control so a 75 kg
+         passenger is a handful of taps, not 75. The fine control is retained. -->
     <div class="mass-station-input__control">
+      <button
+        type="button"
+        class="mass-station-input__stepper mass-station-input__stepper--coarse"
+        :disabled="disabled || station.weight <= minWeight"
+        :aria-label="`Decrease by ${coarseStepValue}`"
+        @click="decrementCoarse"
+      >
+        −{{ coarseStepValue }}
+      </button>
+
       <button
         type="button"
         class="mass-station-input__stepper"
@@ -107,6 +156,36 @@ function decrement(): void {
         @click="increment"
       >
         +
+      </button>
+
+      <button
+        type="button"
+        class="mass-station-input__stepper mass-station-input__stepper--coarse"
+        :disabled="disabled"
+        :aria-label="`Increase by ${coarseStepValue}`"
+        @click="incrementCoarse"
+      >
+        +{{ coarseStepValue }}
+      </button>
+    </div>
+
+    <!-- UX-002: one-tap preset chips (e.g. standard passenger weights). -->
+    <div
+      v-if="presetList.length > 0"
+      class="mass-station-input__presets"
+      role="group"
+      :aria-label="`${station.name} quick presets`"
+    >
+      <button
+        v-for="preset in presetList"
+        :key="preset"
+        type="button"
+        class="mass-station-input__preset-chip"
+        :disabled="disabled"
+        :aria-label="`Set ${station.name} to ${preset}${unit ? ` ${unit}` : ''}`"
+        @click="applyPreset(preset)"
+      >
+        {{ preset }}{{ unit ? ` ${unit}` : '' }}
       </button>
     </div>
 
@@ -259,8 +338,57 @@ function decrement(): void {
   cursor: not-allowed;
 }
 
+.mass-station-input__stepper--coarse {
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  padding: 0 0.25rem;
+  color: var(--color-primary, #1976d2);
+}
+
+/* UX-002: one-tap preset chips ─────────────────────────────────────────── */
+.mass-station-input__presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.mass-station-input__preset-chip {
+  min-height: 2.25rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 1rem;
+  background: var(--color-surface-alt, #f5f5f5);
+  color: var(--color-text-primary, #212121);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    background 0.1s ease,
+    border-color 0.1s ease;
+}
+
+.mass-station-input__preset-chip:hover:not(:disabled) {
+  background: var(--color-surface-hover, #e0e0e0);
+  border-color: var(--color-primary, #1976d2);
+}
+
+.mass-station-input__preset-chip:focus-visible {
+  outline: 2px solid var(--color-focus, #1976d2);
+  outline-offset: 1px;
+}
+
+.mass-station-input__preset-chip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .mass-station-input__field {
-  width: 5rem;
+  /* UX-002: widened from 5rem so 4+ digit loads (e.g. avgas in lb) read with
+     tabular-nums without cramped precision typing under turbulence. */
+  width: 7rem;
   min-height: 2.75rem;
   border: none;
   border-left: 1px solid var(--color-border, #e0e0e0);

--- a/frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
+++ b/frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
@@ -1,3 +1,5 @@
+// @UT-MB-UI-001@ (FROM: @IMP-MB-UI-006@, @IMP-MB-UI-008@)
+
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import MassStationInput from '../MassStationInput.vue'
@@ -77,8 +79,8 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 0 }) },
     })
 
-    const [decrement] = wrapper.findAll('button')
-    expect((decrement!.element as HTMLButtonElement).disabled).toBe(true)
+    const decrement = wrapper.find('button[aria-label="Decrease"]')
+    expect((decrement.element as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('enables the decrement button when weight is above 0 and not disabled', () => {
@@ -86,8 +88,8 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 5 }) },
     })
 
-    const [decrement] = wrapper.findAll('button')
-    expect((decrement!.element as HTMLButtonElement).disabled).toBe(false)
+    const decrement = wrapper.find('button[aria-label="Decrease"]')
+    expect((decrement.element as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('disables the decrement button when the disabled prop is true even if weight > 0', () => {
@@ -95,8 +97,8 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 50 }), disabled: true },
     })
 
-    const [decrement] = wrapper.findAll('button')
-    expect((decrement!.element as HTMLButtonElement).disabled).toBe(true)
+    const decrement = wrapper.find('button[aria-label="Decrease"]')
+    expect((decrement.element as HTMLButtonElement).disabled).toBe(true)
   })
 
   // ─── Increment button — disabled branch ─────────────────────────────────
@@ -106,8 +108,8 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 0 }), disabled: true },
     })
 
-    const buttons = wrapper.findAll('button')
-    expect((buttons[1]!.element as HTMLButtonElement).disabled).toBe(true)
+    const increment = wrapper.find('button[aria-label="Increase"]')
+    expect((increment.element as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('enables the increment button when the disabled prop is false', () => {
@@ -115,8 +117,8 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 0 }), disabled: false },
     })
 
-    const buttons = wrapper.findAll('button')
-    expect((buttons[1]!.element as HTMLButtonElement).disabled).toBe(false)
+    const increment = wrapper.find('button[aria-label="Increase"]')
+    expect((increment.element as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('also disables the input field when the disabled prop is true', () => {
@@ -134,8 +136,7 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 5 }) },
     })
 
-    const [decrement] = wrapper.findAll('button')
-    await decrement!.trigger('click')
+    await wrapper.find('button[aria-label="Decrease"]').trigger('click')
 
     expect(wrapper.emitted('update:weight')).toEqual([[4]])
   })
@@ -156,8 +157,7 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 1 }) },
     })
 
-    const [decrement] = wrapper.findAll('button')
-    await decrement!.trigger('click')
+    await wrapper.find('button[aria-label="Decrease"]').trigger('click')
 
     expect(wrapper.emitted('update:weight')).toEqual([[0]])
   })
@@ -169,8 +169,7 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 10 }) },
     })
 
-    const buttons = wrapper.findAll('button')
-    await buttons[1]!.trigger('click')
+    await wrapper.find('button[aria-label="Increase"]').trigger('click')
 
     expect(wrapper.emitted('update:weight')).toEqual([[11]])
   })
@@ -180,8 +179,7 @@ describe('MassStationInput', () => {
       props: { station: makeStation({ weight: 0 }) },
     })
 
-    const buttons = wrapper.findAll('button')
-    await buttons[1]!.trigger('click')
+    await wrapper.find('button[aria-label="Increase"]').trigger('click')
 
     expect(wrapper.emitted('update:weight')).toEqual([[1]])
   })
@@ -219,5 +217,101 @@ describe('MassStationInput', () => {
     onInput.call(wrapper.vm, { target: { value: '' } } as unknown as Event)
 
     expect(wrapper.emitted('update:weight')).toBeUndefined()
+  })
+
+  // ─── UX-002: coarse step + presets + wider field ────────────────────────
+
+  it('renders coarse +/- controls in addition to the fine +/- control', () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 80 }), unit: 'kg' },
+    })
+
+    const coarse = wrapper.findAll('.mass-station-input__stepper--coarse')
+    // One coarse decrease + one coarse increase.
+    expect(coarse).toHaveLength(2)
+    // Fine controls are retained (the original ± buttons still exist).
+    expect(wrapper.find('button[aria-label="Decrease"]').exists()).toBe(true)
+    expect(wrapper.find('button[aria-label="Increase"]').exists()).toBe(true)
+  })
+
+  it('defaults the coarse step to 5 for kilograms', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 80 }), unit: 'kg' },
+    })
+
+    await wrapper.find('button[aria-label="Increase by 5"]').trigger('click')
+    expect(wrapper.emitted('update:weight')).toEqual([[85]])
+  })
+
+  it('defaults the coarse step to 10 for pounds', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 80 }), unit: 'lb' },
+    })
+
+    await wrapper.find('button[aria-label="Increase by 10"]').trigger('click')
+    expect(wrapper.emitted('update:weight')).toEqual([[90]])
+  })
+
+  it('honours an explicit coarseStep prop', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 80 }), unit: 'kg', coarseStep: 25 },
+    })
+
+    await wrapper.find('button[aria-label="Increase by 25"]').trigger('click')
+    expect(wrapper.emitted('update:weight')).toEqual([[105]])
+  })
+
+  it('coarse decrement clamps to the minimum (unusable fuel)', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 6 }), unit: 'kg', unusableFuel: 3 },
+    })
+
+    // 6 - 5 = 1, clamped up to the 3 kg unusable floor.
+    await wrapper.find('button[aria-label="Decrease by 5"]').trigger('click')
+    expect(wrapper.emitted('update:weight')).toEqual([[3]])
+  })
+
+  it('reaches a 75 kg passenger in far fewer taps via the coarse step', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 0 }), unit: 'kg', coarseStep: 25 },
+    })
+    const coarseUp = wrapper.find('button[aria-label="Increase by 25"]')
+
+    // 3 coarse taps would be 75 (vs 75 fine taps) — prove the first emits 25.
+    await coarseUp.trigger('click')
+    const emissions = wrapper.emitted('update:weight')!
+    expect(emissions[emissions.length - 1]).toEqual([25])
+  })
+
+  it('does not render preset chips when no presets are provided', () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation(), unit: 'kg' },
+    })
+    expect(wrapper.find('.mass-station-input__presets').exists()).toBe(false)
+  })
+
+  it('renders one preset chip per provided preset and emits its value on tap', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 0 }), unit: 'kg', presets: [55, 70, 85] },
+    })
+
+    const chips = wrapper.findAll('.mass-station-input__preset-chip')
+    expect(chips).toHaveLength(3)
+    expect(chips[1]!.text()).toContain('70')
+
+    await chips[1]!.trigger('click')
+    expect(wrapper.emitted('update:weight')).toEqual([[70]])
+  })
+
+  it('disables coarse controls and preset chips when the disabled prop is true', () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 80 }), unit: 'kg', disabled: true, presets: [70] },
+    })
+
+    const coarse = wrapper.findAll('.mass-station-input__stepper--coarse')
+    expect(coarse.every((b) => (b.element as HTMLButtonElement).disabled)).toBe(true)
+    expect(
+      (wrapper.find('.mass-station-input__preset-chip').element as HTMLButtonElement).disabled,
+    ).toBe(true)
   })
 })

--- a/frontend/src/modules/mass-balance/data/__tests__/aircraft-context.schema.spec.ts
+++ b/frontend/src/modules/mass-balance/data/__tests__/aircraft-context.schema.spec.ts
@@ -376,7 +376,7 @@ describe('AircraftContextSchema', () => {
             buildValidLoadPoint({
               fuelTank: {
                 unusableFuel: 1.5,
-                permissibleFuelTypes: ['AVGAS 100LL'],
+                permissibleFuelTypes: ['AvGas 100LL'],
                 burnSequences: [{ sequenceName: 'Main', ordinalPosition: 1 }],
               },
             }),
@@ -412,7 +412,7 @@ describe('AircraftContextSchema', () => {
             buildValidLoadPoint({
               fuelTank: {
                 unusableFuel: 0,
-                permissibleFuelTypes: [],
+                permissibleFuelTypes: ['AvGas 100LL'],
                 burnSequences: [],
               },
             }),
@@ -430,7 +430,7 @@ describe('AircraftContextSchema', () => {
             buildValidLoadPoint({
               fuelTank: {
                 unusableFuel: 0,
-                permissibleFuelTypes: ['AVGAS 100LL', 'MOGAS'],
+                permissibleFuelTypes: ['AvGas 100LL', 'MoGas'],
                 burnSequences: [
                   { sequenceName: 'Main', ordinalPosition: 1 },
                   { sequenceName: 'Aux', ordinalPosition: 2 },
@@ -441,6 +441,61 @@ describe('AircraftContextSchema', () => {
         }),
       )
       expect(result.success).toBe(true)
+    })
+
+    // @UT-MB-DATA-038@ (FROM: @IMP-MB-DATA-003@, @REQ-FE-001@, H-002)
+    it('rejects a genuinely unknown fuel-type string (CS-009 fail-closed)', () => {
+      const result = AircraftContextSchema.safeParse(
+        buildValidContext({
+          loadPoints: [
+            buildValidLoadPoint({
+              fuelTank: {
+                unusableFuel: 0,
+                // typo / attacker value that would silently hit the 0.84 fallback
+                permissibleFuelTypes: ['Kerosene'],
+                burnSequences: [],
+              },
+            }),
+          ],
+        }),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    // @UT-MB-DATA-040@ (FROM: @IMP-MB-DATA-003@, @REQ-FE-001@)
+    it('tolerates the deprecated uppercase aliases that resolve a correct density', () => {
+      const result = AircraftContextSchema.safeParse(
+        buildValidContext({
+          loadPoints: [
+            buildValidLoadPoint({
+              fuelTank: {
+                unusableFuel: 0,
+                permissibleFuelTypes: ['AVGAS', 'MOGAS'],
+                burnSequences: [],
+              },
+            }),
+          ],
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    // @UT-MB-DATA-039@ (FROM: @IMP-MB-DATA-003@, @REQ-FE-001@)
+    it('rejects an empty permissibleFuelTypes array (min 1)', () => {
+      const result = AircraftContextSchema.safeParse(
+        buildValidContext({
+          loadPoints: [
+            buildValidLoadPoint({
+              fuelTank: {
+                unusableFuel: 0,
+                permissibleFuelTypes: [],
+                burnSequences: [],
+              },
+            }),
+          ],
+        }),
+      )
+      expect(result.success).toBe(false)
     })
   })
 

--- a/frontend/src/modules/mass-balance/data/aircraft-catalogue.ts
+++ b/frontend/src/modules/mass-balance/data/aircraft-catalogue.ts
@@ -53,7 +53,7 @@ export const AIRCRAFT_CATALOGUE: AircraftContext[] = [
         allowableCategories: ['Normal'],
         fuelTank: {
           unusableFuel: 3,
-          permissibleFuelTypes: ['MOGAS', 'AVGAS'],
+          permissibleFuelTypes: ['MoGas', 'AvGas 100LL'],
           burnSequences: [],
         },
       },
@@ -108,7 +108,7 @@ export const AIRCRAFT_CATALOGUE: AircraftContext[] = [
         allowableCategories: ['Normal'],
         fuelTank: {
           unusableFuel: 3,
-          permissibleFuelTypes: ['MOGAS', 'AVGAS'],
+          permissibleFuelTypes: ['MoGas', 'AvGas 100LL'],
           burnSequences: [],
         },
       },

--- a/frontend/src/modules/mass-balance/data/aircraft-context.schema.ts
+++ b/frontend/src/modules/mass-balance/data/aircraft-context.schema.ts
@@ -8,15 +8,29 @@
  * @see AircraftContext in core/domain/aircraft.types.ts
  */
 import { z } from 'zod'
+import { CANONICAL_FUEL_TYPES } from '@/core/logic/fuel-density'
 
 const BurnSequenceEntrySchema = z.object({
   sequenceName: z.string(),
   ordinalPosition: z.number(),
 })
 
+// @IMP-MB-DATA-003@ (FROM: @REQ-FE-001@, @REQ-SYS-003@, H-002)
+// Converge the runtime context onto the fuel-type enum (CS-009 / TECH-011): a
+// loose `z.array(z.string())` let arbitrary strings reach fuel-density, where a
+// typo / attacker value silently resolved to the 0.84 fallback and miscomputed
+// AvGas vs Jet-A mass. We accept the canonical keys PLUS the two deprecated
+// uppercase aliases (`AVGAS`, `MOGAS`) that still resolve a CORRECT (non-
+// fallback) density — these are tolerated here so in-flight runtime data mid-
+// migration is not rejected. The authoritative fleet/exchange document schema
+// (AircraftProfileSchema) remains canonical-only, so newly written profiles can
+// never persist a legacy alias. `.min(1)` keeps the "at least one permissible
+// fuel" invariant.
+const ACCEPTED_FUEL_TYPES = [...CANONICAL_FUEL_TYPES, 'AVGAS', 'MOGAS'] as const
+
 const FuelTankSchema = z.object({
   unusableFuel: z.number().nonnegative(),
-  permissibleFuelTypes: z.array(z.string()),
+  permissibleFuelTypes: z.array(z.enum(ACCEPTED_FUEL_TYPES)).min(1),
   burnSequences: z.array(BurnSequenceEntrySchema),
 })
 

--- a/frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.int.spec.ts
+++ b/frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.int.spec.ts
@@ -1,0 +1,354 @@
+// @IT-MB-STORE-001@ (FROM: @IMP-MB-STORE-020@)
+// @IT-MB-STORE-002@ (FROM: @IMP-MB-STORE-022@)
+// @IT-MB-STORE-003@ (FROM: @IMP-MB-STORE-021@)
+
+/**
+ * Mass & Balance store ↔ real math-core integration.
+ *
+ * Unlike mass-balance.store.spec.ts (which mocks the adapter), this suite wires
+ * the store to the REAL `calculateMassBalance` adapter so the full
+ * unit-normalization → Zod validation → math-core chain is exercised end to
+ * end. It covers the v0.3.0-alpha release-audit blockers:
+ *
+ *   - BUNDLE 1 (TECH-001/002): imperial profile (arms in inches, mass in lb)
+ *     produces a CORRECT SI center of gravity and envelope verdict.
+ *   - BUNDLE 3 (TECH-004): an adapter validation failure (success:false with
+ *     NaN-filled CgPoints) must NOT reach `lastResult`; the store takes the
+ *     notifications path so the UI never renders "NaN kg".
+ *   - BUNDLE 4 (TECH-013/CS-008): an unknown fuel type fails closed with a
+ *     WARNING instead of silently substituting the fallback density.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useMassBalanceStore } from '../mass-balance.store'
+import type { AircraftContext } from '@/core/domain/aircraft.types'
+
+// ── Conversion constants (mirror the P1 unit-normalization factors) ─────────────
+const LB_TO_KG = 0.45359237
+const IN_TO_M = 0.0254
+
+// ── Imperial hand-computed vector ───────────────────────────────────────────────
+// Cessna-class single, source unit "lb-in" (mass in lb, arm in inches).
+//
+//   BEM    = 1500 lb @ 40 in
+//   Pilot  =  400 lb @ 38 in
+//   Fuel   =  200 lb @ 48 in, unusable 10 lb  (mass-unit tank)
+//   MTOM   = 2400 lb
+//
+// Hand-computed SI expectations (raw × conversion factor):
+//   ZFM       = (1500+400)·LB                 = 861.825503 kg
+//   ZF arm    = (1500·40 + 400·38)·IN / ZFM   = 1.0053052631578947 m
+//   TO mass   = ZFM + (200-10)·LB             = 948.0080533 kg
+//   TO arm    = … (usable fuel 190 lb @ 48 in)= 1.0247502392344496 m
+const imperialProfile: AircraftContext = {
+  id: 'imperial-c172-class',
+  registration: 'N12345',
+  manufacturer: 'TestCo',
+  model: 'Imperial One',
+  sourceUnit: 'lb-in',
+  weighingReports: [
+    {
+      basicEmptyMass: 1500,
+      emptyCg: 40,
+      weighingDate: '2025-01-01',
+      validFrom: '2025-01-01',
+    },
+  ],
+  loadPoints: [
+    {
+      name: 'Pilot',
+      arm: 38,
+      armLookup: [],
+      operationalLimit: 500,
+      defaultQuantity: 400,
+      unit: 'lb',
+      allowableCategories: ['Normal'],
+      fuelTank: null,
+    },
+    {
+      name: 'Fuel',
+      arm: 48,
+      armLookup: [],
+      operationalLimit: 400,
+      defaultQuantity: 200,
+      unit: 'lb',
+      allowableCategories: ['Normal'],
+      fuelTank: {
+        unusableFuel: 10,
+        permissibleFuelTypes: ['AvGas 100LL'],
+        burnSequences: [],
+      },
+    },
+  ],
+  certificationCategories: [
+    {
+      category: 'Normal',
+      maxTakeoffMass: 2400,
+      maxZeroFuelMass: null,
+      graphType: 'arm',
+      // Envelope in inches: arm 35..45 in, mass 1500..2400 lb. The takeoff CG
+      // (≈40.34 in, ≈2090 lb) sits well inside.
+      envelope: [
+        { armOrMoment: 35, mass: 1500 },
+        { armOrMoment: 35, mass: 2400 },
+        { armOrMoment: 45, mass: 2400 },
+        { armOrMoment: 45, mass: 1500 },
+      ],
+    },
+  ],
+}
+
+describe('MassBalance store ↔ real adapter — imperial unit normalization (BUNDLE 1)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  // @IT-MB-STORE-001@
+  it('normalizes inches/lb to SI and computes the correct CG (in-envelope, no false Go)', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(imperialProfile)
+
+    expect(store.lastResult).not.toBeNull()
+    const r = store.lastResult!
+
+    // Zero-fuel CG
+    expect(r.zeroFuelCenterOfGravityPoint.mass).toBeCloseTo((1500 + 400) * LB_TO_KG, 6)
+    expect(r.zeroFuelCenterOfGravityPoint.arm).toBeCloseTo(1.0053052631578947, 6)
+
+    // Takeoff CG (usable fuel = 190 lb @ 48 in)
+    expect(r.takeoffCenterOfGravityPoint.mass).toBeCloseTo((1500 + 400 + 190) * LB_TO_KG, 6)
+    expect(r.takeoffCenterOfGravityPoint.arm).toBeCloseTo(1.0247502392344496, 6)
+
+    // Sanity: arm is in the metric ballpark (~1 m), NOT the raw inch value (~40)
+    expect(r.takeoffCenterOfGravityPoint.arm).toBeLessThan(2)
+
+    // In-envelope and within MTOM → no violations, VERIFIED_SAFE.
+    expect(r.violations).toHaveLength(0)
+    expect(store.uiState).toBe('VERIFIED_SAFE')
+  })
+
+  // @IT-MB-STORE-001@
+  it('flags CG_OUT_OF_ENVELOPE when an imperial arm pushes the CG past the inch-defined envelope', () => {
+    // Heavy pilot far forward (800 lb @ 10 in), no fuel. Hand calc:
+    //   takeoff mass = 1500+800 = 2300 lb (< 2400 MTOM → NOT a mass violation)
+    //   takeoff arm  ≈ 29.57 in (0.751 m) — left of the 35-in (0.889 m) envelope
+    //                  edge, so the ARM is genuinely out of the certified box.
+    // This only fires if inch→m normalization is applied to BOTH the CG and the
+    // envelope; the pre-fix hardcoded-metres path would have left both in inches
+    // and mis-judged membership.
+    const fwd: AircraftContext = {
+      ...imperialProfile,
+      id: 'imperial-fwd',
+      loadPoints: imperialProfile.loadPoints.map((lp) => {
+        if (lp.name === 'Pilot') return { ...lp, arm: 10, defaultQuantity: 800 }
+        // drain fuel so MTOM is not the trigger
+        return { ...lp, defaultQuantity: lp.fuelTank ? 0 : lp.defaultQuantity }
+      }),
+    }
+
+    const store = useMassBalanceStore()
+    store.loadProfile(fwd)
+
+    const r = store.lastResult!
+    expect(r.takeoffCenterOfGravityPoint.mass).toBeLessThan(2400 * LB_TO_KG) // under MTOM
+    expect(r.violations.some((v) => v.type === 'MTOM_EXCEEDED')).toBe(false)
+    expect(r.violations.some((v) => v.type === 'CG_OUT_OF_ENVELOPE')).toBe(true)
+    expect(store.uiState).toBe('ERROR_CRITICAL')
+  })
+
+  // @IT-MB-STORE-001@
+  it('produces IDENTICAL results to the metric equivalent of the same aircraft', () => {
+    // Metric twin: same physical aircraft expressed in kg / m up front.
+    const metricTwin: AircraftContext = {
+      ...imperialProfile,
+      id: 'metric-twin',
+      sourceUnit: 'kg',
+      weighingReports: [
+        {
+          basicEmptyMass: 1500 * LB_TO_KG,
+          emptyCg: 40 * IN_TO_M,
+          weighingDate: '2025-01-01',
+          validFrom: '2025-01-01',
+        },
+      ],
+      loadPoints: imperialProfile.loadPoints.map((lp) => ({
+        ...lp,
+        arm: lp.arm === null ? null : lp.arm * IN_TO_M,
+        unit: 'kg',
+        defaultQuantity: lp.defaultQuantity * LB_TO_KG,
+        operationalLimit: lp.operationalLimit === null ? null : lp.operationalLimit * LB_TO_KG,
+        fuelTank: lp.fuelTank
+          ? { ...lp.fuelTank, unusableFuel: lp.fuelTank.unusableFuel * LB_TO_KG }
+          : null,
+      })),
+      certificationCategories: imperialProfile.certificationCategories.map((cc) => ({
+        ...cc,
+        maxTakeoffMass: cc.maxTakeoffMass * LB_TO_KG,
+        envelope: cc.envelope.map((p) => ({
+          armOrMoment: p.armOrMoment * IN_TO_M,
+          mass: p.mass * LB_TO_KG,
+        })),
+      })),
+    }
+
+    const impStore = useMassBalanceStore()
+    impStore.loadProfile(imperialProfile)
+    const imp = impStore.lastResult!
+
+    setActivePinia(createPinia())
+    const metStore = useMassBalanceStore()
+    metStore.loadProfile(metricTwin)
+    const met = metStore.lastResult!
+
+    expect(imp.takeoffCenterOfGravityPoint.arm).toBeCloseTo(met.takeoffCenterOfGravityPoint.arm, 6)
+    expect(imp.takeoffCenterOfGravityPoint.mass).toBeCloseTo(met.takeoffCenterOfGravityPoint.mass, 6)
+    expect(imp.violations.map((v) => v.type).sort()).toEqual(met.violations.map((v) => v.type).sort())
+  })
+})
+
+// ── BUNDLE 3 — NaN result must not reach lastResult / the UI ─────────────────────
+
+const metricBase: AircraftContext = {
+  id: 'p2008-metric',
+  registration: 'D-EBPN',
+  manufacturer: 'Tecnam',
+  model: 'P2008 JC',
+  sourceUnit: 'kg',
+  weighingReports: [
+    { basicEmptyMass: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+  ],
+  loadPoints: [
+    {
+      name: 'Pilot & Passenger',
+      arm: 1.8,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 90,
+      unit: 'kg',
+      allowableCategories: ['Normal'],
+      fuelTank: null,
+    },
+    {
+      name: 'Fuel',
+      arm: 2.209,
+      armLookup: [],
+      operationalLimit: 75,
+      defaultQuantity: 60,
+      unit: 'kg',
+      allowableCategories: ['Normal'],
+      fuelTank: {
+        unusableFuel: 3,
+        permissibleFuelTypes: ['AvGas 100LL'],
+        burnSequences: [],
+      },
+    },
+  ],
+  certificationCategories: [
+    {
+      category: 'Normal',
+      maxTakeoffMass: 650,
+      maxZeroFuelMass: null,
+      graphType: 'arm',
+      envelope: [
+        { armOrMoment: 1.841, mass: 432 },
+        { armOrMoment: 1.841, mass: 650 },
+        { armOrMoment: 1.978, mass: 650 },
+        { armOrMoment: 1.978, mass: 432 },
+      ],
+    },
+  ],
+}
+
+describe('MassBalance store ↔ real adapter — NaN result is blocked from the UI (BUNDLE 3)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  // @IT-MB-STORE-002@
+  it('never assigns a NaN-filled failed compute to lastResult; surfaces an ERROR instead', () => {
+    const store = useMassBalanceStore()
+    // Poison the empty CG with a non-finite value — the adapter rejects it
+    // (success:false) and returns NaN CgPoints. The store must NOT keep them.
+    const poisoned: AircraftContext = {
+      ...metricBase,
+      weighingReports: [
+        {
+          basicEmptyMass: 432,
+          emptyCg: Infinity,
+          weighingDate: '2025-01-01',
+          validFrom: '2025-01-01',
+        },
+      ],
+    }
+    store.loadProfile(poisoned)
+
+    // The blocker: lastResult stays null, so no "NaN kg" can render.
+    expect(store.lastResult).toBeNull()
+    expect(store.hasErrorNotification).toBe(true)
+    expect(store.uiState).toBe('ERROR_CRITICAL')
+    expect(store.notifications.some((n) => n.id === 'ERR-SYS-001')).toBe(true)
+  })
+
+  // @IT-MB-STORE-002@
+  it('rejects an absurd out-of-range station mass without rendering a result', () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(metricBase)
+    expect(store.lastResult).not.toBeNull() // baseline computes fine
+
+    store.updateStationWeight(0, 1e30) // absurd kg → OUT_OF_RANGE in adapter
+    expect(store.lastResult).toBeNull()
+    expect(store.uiState).not.toBe('VERIFIED_SAFE')
+  })
+})
+
+// ── BUNDLE 4 — unknown fuel type fails closed ───────────────────────────────────
+
+describe('MassBalance store ↔ real adapter — unknown fuel fails closed (BUNDLE 4)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  // @IT-MB-STORE-003@
+  it('raises WARN-FE-001 and does not compute silently for an unknown fuel type', () => {
+    const store = useMassBalanceStore()
+    // Bypass the context-schema enum (the store consumes a typed AircraftContext
+    // directly) to simulate data that slipped through a looser path.
+    const unknownFuel: AircraftContext = {
+      ...metricBase,
+      id: 'unknown-fuel',
+      loadPoints: metricBase.loadPoints.map((lp) =>
+        lp.fuelTank
+          ? {
+              ...lp,
+              fuelTank: {
+                ...lp.fuelTank,
+                permissibleFuelTypes: ['Kerosene' as unknown as 'Diesel'],
+              },
+            }
+          : lp,
+      ),
+    }
+    store.loadProfile(unknownFuel)
+
+    expect(store.notifications.some((n) => n.id === 'WARN-FE-001')).toBe(true)
+    expect(store.hasWarningNotification).toBe(true)
+  })
+
+  // @IT-MB-STORE-003@
+  it('does NOT warn for each canonical fuel type', () => {
+    for (const fuel of ['MoGas', 'AvGas 100LL', 'Jet A-1', 'AvGas UL91', 'Diesel'] as const) {
+      setActivePinia(createPinia())
+      const store = useMassBalanceStore()
+      const profile: AircraftContext = {
+        ...metricBase,
+        id: `fuel-${fuel}`,
+        loadPoints: metricBase.loadPoints.map((lp) =>
+          lp.fuelTank ? { ...lp, fuelTank: { ...lp.fuelTank, permissibleFuelTypes: [fuel] } } : lp,
+        ),
+      }
+      store.loadProfile(profile)
+      expect(store.notifications.some((n) => n.id === 'WARN-FE-001')).toBe(false)
+    }
+  })
+})

--- a/frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts
+++ b/frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts
@@ -66,7 +66,7 @@ const mockProfile: AircraftContext = {
       allowableCategories: ['Normal'],
       fuelTank: {
         unusableFuel: 3,
-        permissibleFuelTypes: ['MOGAS', 'AVGAS'],
+        permissibleFuelTypes: ['MoGas', 'AvGas 100LL'],
         burnSequences: [],
       },
     },
@@ -121,7 +121,7 @@ const multiCatProfile: AircraftContext = {
       allowableCategories: null,
       fuelTank: {
         unusableFuel: 2,
-        permissibleFuelTypes: ['AVGAS'],
+        permissibleFuelTypes: ['AvGas 100LL'],
         burnSequences: [],
       },
     },

--- a/frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+++ b/frontend/src/modules/mass-balance/stores/mass-balance.store.ts
@@ -24,9 +24,15 @@
 
 import { defineStore } from 'pinia'
 import { calculateMassBalance } from '@/core/adapters/mass-balance.adapter'
-import { normalizeMassToKg, normalizeArmToM } from '@/core/logic/unit-normalization'
+import {
+  normalizeMassToKg,
+  normalizeArmToM,
+  normalizeMomentToSI,
+  parseSourceUnit,
+} from '@/core/logic/unit-normalization'
 import { normalizeFuelQuantityToKg, isFuelQuantityUnit } from '@/core/logic/fuel-mass'
-import type { MassUnit, ArmUnit } from '@/core/domain/units'
+import { isKnownFuelType } from '@/core/logic/fuel-density'
+import type { MassUnit } from '@/core/domain/units'
 import type { SessionPayload } from '@/core/domain/session.schema'
 import type {
   MassBalanceState,
@@ -393,10 +399,38 @@ export const useMassBalanceStore = defineStore('massBalance', {
       }
 
       // @IMP-MB-STORE-016@ (FROM: @REQ-AD-014@, @REQ-SYS-003@)
-      // Values stored at rest in their original source unit (per REQ-AD-014).
-      // Normalize to SI (kg, m) at the adapter boundary before passing to the
-      // math core, using the load point's unit field and the profile's sourceUnit.
-      const sourceUnit = this.aircraft!.sourceUnit as MassUnit
+      // @IMP-MB-STORE-020@ (FROM: @REQ-SYS-003@, @REQ-AD-014@)
+      // Values are stored at rest in their original source unit (REQ-AD-014).
+      // Normalize EVERY geometric quantity to SI (kg, m, kg·m) at the adapter
+      // boundary before passing to the math core — not just mass. The arm unit
+      // is derived from the profile's `sourceUnit` (e.g. `lb-in`) rather than
+      // hardcoded to metres (TECH-001 / TECH-002): an imperial profile with
+      // arms in inches would otherwise yield a wrong CG and a false in-envelope
+      // verdict (H-005 / H-006 class defect).
+      const { massUnit: profileMassUnit, armUnit } = parseSourceUnit(this.aircraft!.sourceUnit)
+
+      // @IMP-MB-STORE-021@ (FROM: @REQ-FE-001@, @REQ-SYS-003@, H-002)
+      // Fail-closed on an unrecognized fuel type: surface a WARNING instead of
+      // silently substituting the conservative fallback density (TECH-013 /
+      // CS-008). Collected here and merged into the notification set below.
+      const fuelFallbackNotes: Notification[] = []
+
+      // Normalize an armLookup table (mass/volume axis → kg, moment → kg·m).
+      const normalizeArmLookup = (
+        entries: { massOrVolume: number; moment: number }[],
+        massToKg: (v: number) => number,
+      ) =>
+        entries.map((e) => ({
+          massOrVolume: massToKg(e.massOrVolume),
+          moment: normalizeMomentToSI(e.moment, armUnit),
+        }))
+
+      // Normalize an envelope point's armOrMoment: it is an ARM (length) in
+      // arm-graph mode and a MOMENT in moment-graph mode.
+      const normalizeArmOrMoment = (value: number) =>
+        catDef.graphType === 'arm'
+          ? normalizeArmToM(value, armUnit)
+          : normalizeMomentToSI(value, armUnit)
 
       const input: MathCoreInput = {
         stations: this.availableStations
@@ -406,20 +440,25 @@ export const useMassBalanceStore = defineStore('massBalance', {
           })
           .map((s) => {
             const def = this.aircraft!.loadPoints[s.index]!
-            const massUnit = (def.unit || sourceUnit) as MassUnit
-            const armUnit = 'm' as ArmUnit
+            const massUnit = (def.unit || profileMassUnit) as MassUnit
             return {
               index: s.index,
               mass: normalizeMassToKg(s.weight, massUnit),
               arm: def.arm !== null ? normalizeArmToM(def.arm, armUnit) : null,
-              armLookup: def.armLookup,
+              armLookup: normalizeArmLookup(def.armLookup, (v) => normalizeMassToKg(v, massUnit)),
             }
           }),
-        basicEmptyMass: normalizeMassToKg(activeReport.basicEmptyMass, sourceUnit),
-        emptyCenterOfGravity: activeReport.emptyCg,
-        maxTakeoffMass: catDef.maxTakeoffMass,
-        maxZeroFuelMass: catDef.maxZeroFuelMass,
-        envelope: catDef.envelope,
+        basicEmptyMass: normalizeMassToKg(activeReport.basicEmptyMass, profileMassUnit),
+        emptyCenterOfGravity: normalizeArmToM(activeReport.emptyCg, armUnit),
+        maxTakeoffMass: normalizeMassToKg(catDef.maxTakeoffMass, profileMassUnit),
+        maxZeroFuelMass:
+          catDef.maxZeroFuelMass !== null
+            ? normalizeMassToKg(catDef.maxZeroFuelMass, profileMassUnit)
+            : null,
+        envelope: catDef.envelope.map((p) => ({
+          mass: normalizeMassToKg(p.mass, profileMassUnit),
+          armOrMoment: normalizeArmOrMoment(p.armOrMoment),
+        })),
         graphType: catDef.graphType,
         fuelStations: this.availableStations
           .filter((_s) => {
@@ -435,15 +474,33 @@ export const useMassBalanceStore = defineStore('massBalance', {
             // input must go through fuel-density conversion, not through the
             // mass-only normalizeMassToKg which silently treats 'L' as 'kg'
             // (H-002 — fuel unit confusion).
-            const rawUnit = def.unit || sourceUnit
-            const fuelUnit = isFuelQuantityUnit(rawUnit) ? rawUnit : (sourceUnit as MassUnit)
+            const rawUnit = def.unit || profileMassUnit
+            const fuelUnit = isFuelQuantityUnit(rawUnit)
+              ? rawUnit
+              : (profileMassUnit as MassUnit)
             const permissible = ft.permissibleFuelTypes
-            const armUnit = 'm' as ArmUnit
+
+            // Fail-closed: if the tank's first permissible fuel type is not
+            // canonical, the density used would be the silent fallback. Warn.
+            const primaryFuel = permissible[0]
+            if (primaryFuel === undefined || !isKnownFuelType(primaryFuel)) {
+              fuelFallbackNotes.push({
+                id: 'WARN-FE-001',
+                severity: 'WARNING',
+                message: `Unknown fuel type${primaryFuel ? ` "${primaryFuel}"` : ''} — using conservative fallback density; verify fuel mass`,
+                context: 'FuelEndurance.Density',
+                persistent: false,
+                dismissible: true,
+              })
+            }
+
             return {
               index: s.index,
               mass: normalizeFuelQuantityToKg(s.weight, fuelUnit, permissible),
               arm: def.arm !== null ? normalizeArmToM(def.arm, armUnit) : null,
-              armLookup: def.armLookup,
+              armLookup: normalizeArmLookup(def.armLookup, (v) =>
+                normalizeFuelQuantityToKg(v, fuelUnit, permissible),
+              ),
               unusableFuel: normalizeFuelQuantityToKg(ft.unusableFuel, fuelUnit, permissible),
               burnSequences: ft.burnSequences,
             }
@@ -464,6 +521,43 @@ export const useMassBalanceStore = defineStore('massBalance', {
         }
         this.notifications = draftProfileWarning ? [draftProfileWarning, crit] : [crit]
         this.lastResult = null
+        return
+      }
+
+      // @IMP-MB-STORE-022@ (FROM: @REQ-SYS-012@, @REQ-UI-008@)
+      // Fail-closed on adapter validation failure (TECH-004). The adapter
+      // returns `success: false` with NaN-filled CgPoints; if we assigned that
+      // to `lastResult` the UI would render "NaN kg" to the pilot, masking the
+      // failure. Take the notifications path and NEVER set `lastResult` from a
+      // failed compute. The error/warning violations still surface so the state
+      // machine resolves to ERROR_CRITICAL / WARNING (never VERIFIED_SAFE).
+      if (!result.success) {
+        const failureNotes = result.violations.map((v): Notification =>
+          v.type === 'INVALID_INPUT' && v.code === 'OUT_OF_RANGE'
+            ? {
+                id: 'WARN-UI-001',
+                severity: 'WARNING',
+                message: `${v.field ?? 'Input'} is out of standard operational range`,
+                context: 'MassBalance.Validation',
+                persistent: false,
+                dismissible: true,
+              }
+            : {
+                id: 'ERR-SYS-001',
+                severity: 'ERROR',
+                message: `Invalid input: ${v.field ?? 'unknown'} (${v.code ?? 'validation failed'})`,
+                context: 'MassBalance.Validation',
+                persistent: false,
+                dismissible: true,
+              },
+        )
+        this.notifications = [
+          ...(draftProfileWarning ? [draftProfileWarning] : []),
+          ...fuelFallbackNotes,
+          ...failureNotes,
+        ]
+        this.lastResult = null
+        this._updateStationErrorFlags(result.violations)
         return
       }
 
@@ -561,9 +655,11 @@ export const useMassBalanceStore = defineStore('massBalance', {
         }
       })
 
-      this.notifications = draftProfileWarning
-        ? [draftProfileWarning, ...violationNotes]
-        : violationNotes
+      this.notifications = [
+        ...(draftProfileWarning ? [draftProfileWarning] : []),
+        ...fuelFallbackNotes,
+        ...violationNotes,
+      ]
 
       this.lastResult = result
 

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -12,6 +12,8 @@ import InputGroupCard from '@/modules/mass-balance/components/InputGroupCard.vue
 import MassStationInput from '@/modules/mass-balance/components/MassStationInput.vue'
 import CGEnvelopeChart from '@/modules/mass-balance/components/CGEnvelopeChart.vue'
 import ResultSummary from '@/modules/mass-balance/components/ResultSummary.vue'
+import ConfirmDialog from '@/shared/components/ConfirmDialog.vue'
+import UndoToast from '@/shared/components/UndoToast.vue'
 
 // @IMP-MB-UI-FLEET-001@ (FROM: @REQ-AC-001@, @REQ-MB-002@, @UJ-F-002@)
 
@@ -308,6 +310,16 @@ const stations = computed(() => store.availableStations)
 const notifications = computed(() => store.notifications)
 const lastResult = computed(() => store.lastResult)
 
+// UX-002: one-tap preset weights for occupant (non-fuel) stations. Fuel tanks
+// are scrubbed via their slider, so they get no presets. Presets are unit-aware
+// so an imperial profile sees pound figures.
+function presetsForStation(stationIndex: number): readonly number[] {
+  const lp = store.aircraft?.loadPoints[stationIndex]
+  if (!lp || lp.fuelTank) return []
+  const isImperial = lp.unit?.toLowerCase() === 'lb'
+  return isImperial ? [120, 160, 200] : [55, 70, 85]
+}
+
 const aircraftLabel = computed(() => {
   if (!store.aircraft) return ''
   return `${store.aircraft.registration} — ${store.aircraft.manufacturer} ${store.aircraft.model}`
@@ -409,8 +421,48 @@ function onCategoryChange(category: string): void {
   store.changeCertificationCategory(category)
 }
 
+// ─── UX-004: confirm-then-undo Reset Payload ──────────────────────────────
+// @IMP-MB-UI-FLEET-002@ (FROM: @REQ-UI-018@)
+//
+// A single tap on Reset Payload wipes every station weight — catastrophic
+// workload at a just-loaded, engine-running aircraft. Gate it behind a confirm
+// carrying the discard count, then offer a short undo window that restores the
+// captured pre-reset weights via the public updateStationWeight action.
+
+const showResetConfirm = ref(false)
+const resetSnapshot = ref<{ index: number; weight: number }[] | null>(null)
+
+/** Stations the pilot has actually entered a non-default weight for. */
+const resetCandidateCount = computed(
+  () => stations.value.filter((s) => s.touched && s.weight > 0).length,
+)
+
 function onResetPayload(): void {
+  showResetConfirm.value = true
+}
+
+function onCancelReset(): void {
+  showResetConfirm.value = false
+}
+
+function onConfirmReset(): void {
+  showResetConfirm.value = false
+  // Snapshot before wiping so undo can restore the exact prior load.
+  resetSnapshot.value = stations.value.map((s) => ({ index: s.index, weight: s.weight }))
   store.resetPayload()
+}
+
+function onUndoReset(): void {
+  const snapshot = resetSnapshot.value
+  resetSnapshot.value = null
+  if (!snapshot) return
+  for (const s of snapshot) {
+    store.updateStationWeight(s.index, s.weight)
+  }
+}
+
+function onDismissResetUndo(): void {
+  resetSnapshot.value = null
 }
 
 function onAircraftSelected(event: Event): void {
@@ -679,6 +731,7 @@ function onAircraftSelected(event: Event): void {
                 :max-capacity="store.aircraft?.loadPoints[station.index]?.fuelTank
                   ? (store.aircraft?.loadPoints[station.index]?.operationalLimit ?? null)
                   : null"
+                :presets="presetsForStation(station.index)"
                 :disabled="viewModel.inputsDisabled"
                 @update:weight="onStationWeightChange(station.index, $event)"
               />
@@ -770,6 +823,31 @@ function onAircraftSelected(event: Event): void {
       <strong>Advisory only</strong> — verify all results against the official POH/AFM before
       flight. This tool is not a certified aviation device.
     </div>
+
+    <!-- UX-004: Reset Payload confirmation + undo -->
+    <ConfirmDialog
+      :open="showResetConfirm"
+      title="Reset payload?"
+      :message="
+        resetCandidateCount > 0
+          ? `Discard ${resetCandidateCount} entered ${resetCandidateCount === 1 ? 'weight' : 'weights'} and reset all stations to POH defaults? You can undo for a few seconds.`
+          : 'Reset all stations to POH defaults?'
+      "
+      confirm-label="Reset"
+      cancel-label="Keep"
+      variant="danger"
+      @confirm="onConfirmReset"
+      @cancel="onCancelReset"
+    />
+
+    <UndoToast
+      :open="resetSnapshot !== null"
+      message="Payload reset"
+      action-label="Undo"
+      :duration="5000"
+      @undo="onUndoReset"
+      @dismiss="onDismissResetUndo"
+    />
 
   </div>
 </template>

--- a/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.spec.ts
+++ b/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.spec.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+// @UT-MB-VIEW-021@ (FROM: @IMP-MB-UI-FLEET-002@, @IMP-MB-UI-008@)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { mount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
@@ -301,7 +303,7 @@ describe('MassBalanceView integration', () => {
     expect(wrapper.text()).toContain('Mass & Balance verified')
   })
 
-  it('calls resetPayload from Reset Payload action and keeps results visible', async () => {
+  it('calls resetPayload after confirming the Reset Payload action and keeps results visible', async () => {
     const store = useMassBalanceStore()
     store.loadProfile(mockProfile)
     const resetSpy = vi.spyOn(store, 'resetPayload')
@@ -310,14 +312,20 @@ describe('MassBalanceView integration', () => {
     await wrapper.find('input#station-0').setValue('80')
     expect(store.uiState).toBe('VERIFIED_SAFE')
 
+    // UX-004: the tap now opens a confirm dialog; reset only fires on confirm.
     await wrapper
       .findAll('button')
       .find((b) => b.text() === 'Reset Payload')!
       .trigger('click')
+    expect(resetSpy).not.toHaveBeenCalled()
+    ;(document.querySelector('.confirm-dialog__btn--danger') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
 
     expect(resetSpy).toHaveBeenCalledTimes(1)
     expect(store.uiState).toBe('VERIFIED_SAFE')
     expect(store.lastResult).not.toBeNull()
+
+    document.body.innerHTML = ''
   })
 
   it('does not render a Verify All button (verification not applicable to M&B inputs)', () => {
@@ -369,5 +377,87 @@ describe('MassBalanceView integration', () => {
 
     expect(categorySpy).toHaveBeenCalledWith('Utility')
     expect(store.activeCategory).toBe('Utility')
+  })
+})
+
+// ─── UX-004: confirm-then-undo Reset Payload ───────────────────────────────
+
+describe('MassBalanceView — Reset Payload confirm + undo (UX-004)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockedCalculate.mockReturnValue(buildSuccessResult())
+    seedFleet([toFleetProfile(mockProfile)])
+  })
+
+  afterEach(() => {
+    // ConfirmDialog + UndoToast teleport to <body>.
+    document.body.innerHTML = ''
+  })
+
+  function findResetButton(wrapper: ReturnType<typeof mountView>) {
+    return wrapper.findAll('button').find((b) => b.text() === 'Reset Payload')!
+  }
+
+  it('does not reset on tap — opens an in-app confirmation with a discard count', async () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+    const resetSpy = vi.spyOn(store, 'resetPayload')
+    const wrapper = mountView()
+
+    await wrapper.find('input#station-0').setValue('80')
+    await findResetButton(wrapper).trigger('click')
+
+    expect(resetSpy).not.toHaveBeenCalled()
+    const dialog = document.querySelector('.confirm-dialog')
+    expect(dialog).not.toBeNull()
+    // One station carries an entered weight → "discard 1 ... weight".
+    expect(dialog?.textContent).toContain('Discard 1')
+  })
+
+  it('cancelling the confirmation leaves weights untouched', async () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+    const resetSpy = vi.spyOn(store, 'resetPayload')
+    const wrapper = mountView()
+
+    await wrapper.find('input#station-0').setValue('80')
+    await findResetButton(wrapper).trigger('click')
+    ;(document.querySelector('.confirm-dialog__btn--cancel') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+
+    expect(resetSpy).not.toHaveBeenCalled()
+    expect(store.stations[0]!.weight).toBe(80)
+    expect(document.querySelector('.confirm-dialog')).toBeNull()
+  })
+
+  it('confirming resets the payload and surfaces an undo toast', async () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+    const wrapper = mountView()
+
+    await wrapper.find('input#station-0').setValue('80')
+    await findResetButton(wrapper).trigger('click')
+    ;(document.querySelector('.confirm-dialog__btn--danger') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+
+    expect(store.stations[0]!.weight).toBe(0)
+    expect(document.querySelector('.undo-toast')).not.toBeNull()
+  })
+
+  it('undo restores the pre-reset station weights', async () => {
+    const store = useMassBalanceStore()
+    store.loadProfile(mockProfile)
+    const wrapper = mountView()
+
+    await wrapper.find('input#station-0').setValue('80')
+    await findResetButton(wrapper).trigger('click')
+    ;(document.querySelector('.confirm-dialog__btn--danger') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+    expect(store.stations[0]!.weight).toBe(0)
+    ;(document.querySelector('.undo-toast__action') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+
+    expect(store.stations[0]!.weight).toBe(80)
   })
 })

--- a/frontend/src/shared/components/ConfirmDialog.vue
+++ b/frontend/src/shared/components/ConfirmDialog.vue
@@ -1,0 +1,209 @@
+<!-- @IMP-UI-SHARED-003@ (FROM: @REQ-UI-011@) -->
+<template>
+  <!--
+    Accessible, dark-mode-safe confirmation modal — the in-app replacement for
+    the native `window.confirm()` used on destructive cockpit actions. A native
+    confirm renders unstyled, ignores the dark theme, reads poorly on a screen
+    reader, and is dismissable by the iOS back-gesture. This modal:
+      • traps and restores focus (focus lands on the confirm action),
+      • labels itself via aria-labelledby / aria-describedby,
+      • closes on Escape and on backdrop tap (treated as cancel),
+      • paints from the same design tokens as the rest of the shell.
+  -->
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="confirm-dialog__backdrop"
+      @click.self="onCancel"
+    >
+      <div
+        ref="dialogEl"
+        class="confirm-dialog"
+        role="alertdialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        :aria-describedby="messageId"
+        @keydown.esc.prevent="onCancel"
+      >
+        <h2 :id="titleId" class="confirm-dialog__title">{{ title }}</h2>
+        <p :id="messageId" class="confirm-dialog__message">{{ message }}</p>
+
+        <div class="confirm-dialog__actions">
+          <button
+            ref="cancelBtn"
+            type="button"
+            class="confirm-dialog__btn confirm-dialog__btn--cancel"
+            @click="onCancel"
+          >
+            {{ cancelLabel }}
+          </button>
+          <button
+            ref="confirmBtn"
+            type="button"
+            class="confirm-dialog__btn"
+            :class="
+              variant === 'danger'
+                ? 'confirm-dialog__btn--danger'
+                : 'confirm-dialog__btn--primary'
+            "
+            @click="onConfirm"
+          >
+            {{ confirmLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// @IMP-UI-SHARED-004@ (FROM: @REQ-UI-011@)
+import { nextTick, ref, watch } from 'vue'
+
+let uid = 0
+const localId = `confirm-${++uid}`
+const titleId = `${localId}-title`
+const messageId = `${localId}-message`
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean
+    title: string
+    message: string
+    confirmLabel?: string
+    cancelLabel?: string
+    /** `danger` paints the confirm action in the critical colour. */
+    variant?: 'danger' | 'primary'
+  }>(),
+  {
+    confirmLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+    variant: 'danger',
+  },
+)
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+
+const dialogEl = ref<HTMLElement | null>(null)
+const confirmBtn = ref<HTMLButtonElement | null>(null)
+const cancelBtn = ref<HTMLButtonElement | null>(null)
+let lastFocused: HTMLElement | null = null
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      lastFocused = document.activeElement as HTMLElement | null
+      await nextTick()
+      // Land focus on Cancel — the non-destructive default — so a stray
+      // Enter/Space under turbulence doesn't trigger the destructive action.
+      cancelBtn.value?.focus()
+    } else {
+      lastFocused?.focus?.()
+      lastFocused = null
+    }
+  },
+)
+
+function onConfirm(): void {
+  emit('confirm')
+}
+
+function onCancel(): void {
+  emit('cancel')
+}
+</script>
+
+<style scoped>
+.confirm-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 400; /* above app header (200) + sticky strips (150) */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4, 1rem);
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.confirm-dialog {
+  width: 100%;
+  max-width: 28rem;
+  padding: var(--space-5, 1.5rem);
+  border-radius: var(--radius-xl, 12px);
+  background: var(--color-surface-card, var(--color-surface, #fff));
+  color: var(--color-text-primary, #212121);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--color-border, #e5e7eb);
+}
+
+.confirm-dialog__title {
+  margin: 0 0 var(--space-2, 0.5rem);
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: 700;
+}
+
+.confirm-dialog__message {
+  margin: 0 0 var(--space-5, 1.5rem);
+  font-size: var(--text-sm, 0.875rem);
+  line-height: 1.5;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3, 0.75rem);
+  flex-wrap: wrap;
+}
+
+.confirm-dialog__btn {
+  min-height: 44px; /* WCAG 2.2 AAA touch target — gloved cockpit use */
+  padding: var(--space-2, 0.5rem) var(--space-5, 1.5rem);
+  border-radius: var(--radius-md, 6px);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background var(--transition-fast, 150ms ease),
+    border-color var(--transition-fast, 150ms ease),
+    color var(--transition-fast, 150ms ease);
+}
+
+.confirm-dialog__btn:focus-visible {
+  outline: 2px solid var(--color-focus, var(--color-primary, #3b82f6));
+  outline-offset: 2px;
+}
+
+.confirm-dialog__btn--cancel {
+  background: var(--color-surface-alt, #f3f4f6);
+  color: var(--color-text-primary, #212121);
+  border-color: var(--color-border, #e5e7eb);
+}
+
+.confirm-dialog__btn--cancel:hover {
+  background: var(--color-surface-hover, #e5e7eb);
+}
+
+.confirm-dialog__btn--danger {
+  background: var(--color-critical, #dc2626);
+  color: var(--neutral-0, #fff);
+}
+
+.confirm-dialog__btn--danger:hover {
+  background: var(--color-critical-hover, var(--color-critical, #b91c1c));
+}
+
+.confirm-dialog__btn--primary {
+  background: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #fff);
+}
+
+.confirm-dialog__btn--primary:hover {
+  background: var(--color-primary-hover, var(--color-primary, #2563eb));
+}
+</style>

--- a/frontend/src/shared/components/UndoToast.vue
+++ b/frontend/src/shared/components/UndoToast.vue
@@ -1,0 +1,198 @@
+<!-- @IMP-UI-SHARED-005@ (FROM: @REQ-UI-011@) -->
+<template>
+  <!--
+    Transient "undo" toast for recoverable destructive actions (delete aircraft,
+    reset payload). After the action commits, this surfaces a short-lived bar
+    with an UNDO control; if the pilot taps it within the window the parent
+    restores the prior state. Auto-dismisses after `duration` ms.
+
+    A live-region (role="status") so a screen reader announces both the message
+    and the recovery affordance. The countdown is purely cosmetic.
+  -->
+  <Teleport to="body">
+    <Transition name="undo-toast">
+      <div
+        v-if="open"
+        class="undo-toast"
+        role="status"
+        aria-live="polite"
+      >
+        <span class="undo-toast__message">{{ message }}</span>
+        <button
+          ref="undoBtn"
+          type="button"
+          class="undo-toast__action"
+          @click="onUndo"
+        >
+          {{ actionLabel }}
+        </button>
+        <button
+          type="button"
+          class="undo-toast__dismiss"
+          :aria-label="dismissLabel"
+          @click="onDismiss"
+        >
+          &times;
+        </button>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// @IMP-UI-SHARED-006@ (FROM: @REQ-UI-011@)
+import { onBeforeUnmount, watch } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean
+    message: string
+    actionLabel?: string
+    dismissLabel?: string
+    /** Auto-dismiss window in ms. Audit UX-001 specifies 5–10s. */
+    duration?: number
+  }>(),
+  {
+    actionLabel: 'Undo',
+    dismissLabel: 'Dismiss',
+    duration: 7000,
+  },
+)
+
+const emit = defineEmits<{
+  /** Pilot tapped UNDO within the window. */
+  undo: []
+  /** Window elapsed or pilot dismissed — the action is now permanent. */
+  dismiss: []
+}>()
+
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function clearTimer(): void {
+  if (timer !== null) {
+    clearTimeout(timer)
+    timer = null
+  }
+}
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    clearTimer()
+    if (isOpen) {
+      timer = setTimeout(() => {
+        emit('dismiss')
+      }, props.duration)
+    }
+  },
+  { immediate: true },
+)
+
+function onUndo(): void {
+  clearTimer()
+  emit('undo')
+}
+
+function onDismiss(): void {
+  clearTimer()
+  emit('dismiss')
+}
+
+onBeforeUnmount(clearTimer)
+</script>
+
+<style scoped>
+.undo-toast {
+  position: fixed;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
+  transform: translateX(-50%);
+  z-index: 420; /* above the confirm dialog backdrop */
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 0.75rem);
+  max-width: calc(100vw - 2rem);
+  padding: var(--space-3, 0.75rem) var(--space-4, 1rem);
+  border-radius: var(--radius-lg, 10px);
+  background: var(--color-surface-inverse, #1f2933);
+  color: var(--color-text-inverse, #f8fafc);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.undo-toast__message {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 500;
+}
+
+.undo-toast__action {
+  min-height: 36px;
+  padding: var(--space-1, 0.25rem) var(--space-3, 0.75rem);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md, 6px);
+  background: transparent;
+  color: var(--color-primary-on-dark, #93c5fd);
+  font: inherit;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.undo-toast__action:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.undo-toast__action:focus-visible {
+  outline: 2px solid var(--color-primary-on-dark, #93c5fd);
+  outline-offset: 2px;
+}
+
+.undo-toast__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--radius-full, 999px);
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.undo-toast__dismiss:hover {
+  opacity: 1;
+}
+
+.undo-toast__dismiss:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+/* Enter/leave transition — slide up + fade. */
+.undo-toast-enter-active,
+.undo-toast-leave-active {
+  transition:
+    opacity var(--transition-fast, 150ms ease),
+    transform var(--transition-fast, 150ms ease);
+}
+
+.undo-toast-enter-from,
+.undo-toast-leave-to {
+  opacity: 0;
+  transform: translate(-50%, 1rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .undo-toast-enter-active,
+  .undo-toast-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/frontend/src/shared/components/__tests__/ConfirmDialog.spec.ts
+++ b/frontend/src/shared/components/__tests__/ConfirmDialog.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for ConfirmDialog.vue — the in-app replacement for native
+ * window.confirm() on destructive cockpit actions (UX-001 / UX-004).
+ *
+ * @see frontend/src/shared/components/ConfirmDialog.vue
+ */
+
+// @UT-UI-SHARED-001@ (FROM: @IMP-UI-SHARED-003@, @IMP-UI-SHARED-004@)
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ConfirmDialog from '../ConfirmDialog.vue'
+
+// Teleport renders to document.body — clean it between tests.
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function mountDialog(props: Record<string, unknown> = {}) {
+  return mount(ConfirmDialog, {
+    attachTo: document.body,
+    props: {
+      open: true,
+      title: 'Delete aircraft profile?',
+      message: 'Delete "D-EBPN"? You can undo for a few seconds.',
+      ...props,
+    },
+  })
+}
+
+describe('ConfirmDialog', () => {
+  it('does not render anything when closed', () => {
+    mountDialog({ open: false })
+    expect(document.querySelector('.confirm-dialog')).toBeNull()
+  })
+
+  it('renders title and message when open', () => {
+    mountDialog()
+    expect(document.querySelector('.confirm-dialog__title')?.textContent).toContain(
+      'Delete aircraft profile?',
+    )
+    expect(document.querySelector('.confirm-dialog__message')?.textContent).toContain('D-EBPN')
+  })
+
+  it('exposes an accessible alertdialog with aria-labelledby and aria-describedby', () => {
+    mountDialog()
+    const dialog = document.querySelector('.confirm-dialog')!
+    expect(dialog.getAttribute('role')).toBe('alertdialog')
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    const labelledby = dialog.getAttribute('aria-labelledby')
+    const describedby = dialog.getAttribute('aria-describedby')
+    expect(document.getElementById(labelledby!)?.classList.contains('confirm-dialog__title')).toBe(
+      true,
+    )
+    expect(
+      document.getElementById(describedby!)?.classList.contains('confirm-dialog__message'),
+    ).toBe(true)
+  })
+
+  it('emits confirm when the confirm button is clicked', async () => {
+    const wrapper = mountDialog()
+    const confirmBtn = document.querySelector('.confirm-dialog__btn--danger') as HTMLButtonElement
+    confirmBtn.click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('emits cancel when the cancel button is clicked', async () => {
+    const wrapper = mountDialog()
+    const cancelBtn = document.querySelector('.confirm-dialog__btn--cancel') as HTMLButtonElement
+    cancelBtn.click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('emits cancel when the backdrop is tapped', async () => {
+    const wrapper = mountDialog()
+    const backdrop = document.querySelector('.confirm-dialog__backdrop') as HTMLElement
+    backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+  })
+
+  it('renders the danger variant by default and a primary variant when requested', () => {
+    mountDialog()
+    expect(document.querySelector('.confirm-dialog__btn--danger')).not.toBeNull()
+    document.body.innerHTML = ''
+    mountDialog({ variant: 'primary' })
+    expect(document.querySelector('.confirm-dialog__btn--primary')).not.toBeNull()
+    expect(document.querySelector('.confirm-dialog__btn--danger')).toBeNull()
+  })
+
+  it('uses custom confirm and cancel labels', () => {
+    mountDialog({ confirmLabel: 'Delete', cancelLabel: 'Keep' })
+    expect(document.querySelector('.confirm-dialog__btn--danger')?.textContent).toContain('Delete')
+    expect(document.querySelector('.confirm-dialog__btn--cancel')?.textContent).toContain('Keep')
+  })
+})

--- a/frontend/src/shared/components/__tests__/UndoToast.spec.ts
+++ b/frontend/src/shared/components/__tests__/UndoToast.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for UndoToast.vue — the transient undo affordance for recoverable
+ * destructive actions (UX-001 delete, UX-004 reset payload).
+ *
+ * @see frontend/src/shared/components/UndoToast.vue
+ */
+
+// @UT-UI-SHARED-002@ (FROM: @IMP-UI-SHARED-005@, @IMP-UI-SHARED-006@)
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import UndoToast from '../UndoToast.vue'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  document.body.innerHTML = ''
+})
+
+function mountToast(props: Record<string, unknown> = {}) {
+  return mount(UndoToast, {
+    attachTo: document.body,
+    props: {
+      open: true,
+      message: 'Deleted "D-EBPN"',
+      ...props,
+    },
+  })
+}
+
+describe('UndoToast', () => {
+  it('does not render when closed', () => {
+    mountToast({ open: false })
+    expect(document.querySelector('.undo-toast')).toBeNull()
+  })
+
+  it('renders the message and an undo action when open', () => {
+    mountToast()
+    expect(document.querySelector('.undo-toast')?.textContent).toContain('Deleted "D-EBPN"')
+    expect(document.querySelector('.undo-toast__action')?.textContent).toContain('Undo')
+  })
+
+  it('uses a polite live region so screen readers announce it', () => {
+    mountToast()
+    const toast = document.querySelector('.undo-toast')!
+    expect(toast.getAttribute('role')).toBe('status')
+    expect(toast.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('emits undo when the undo action is clicked', async () => {
+    const wrapper = mountToast()
+    ;(document.querySelector('.undo-toast__action') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('undo')).toHaveLength(1)
+  })
+
+  it('emits dismiss when the dismiss control is clicked', async () => {
+    const wrapper = mountToast()
+    ;(document.querySelector('.undo-toast__dismiss') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+  })
+
+  it('auto-emits dismiss after the duration window elapses', async () => {
+    const wrapper = mountToast({ duration: 5000 })
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+    vi.advanceTimersByTime(5000)
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+  })
+
+  it('does not auto-dismiss before the window elapses', () => {
+    const wrapper = mountToast({ duration: 8000 })
+    vi.advanceTimersByTime(7999)
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+  })
+
+  it('cancels the auto-dismiss timer once the pilot taps undo', async () => {
+    const wrapper = mountToast({ duration: 5000 })
+    ;(document.querySelector('.undo-toast__action') as HTMLButtonElement).click()
+    await wrapper.vm.$nextTick()
+    vi.advanceTimersByTime(10000)
+    // Only the undo fired; the auto-dismiss timer was cleared.
+    expect(wrapper.emitted('undo')).toHaveLength(1)
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+  })
+})

--- a/frontend/src/shared/utils/__tests__/logger.spec.ts
+++ b/frontend/src/shared/utils/__tests__/logger.spec.ts
@@ -210,3 +210,65 @@ describe('createLogger', () => {
     expect(output.data.momentTable[100]).toBe('[...+100 items]')
   })
 })
+
+// DP-011 — production console gating. DEBUG/INFO must be suppressed in
+// production builds; WARN/ERROR must always reach the console.
+describe('createLogger — production gating (DP-011)', () => {
+  let consoleSpy: {
+    info: ReturnType<typeof vi.spyOn>
+    warn: ReturnType<typeof vi.spyOn>
+    error: ReturnType<typeof vi.spyOn>
+    debug: ReturnType<typeof vi.spyOn>
+  }
+
+  beforeEach(() => {
+    consoleSpy = {
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+    }
+    // Simulate a production build.
+    vi.stubEnv('PROD', true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  // @UT-SYS-SHARED-016@ (FROM: @IMP-SYS-SHARED-002@)
+  it('suppresses debug() output in production', () => {
+    const logger = createLogger('Prod')
+    logger.debug('debug message')
+    expect(consoleSpy.debug).not.toHaveBeenCalled()
+  })
+
+  // @UT-SYS-SHARED-017@ (FROM: @IMP-SYS-SHARED-002@)
+  it('suppresses info() output in production', () => {
+    const logger = createLogger('Prod')
+    logger.info('info message')
+    expect(consoleSpy.info).not.toHaveBeenCalled()
+  })
+
+  // @UT-SYS-SHARED-018@ (FROM: @IMP-SYS-SHARED-002@)
+  it('suppresses telemetryTrace() (INFO level) output in production', () => {
+    const logger = createLogger('Prod')
+    logger.telemetryTrace({ inputs: { mass: 80 }, outputs: { cg: 2.3 } })
+    expect(consoleSpy.info).not.toHaveBeenCalled()
+  })
+
+  // @UT-SYS-SHARED-019@ (FROM: @IMP-SYS-SHARED-002@)
+  it('still emits warn() in production', () => {
+    const logger = createLogger('Prod')
+    logger.warn('warning message')
+    expect(consoleSpy.warn).toHaveBeenCalledOnce()
+  })
+
+  // @UT-SYS-SHARED-020@ (FROM: @IMP-SYS-SHARED-002@)
+  it('still emits error() in production', () => {
+    const logger = createLogger('Prod')
+    logger.error('error message')
+    expect(consoleSpy.error).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/shared/utils/logger.ts
+++ b/frontend/src/shared/utils/logger.ts
@@ -69,9 +69,33 @@ function formatEntry(entry: LogEntry): LogEntry {
   }
 }
 
+/**
+ * DP-011 — diagnostic console gating.
+ *
+ * In production builds (`import.meta.env.PROD`) DEBUG and INFO output is
+ * suppressed: these levels carry verbose telemetry that may echo pilot-entered
+ * M&B inputs and aircraft data, and have no place on a shipped console. WARN and
+ * ERROR are always emitted — they carry operational and safety-relevant
+ * diagnostics. In development (dev server, tests) all levels are emitted.
+ *
+ * Gating lives in the logger rather than the bundler because Vite 8's default
+ * minifier (oxc) ignores esbuild's `pure`/`drop` options, so a build-time strip
+ * would silently no-op.
+ *
+ * NOTE: broader PII redaction of WARN/ERROR payloads (DP-004) is deferred to
+ * issue #263 and intentionally NOT implemented here.
+ */
+function isLevelEnabled(level: LogLevel): boolean {
+  if (level === 'WARN' || level === 'ERROR') return true
+  // DEBUG / INFO: suppressed in production builds only.
+  return !import.meta.env.PROD
+}
+
 // @IMP-SYS-SHARED-002@ (FROM: @DES-ARCH-001@)
 export function createLogger(context: string): Logger {
   const log = (level: LogLevel, message: string, data?: unknown): void => {
+    if (!isLevelEnabled(level)) return
+
     const entry = formatEntry({
       timestamp: new Date().toISOString(),
       level,

--- a/frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
@@ -1,12 +1,11 @@
-# @E2E-AC-001@ (FROM: @UJ-A-001@)
 @wip @phase-A @fleet @wizard
 Feature: Aircraft creation wizard
   As a pilot
   I want to create a new aircraft profile via a guided 5-step wizard
   So that my Mass & Balance calculations use correct limits from my POH/AFM
 
-  # @E2E-AC-001@ (FROM: @UJ-A-001@)
-  @smoke @E2E-AC-001
+  # @E2E-A-002@ (FROM: @UJ-A-001@)
+  @UJ-A-001 @phase-A @e2e @smoke @E2E-A-002
   Scenario: Pilot completes all 5 wizard steps and sees the new aircraft on the Fleet page with a Draft badge
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"
@@ -42,8 +41,8 @@ Feature: Aircraft creation wizard
     Then the pilot is back on the Fleet page
     And the aircraft "D-EBPN" is listed with a "Draft" status badge
 
-  # @E2E-AC-002@ (FROM: @UJ-A-001@)
-  @E2E-AC-002
+  # @E2E-A-003@ (FROM: @UJ-A-001@)
+  @UJ-A-001 @phase-A @e2e @E2E-A-003
   Scenario: Pilot cannot advance past Step 2 with fewer than 4 envelope points — Continue is disabled and an error is visible
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"
@@ -59,8 +58,8 @@ Feature: Aircraft creation wizard
     When the pilot adds a fourth envelope point
     Then the "Continue" button is enabled
 
-  # @E2E-AC-003@ (FROM: @UJ-A-001@)
-  @E2E-AC-003
+  # @E2E-A-004@ (FROM: @UJ-A-001@)
+  @UJ-A-001 @phase-A @e2e @E2E-A-004
   Scenario: Owner ID field is not present anywhere in the wizard — system generates it automatically (REQ-AD-019)
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"

--- a/frontend/tests/e2e/features/phase-a-fleet-management/decimal-input-precision.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/decimal-input-precision.feature
@@ -1,4 +1,3 @@
-# @E2E-AC-004@ (FROM: @UJ-A-001@)
 @wip @phase-A @fleet @wizard @decimal
 Feature: Decimal input precision in the aircraft wizard
   As a pilot
@@ -13,8 +12,8 @@ Feature: Decimal input precision in the aircraft wizard
     And the pilot sets MTOM to "630"
     And the pilot clicks "Continue"
 
-  # @E2E-AC-004@ (FROM: @UJ-A-001@)
-  @E2E-AC-004
+  # @E2E-A-005@ (FROM: @UJ-A-001@)
+  @UJ-A-001 @phase-A @e2e @E2E-A-005
   Scenario: High-precision decimal values survive the Weighing Reports step intact
     When the pilot types "433.75" into the BEM field and tabs away
     Then the BEM field retains the value "433.75"
@@ -26,8 +25,8 @@ Feature: Decimal input precision in the aircraft wizard
     And the pilot adds a seat station named "Pilot" with arm "1.877"
     Then the arm field for station "Pilot" retains the value "1.877"
 
-  # @E2E-AC-005@ (FROM: @UJ-A-001@)
-  @E2E-AC-005
+  # @E2E-A-006@ (FROM: @UJ-A-001@)
+  @UJ-A-001 @phase-A @e2e @E2E-A-006
   Scenario: European comma decimal separator is accepted and treated identically to a period
     When the pilot types "433,75" into the BEM field and tabs away
     Then the BEM field retains the value "433.75"

--- a/frontend/tests/e2e/features/phase-a-fleet-management/electric-aircraft-wizard.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/electric-aircraft-wizard.feature
@@ -1,4 +1,3 @@
-# @E2E-AC-ELECTRIC-001@ (FROM: @UJ-A-004@, @REQ-AD-020@, @REQ-AD-021@, @REQ-UI-021@, @REQ-UI-022@)
 @wip @phase-A @fleet @wizard @electric
 Feature: Battery-electric aircraft wizard (Pipistrel Velis Electro)
   As a pilot / flight-school instructor
@@ -6,8 +5,8 @@ Feature: Battery-electric aircraft wizard (Pipistrel Velis Electro)
   So that the aircraft is represented on its own terms (battery pack, reserve floor)
   And so that the combustion UX for the rest of my fleet is unchanged
 
-  # @E2E-AC-ELECTRIC-001@ (FROM: @UJ-A-004@)
-  @smoke @E2E-AC-ELECTRIC-001
+  # @E2E-A-007@ (FROM: @UJ-A-004@)
+  @UJ-A-004 @phase-A @e2e @smoke @E2E-A-007
   Scenario: Pilot creates a Pipistrel Velis Electro, the wizard flips to electric and fuel UI is hidden
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"
@@ -46,8 +45,8 @@ Feature: Battery-electric aircraft wizard (Pipistrel Velis Electro)
     Then the pilot is back on the Fleet page
     And the aircraft "OK-VVV" is listed with a "Draft" status badge
 
-  # @E2E-AC-ELECTRIC-002@ (FROM: @UJ-A-004@, @REQ-AD-020@)
-  @E2E-AC-ELECTRIC-002
+  # @E2E-A-008@ (FROM: @UJ-A-004@)
+  @UJ-A-004 @phase-A @e2e @E2E-A-008
   Scenario: Combustion wizard is unchanged — fuel tank button remains visible for a Tecnam P2008 JC
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
@@ -1,12 +1,11 @@
-# @E2E-MB-001@ (FROM: @UJ-F-002@)
-@wip @phase-B @fleet @flight-prep
+@phase-B @fleet @flight-prep
 Feature: Fleet-based aircraft selection on the Flight Prep page
   As a pilot
   I want the Flight Prep page to read aircraft from my personal fleet
   So that only my own aircraft are available for Mass & Balance planning
 
-  # @E2E-MB-001@ (FROM: @UJ-F-002@)
-  @E2E-MB-001
+  # @E2E-B-008@ (FROM: @UJ-B-005@)
+  @UJ-B-005 @phase-B @e2e @E2E-B-008
   Scenario: Empty fleet shows "No aircraft" CTA that navigates to the wizard
     Given the pilot opens the Flight Prep page on a fresh browser session
     Then the "No aircraft in your fleet yet" message is visible
@@ -15,8 +14,10 @@ Feature: Fleet-based aircraft selection on the Flight Prep page
     When the pilot clicks the "Add Aircraft" button on the Flight Prep page
     Then the pilot is taken to the aircraft creation wizard
 
-  # @E2E-MB-002@ (FROM: @UJ-F-002@)
-  @smoke @E2E-MB-002
+  # @E2E-B-009@ (FROM: @UJ-B-005@)
+  # @wip: depends on the wizard-creation flow (completeWizardFlow helper), which is
+  # not yet stable end-to-end — un-wip together with aircraft-wizard-creation.feature.
+  @wip @UJ-B-005 @phase-B @e2e @E2E-B-009
   Scenario: Aircraft added via wizard appears in the Flight Prep dropdown with a [Draft] label
     Given the pilot has added an aircraft with registration "D-EBPN" via the wizard
     When the pilot navigates to the Flight Prep page
@@ -26,8 +27,8 @@ Feature: Fleet-based aircraft selection on the Flight Prep page
     When the pilot selects the "D-EBPN" aircraft from the dropdown
     Then the M&B section becomes unlocked
 
-  # @E2E-MB-003@ (FROM: @UJ-F-002@)
-  @E2E-MB-003
+  # @E2E-B-010@ (FROM: @UJ-B-005@)
+  @UJ-B-005 @phase-B @e2e @E2E-B-010
   Scenario: Hardcoded catalogue aircraft are not in the dropdown when the fleet is empty — regression against AIRCRAFT_CATALOGUE leak
     Given the pilot opens the Flight Prep page on a fresh browser session
     Then the "No aircraft in your fleet yet" message is visible

--- a/frontend/tests/e2e/features/phase-sys-pwa/offline-smoke.feature
+++ b/frontend/tests/e2e/features/phase-sys-pwa/offline-smoke.feature
@@ -1,12 +1,11 @@
-# @E2E-SYS-001@ (FROM: @UJ-SYS-001@)
-@smoke @offline @pwa @sys
+@offline @pwa @sys
 Feature: Offline-first app shell and M&B navigation
   As a pilot with no network connectivity
   I want the AeroDash app shell and M&B page to remain accessible
   So that I can perform safety-critical calculations without an internet connection
 
-  # @E2E-SYS-001@ (FROM: @UJ-SYS-001@)
-  @E2E-SYS-001 @smoke @offline
+  # @E2E-D-001@ (TECHNICAL)
+  @smoke @technical-e2e @phase-D @offline
   Scenario: App shell loads and M&B navigation works while offline
     Given the pilot loads the app while online
     When the pilot goes offline

--- a/frontend/tests/e2e/steps/aircraft-wizard.steps.ts
+++ b/frontend/tests/e2e/steps/aircraft-wizard.steps.ts
@@ -1,5 +1,5 @@
-// @E2E-AC-001@ (FROM: @UJ-A-001@)
 // Step definitions for aircraft-wizard-creation.feature and decimal-input-precision.feature
+// E2E trace tags live in the .feature file only (STC §B.3 / §3.4).
 
 import { expect } from '@playwright/test'
 import { createBdd } from 'playwright-bdd'

--- a/frontend/tests/e2e/steps/electric-aircraft-wizard.steps.ts
+++ b/frontend/tests/e2e/steps/electric-aircraft-wizard.steps.ts
@@ -1,7 +1,7 @@
-// @E2E-AC-ELECTRIC-001@ (FROM: @UJ-A-004@, @REQ-AD-020@, @REQ-AD-021@, @REQ-UI-021@, @REQ-UI-022@)
 // Step definitions for electric-aircraft-wizard.feature — powertrain selector,
 // catalogue hint auto-flip, Battery Pack step, fuel-UI suppression on Step 4,
 // and the combustion-unchanged control scenario.
+// E2E trace tags live in the .feature file only (STC §B.3 / §3.4).
 
 import { expect } from '@playwright/test'
 import { createBdd } from 'playwright-bdd'

--- a/frontend/tests/e2e/steps/flight-prep-fleet.steps.ts
+++ b/frontend/tests/e2e/steps/flight-prep-fleet.steps.ts
@@ -1,5 +1,5 @@
-// @E2E-MB-001@ (FROM: @UJ-F-002@)
 // Step definitions for fleet-based-aircraft-selection.feature
+// E2E trace tags live in the .feature file only (STC §B.3 / §3.4).
 
 import { expect } from '@playwright/test'
 import { createBdd } from 'playwright-bdd'

--- a/frontend/tests/e2e/steps/offline-smoke.steps.ts
+++ b/frontend/tests/e2e/steps/offline-smoke.steps.ts
@@ -5,7 +5,7 @@ import { createBdd } from 'playwright-bdd'
 
 const { Given, When, Then } = createBdd()
 
-// @E2E-SYS-001@ (FROM: @UJ-SYS-001@)
+// E2E trace tags live in the .feature file only (STC §B.3 / §3.4).
 
 Given('the pilot loads the app while online', async ({ page }) => {
   await page.goto('/')

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,11 +5,26 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import { VitePWA } from 'vite-plugin-pwa'
 
+// Production gate for dev-only tooling (DP-016 vue-devtools). Kept as a plain
+// boolean rather than a `defineConfig(({ command }) => …)` callback so the
+// exported config stays an object: vitest.config.ts imports this value and
+// passes it to `mergeConfig`, which throws on a callback-form config.
+//
+// `vite build` sets NODE_ENV='production'; the dev server and Vitest do not.
+//
+// NB: production console stripping (DP-011) is handled in the logger
+// (`import.meta.env.PROD`), not here — Vite 8's default minifier is oxc, which
+// ignores esbuild's `pure`/`drop` options, so a build-time strip here would be
+// silently dropped.
+const isProd = process.env.NODE_ENV === 'production'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
-    vueDevTools(),
+    // DP-016 — vue-devtools must never ship in a production bundle (it exposes
+    // component internals and store state). Enabled for dev only.
+    ...(isProd ? [] : [vueDevTools()]),
     VitePWA({
       registerType: 'prompt',
       injectRegister: 'auto',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3))
-      serve:
-        specifier: ^14.2.6
-        version: 14.2.6
       uuid:
         specifier: '>=11.1.1'
         version: 14.0.0
@@ -145,6 +142,9 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
+      serve:
+        specifier: ^14.2.6
+        version: 14.2.6
       typescript:
         specifier: ~6.0.3
         version: 6.0.3

--- a/trace/e2e/fleet-management.yaml
+++ b/trace/e2e/fleet-management.yaml
@@ -3,3 +3,38 @@ Phase A End-to-End Tests
     title: Utility category applies tighter limits and removes rear-seat loading
     files:
       - frontend/tests/e2e/features/phase-a-fleet-management/certification-category-switch.feature
+
+  E2E-A-002
+    title: Pilot completes all 5 wizard steps and sees the new aircraft on the Fleet page with a Draft badge
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
+
+  E2E-A-003
+    title: Pilot cannot advance past Step 2 with fewer than 4 envelope points
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
+
+  E2E-A-004
+    title: Owner ID field is not present anywhere in the wizard
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
+
+  E2E-A-005
+    title: High-precision decimal values survive the Weighing Reports step intact
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/decimal-input-precision.feature
+
+  E2E-A-006
+    title: European comma decimal separator is accepted and treated identically to a period
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/decimal-input-precision.feature
+
+  E2E-A-007
+    title: Pilot creates a Pipistrel Velis Electro, the wizard flips to electric and fuel UI is hidden
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/electric-aircraft-wizard.feature
+
+  E2E-A-008
+    title: Combustion wizard is unchanged — fuel tank button remains visible for a Tecnam P2008 JC
+    files:
+      - frontend/tests/e2e/features/phase-a-fleet-management/electric-aircraft-wizard.feature

--- a/trace/e2e/flight-prep.yaml
+++ b/trace/e2e/flight-prep.yaml
@@ -33,3 +33,18 @@ Phase B End-to-End Tests
     title: Redistributing load resolves burn-sequence CG migration violation
     files:
       - frontend/tests/e2e/features/phase-b-flight-preparation/burn-sequence-polygon.feature
+
+  E2E-B-008
+    title: Empty fleet shows "No aircraft" CTA that navigates to the wizard
+    files:
+      - frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+
+  E2E-B-009
+    title: Aircraft added via wizard appears in the Flight Prep dropdown with a [Draft] label
+    files:
+      - frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+
+  E2E-B-010
+    title: Hardcoded catalogue aircraft are not in the dropdown when the fleet is empty
+    files:
+      - frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature

--- a/trace/e2e/system-pwa.yaml
+++ b/trace/e2e/system-pwa.yaml
@@ -1,0 +1,5 @@
+Phase D System & Usability End-to-End Tests
+  E2E-D-001
+    title: App shell loads and M&B navigation works while offline (technical smoke)
+    files:
+      - frontend/tests/e2e/features/phase-sys-pwa/offline-smoke.feature

--- a/trace/implementation/ac.yaml
+++ b/trace/implementation/ac.yaml
@@ -50,6 +50,13 @@ AC Store — Fleet Repository
     files:
       - frontend/src/modules/aircraft/services/profile.import.ts
 
+  IMP-AC-STORE-007
+    title: validateImportFile — fail-closed file size/MIME guard for exchange-file import (CS-003)
+    req:
+      - REQ-AC-004
+    files:
+      - frontend/src/modules/aircraft/services/profile.import.ts
+
   IMP-AC-STORE-005
     title: useFleetStore — Pinia store for fleet CRUD and Draft/Verified FSM
     req:
@@ -245,3 +252,10 @@ AC View — Model Catalogue and Components
       - REQ-AD-012
     files:
       - frontend/src/modules/aircraft/components/LoadPointsSection.vue
+
+  IMP-AC-VIEW-019
+    title: FleetList delete — confirm-then-undo destructive delete (in-app modal + undo toast, active-aircraft delete disabled) (UX-001)
+    req:
+      - REQ-AC-001
+    files:
+      - frontend/src/modules/aircraft/components/FleetList.vue

--- a/trace/implementation/ad.yaml
+++ b/trace/implementation/ad.yaml
@@ -139,3 +139,12 @@ AD Core (domain + mass-balance input schema)
       - REQ-AD-009
     files:
       - frontend/src/core/domain/aircraft.types.ts
+
+  IMP-AD-CORE-022
+    title: Finite + Numeric Domain-Range Guards on AircraftProfile Schema Fields
+    req:
+      - REQ-AD-002
+      - REQ-AD-014
+      - REQ-SYS-003
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts

--- a/trace/implementation/fe.yaml
+++ b/trace/implementation/fe.yaml
@@ -5,3 +5,11 @@ FE Core — Fuel & Endurance
       - REQ-FE-001
     files:
       - frontend/src/core/logic/fuel-density.ts
+
+  IMP-FE-CORE-002
+    title: Canonical Fuel-Type Set and Fail-Closed Known-Type Guard
+    req:
+      - REQ-FE-001
+      - REQ-SYS-003
+    files:
+      - frontend/src/core/logic/fuel-density.ts

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -106,6 +106,15 @@ MB Adapter Entry (delegation to core)
     files:
       - frontend/src/core/adapters/mass-balance.adapter.ts
 
+  IMP-MB-CORE-016
+    title: Finite + Numeric Domain-Range Guards on Math-Core Adapter Inputs
+    req:
+      - REQ-MB-002
+      - REQ-SYS-003
+      - REQ-SYS-012
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.ts
+
 MB Store - Type Definitions
   IMP-MB-STORE-001
     title: MassBalanceState Type (State Machine Pointer)
@@ -243,6 +252,14 @@ MB Data Schema
     files:
       - frontend/src/modules/mass-balance/data/aircraft-context.schema.ts
 
+  IMP-MB-DATA-003
+    title: AircraftContext Fuel-Type Enum Convergence (fail-closed on unknown)
+    req:
+      - REQ-FE-001
+      - REQ-SYS-003
+    files:
+      - frontend/src/modules/mass-balance/data/aircraft-context.schema.ts
+
 MB Store - Error Flag Derivation
   IMP-MB-STORE-015
     title: Per-Station Error Flag Derivation from INVALID_INPUT Violations
@@ -271,6 +288,30 @@ MB Store - Error Flag Derivation
     title: clearProfile — detach aircraft and reset M&B state on hot-swap (no stale-data leak)
     req:
       - REQ-AC-005
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+  IMP-MB-STORE-020
+    title: Full Geometric SI Normalization at Adapter Boundary (arm/moment/envelope via sourceUnit)
+    req:
+      - REQ-SYS-003
+      - REQ-AD-014
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+  IMP-MB-STORE-021
+    title: Fail-Closed Warning on Unrecognized Fuel Type (no silent fallback density)
+    req:
+      - REQ-FE-001
+      - REQ-SYS-003
+    files:
+      - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
+
+  IMP-MB-STORE-022
+    title: Block NaN-Filled Failed Compute from Reaching lastResult / UI
+    req:
+      - REQ-SYS-012
+      - REQ-UI-008
     files:
       - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
 
@@ -324,4 +365,19 @@ MB UI Components
       - REQ-UQ-005
     files:
       - frontend/src/modules/mass-balance/components/MassStationInput.vue
+      - frontend/src/modules/mass-balance/views/MassBalanceView.vue
+
+  IMP-MB-UI-008
+    title: Turbulence-tolerant station stepper — coarse (±N) controls, unit-aware step, and one-tap preset chips (UX-002)
+    req:
+      - REQ-UQ-004
+    files:
+      - frontend/src/modules/mass-balance/components/MassStationInput.vue
+      - frontend/src/modules/mass-balance/views/MassBalanceView.vue
+
+  IMP-MB-UI-FLEET-002
+    title: Reset Payload confirm-then-undo — in-app confirmation with discard count plus a short undo window restoring pre-reset weights (UX-004)
+    req:
+      - REQ-UI-018
+    files:
       - frontend/src/modules/mass-balance/views/MassBalanceView.vue

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -61,6 +61,22 @@ SYS Core
     files:
       - frontend/src/core/logic/display-rounding.ts
 
+SYS Core — Moment & sourceUnit Normalization
+  IMP-SYS-CORE-010
+    title: Moment Normalization to SI (kg·m) via arm-unit length factor
+    req:
+      - REQ-SYS-003
+    files:
+      - frontend/src/core/logic/unit-normalization.ts
+
+  IMP-SYS-CORE-011
+    title: sourceUnit Parsing into Mass and Arm Components
+    req:
+      - REQ-SYS-003
+      - REQ-AD-014
+    files:
+      - frontend/src/core/logic/unit-normalization.ts
+
 SYS Core — Session Payload Schema
   IMP-SYS-CORE-009
     title: Session Payload Zod Schema for localStorage Persistence Validation

--- a/trace/implementation/ui.yaml
+++ b/trace/implementation/ui.yaml
@@ -14,6 +14,34 @@ UI Shared Components
     files:
       - frontend/src/App.vue
 
+  IMP-UI-SHARED-003
+    title: ConfirmDialog template — accessible dark-mode-safe confirmation modal (in-app replacement for native window.confirm on destructive actions)
+    req:
+      - REQ-UI-011
+    files:
+      - frontend/src/shared/components/ConfirmDialog.vue
+
+  IMP-UI-SHARED-004
+    title: ConfirmDialog script — focus management, Escape/backdrop cancel, confirm/cancel emits, danger/primary variants
+    req:
+      - REQ-UI-011
+    files:
+      - frontend/src/shared/components/ConfirmDialog.vue
+
+  IMP-UI-SHARED-005
+    title: UndoToast template — transient undo affordance (live region) for recoverable destructive actions
+    req:
+      - REQ-UI-011
+    files:
+      - frontend/src/shared/components/UndoToast.vue
+
+  IMP-UI-SHARED-006
+    title: UndoToast script — auto-dismiss timer, undo/dismiss emits, timer cleanup on undo
+    req:
+      - REQ-UI-011
+    files:
+      - frontend/src/shared/components/UndoToast.vue
+
 UI Views
   IMP-UI-VIEW-001
     title: HomeView — Dashboard landing page with module navigation

--- a/trace/integration_test/mb.yaml
+++ b/trace/integration_test/mb.yaml
@@ -54,3 +54,25 @@ MB Core - Arm Lookup Integration via computeMassBalanceCore
       - IMP-MB-CORE-012
     files:
       - frontend/src/core/logic/__tests__/mass-balance.int.spec.ts
+
+MB Store ↔ Real Adapter Integration
+  IT-MB-STORE-001
+    title: Imperial profile (inches/lb) normalizes to SI and yields correct CG + envelope verdict
+    impl:
+      - IMP-MB-STORE-020
+    files:
+      - frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.int.spec.ts
+
+  IT-MB-STORE-002
+    title: NaN-filled failed compute is blocked from lastResult; ERROR surfaced instead
+    impl:
+      - IMP-MB-STORE-022
+    files:
+      - frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.int.spec.ts
+
+  IT-MB-STORE-003
+    title: Unknown fuel type fails closed (WARN-FE-001); canonical types do not warn
+    impl:
+      - IMP-MB-STORE-021
+    files:
+      - frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.int.spec.ts

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -232,6 +232,49 @@ AC Store — Profile Import (Unit)
     files:
       - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
 
+AC Store — Import File Guard (Unit)
+  UT-AC-STORE-084
+    title: rejects an oversized file before reading it (CS-003)
+    impl:
+      - IMP-AC-STORE-007
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-085
+    title: rejects an empty (0-byte) file
+    impl:
+      - IMP-AC-STORE-007
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-086
+    title: rejects a non-JSON MIME type even with a .json name
+    impl:
+      - IMP-AC-STORE-007
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-087
+    title: rejects a non-.json extension even with a JSON MIME type
+    impl:
+      - IMP-AC-STORE-007
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-088
+    title: accepts a well-formed .json file at the size limit
+    impl:
+      - IMP-AC-STORE-007
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-089
+    title: tolerates an empty MIME type when the extension is .json
+    impl:
+      - IMP-AC-STORE-007
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
 AC Store — Fleet Store (Unit)
   UT-AC-STORE-025
     title: creates Draft profile by default
@@ -1516,3 +1559,52 @@ AC View — ProfileStatusBadge Component (Unit)
       - IMP-AC-VIEW-018
     files:
       - frontend/src/modules/aircraft/__tests__/LoadPointsSection.spec.ts
+
+  UT-AC-VIEW-165
+    title: FleetList — does not use native window.confirm() when deleting
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+  UT-AC-VIEW-166
+    title: FleetList — opens an in-app confirmation dialog naming the aircraft on delete tap
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+  UT-AC-VIEW-167
+    title: FleetList — cancelling the confirmation does not delete and shows no undo toast
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+  UT-AC-VIEW-168
+    title: FleetList — accepting the confirmation deletes and surfaces an undo toast
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+  UT-AC-VIEW-169
+    title: FleetList — undo restores the deleted profile via the repository
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+  UT-AC-VIEW-170
+    title: FleetList — delete control disabled while the profile is the active aircraft
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+  UT-AC-VIEW-171
+    title: FleetList — delete handler is a no-op for the active aircraft (defence in depth)
+    impl:
+      - IMP-AC-VIEW-019
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts

--- a/trace/unit_test/ad.yaml
+++ b/trace/unit_test/ad.yaml
@@ -401,3 +401,53 @@ AD Schema — Performance Profiles (Unit)
       - IMP-AD-CORE-015
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+AD Core — Finite + numeric range guards (Unit)
+  UT-AD-CORE-061
+    title: Rejects Infinity for weighing-report bem
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-062
+    title: Rejects -Infinity for a load point arm
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-063
+    title: Rejects NaN for mtom
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-064
+    title: Rejects an absurd mtom magnitude (1e308) as out of physical range
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-065
+    title: Rejects an absurd bem magnitude (1e30)
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-066
+    title: Rejects Infinity for batteryPack.usableEnergyKwh
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+
+  UT-AD-CORE-067
+    title: Accepts a near-edge finite mtom just under the ceiling
+    impl:
+      - IMP-AD-CORE-022
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts

--- a/trace/unit_test/fe.yaml
+++ b/trace/unit_test/fe.yaml
@@ -96,3 +96,38 @@ FE Core — Fuel Density (Unit)
       - IMP-FE-CORE-001
     files:
       - frontend/src/core/logic/fuel-density.spec.ts
+
+  UT-FE-CORE-015
+    title: Verify CANONICAL_FUEL_TYPES matches the AircraftProfile schema enum set
+    impl:
+      - IMP-FE-CORE-002
+    files:
+      - frontend/src/core/logic/fuel-density.spec.ts
+
+  UT-FE-CORE-016
+    title: Verify every canonical type resolves to an explicit (non-fallback) density
+    impl:
+      - IMP-FE-CORE-002
+    files:
+      - frontend/src/core/logic/fuel-density.spec.ts
+
+  UT-FE-CORE-017
+    title: Verify isKnownFuelType accepts canonical types and recognised legacy aliases
+    impl:
+      - IMP-FE-CORE-002
+    files:
+      - frontend/src/core/logic/fuel-density.spec.ts
+
+  UT-FE-CORE-018
+    title: Verify isKnownFuelType rejects genuinely unknown types (fallback risk)
+    impl:
+      - IMP-FE-CORE-002
+    files:
+      - frontend/src/core/logic/fuel-density.spec.ts
+
+  UT-FE-CORE-019
+    title: Verify isCanonicalFuelType accepts only the canonical enum (rejects aliases)
+    impl:
+      - IMP-FE-CORE-002
+    files:
+      - frontend/src/core/logic/fuel-density.spec.ts

--- a/trace/unit_test/mb.yaml
+++ b/trace/unit_test/mb.yaml
@@ -580,6 +580,49 @@ MB Adapter entry (Unit)
     files:
       - frontend/src/core/adapters/mass-balance.adapter.spec.ts
 
+MB Adapter — Finite + numeric range guards (Unit)
+  UT-MB-CORE-098
+    title: Rejects Infinity for basicEmptyMass (no success:true with NaN CG)
+    impl:
+      - IMP-MB-CORE-016
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.spec.ts
+
+  UT-MB-CORE-099
+    title: Rejects -Infinity for a station arm
+    impl:
+      - IMP-MB-CORE-016
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.spec.ts
+
+  UT-MB-CORE-100
+    title: Rejects NaN for emptyCenterOfGravity
+    impl:
+      - IMP-MB-CORE-016
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.spec.ts
+
+  UT-MB-CORE-101
+    title: Rejects an absurd finite station mass (1e30) as OUT_OF_RANGE
+    impl:
+      - IMP-MB-CORE-016
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.spec.ts
+
+  UT-MB-CORE-102
+    title: Rejects an absurd finite maxTakeoffMass (1e308)
+    impl:
+      - IMP-MB-CORE-016
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.spec.ts
+
+  UT-MB-CORE-103
+    title: Accepts a near-edge finite value just under the ceiling
+    impl:
+      - IMP-MB-CORE-016
+    files:
+      - frontend/src/core/adapters/mass-balance.adapter.spec.ts
+
 MB Store - Initialization
   UT-MB-STORE-001
     title: Verify store starts in INITIAL state with null aircraft
@@ -1196,6 +1239,28 @@ MB Data Schema
     files:
       - frontend/src/modules/mass-balance/data/__tests__/aircraft-context.schema.spec.ts
 
+MB Data — Fuel-Type Enum Convergence (Unit)
+  UT-MB-DATA-038
+    title: Rejects a genuinely unknown fuel-type string (fail-closed)
+    impl:
+      - IMP-MB-DATA-003
+    files:
+      - frontend/src/modules/mass-balance/data/__tests__/aircraft-context.schema.spec.ts
+
+  UT-MB-DATA-039
+    title: Rejects an empty permissibleFuelTypes array (min 1)
+    impl:
+      - IMP-MB-DATA-003
+    files:
+      - frontend/src/modules/mass-balance/data/__tests__/aircraft-context.schema.spec.ts
+
+  UT-MB-DATA-040
+    title: Tolerates deprecated uppercase aliases that resolve a correct density
+    impl:
+      - IMP-MB-DATA-003
+    files:
+      - frontend/src/modules/mass-balance/data/__tests__/aircraft-context.schema.spec.ts
+
 MB Store - Mutant-Killing Boundary Tests
   UT-MB-STORE-051
     title: Verify availableStations empty when aircraft loaded but activeCategory null
@@ -1262,3 +1327,20 @@ MB Store - Mutant-Killing Boundary Tests
       - H-011
     files:
       - frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts
+
+MB UI — Station Input & View Recovery (Unit)
+  UT-MB-UI-001
+    title: MassStationInput — coarse (±N) controls, unit-aware step, clamping, and one-tap preset chips (UX-002)
+    impl:
+      - IMP-MB-UI-006
+      - IMP-MB-UI-008
+    files:
+      - frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
+
+  UT-MB-VIEW-021
+    title: MassBalanceView — Reset Payload confirm-then-undo flow (confirmation gate, discard count, undo restore) (UX-004)
+    impl:
+      - IMP-MB-UI-FLEET-002
+      - IMP-MB-UI-008
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.spec.ts

--- a/trace/unit_test/sys.yaml
+++ b/trace/unit_test/sys.yaml
@@ -210,6 +210,77 @@ SYS Core — Notification Schema (Unit)
     files:
       - frontend/src/core/domain/notification.schema.spec.ts
 
+SYS Core — Moment & sourceUnit Normalization (Unit)
+  UT-SYS-CORE-031
+    title: normalizeMomentToSI returns value unchanged for kg·m input
+    impl:
+      - IMP-SYS-CORE-010
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-032
+    title: normalizeMomentToSI scales kg·in moment by the inch factor
+    impl:
+      - IMP-SYS-CORE-010
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-033
+    title: normalizeMomentToSI scales kg·ft moment by the foot factor
+    impl:
+      - IMP-SYS-CORE-010
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-034
+    title: normalizeMomentToSI is consistent with mass×arm normalization
+    impl:
+      - IMP-SYS-CORE-010
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-035
+    title: parseSourceUnit parses mass-only "kg" to { kg, m }
+    impl:
+      - IMP-SYS-CORE-011
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-036
+    title: parseSourceUnit parses mass-only "lb" to { lb, m }
+    impl:
+      - IMP-SYS-CORE-011
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-037
+    title: parseSourceUnit parses combined "lb-in" to { lb, in }
+    impl:
+      - IMP-SYS-CORE-011
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-038
+    title: parseSourceUnit parses combined "kg-m" and "lb-ft"
+    impl:
+      - IMP-SYS-CORE-011
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-039
+    title: parseSourceUnit is case-insensitive and trims whitespace
+    impl:
+      - IMP-SYS-CORE-011
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
+  UT-SYS-CORE-040
+    title: parseSourceUnit falls back to SI defaults for unknown components
+    impl:
+      - IMP-SYS-CORE-011
+    files:
+      - frontend/src/core/logic/unit-normalization.spec.ts
+
 SYS Shared — Structured Logger Utility (Unit)
   UT-SYS-SHARED-001
     title: Returns primitives unchanged
@@ -313,6 +384,41 @@ SYS Shared — Structured Logger Utility (Unit)
     title: Safely serializes large aircraft schematic objects without choking
     impl:
       - IMP-SYS-SHARED-001
+      - IMP-SYS-SHARED-002
+    files:
+      - frontend/src/shared/utils/__tests__/logger.spec.ts
+
+  UT-SYS-SHARED-016
+    title: Suppresses debug() output in production (DP-011)
+    impl:
+      - IMP-SYS-SHARED-002
+    files:
+      - frontend/src/shared/utils/__tests__/logger.spec.ts
+
+  UT-SYS-SHARED-017
+    title: Suppresses info() output in production (DP-011)
+    impl:
+      - IMP-SYS-SHARED-002
+    files:
+      - frontend/src/shared/utils/__tests__/logger.spec.ts
+
+  UT-SYS-SHARED-018
+    title: Suppresses telemetryTrace() (INFO level) output in production (DP-011)
+    impl:
+      - IMP-SYS-SHARED-002
+    files:
+      - frontend/src/shared/utils/__tests__/logger.spec.ts
+
+  UT-SYS-SHARED-019
+    title: Still emits warn() in production (DP-011)
+    impl:
+      - IMP-SYS-SHARED-002
+    files:
+      - frontend/src/shared/utils/__tests__/logger.spec.ts
+
+  UT-SYS-SHARED-020
+    title: Still emits error() in production (DP-011)
+    impl:
       - IMP-SYS-SHARED-002
     files:
       - frontend/src/shared/utils/__tests__/logger.spec.ts

--- a/trace/unit_test/ui.yaml
+++ b/trace/unit_test/ui.yaml
@@ -5,3 +5,20 @@ UI Routing — Route Table (Unit)
       - IMP-UI-ROUTE-001
     files:
       - frontend/src/router/index.spec.ts
+
+UI Shared Components (Unit)
+  UT-UI-SHARED-001
+    title: ConfirmDialog — accessible alertdialog, confirm/cancel + backdrop/Escape, danger/primary variants, custom labels (UX-001/UX-004)
+    impl:
+      - IMP-UI-SHARED-003
+      - IMP-UI-SHARED-004
+    files:
+      - frontend/src/shared/components/__tests__/ConfirmDialog.spec.ts
+
+  UT-UI-SHARED-002
+    title: UndoToast — live-region rendering, undo/dismiss emits, auto-dismiss timer + timer cleanup on undo (UX-001/UX-004)
+    impl:
+      - IMP-UI-SHARED-005
+      - IMP-UI-SHARED-006
+    files:
+      - frontend/src/shared/components/__tests__/UndoToast.spec.ts


### PR DESCRIPTION
Closes #293.

Remediates the **immediate blockers** from the v0.3.0-alpha release audit bundle (`.logs/audit.*-2026-05-08.md`). All deferred findings are filed as milestone-assigned issues (#259–#292); the remaining `@wip` E2E follow-up is tracked in #294. See the readiness report for the full split.

## What's done (13 bundles)

**Safety core (P1 — under approved consolidated FRR)**
- Arm/CG/moment/envelope normalized to SI from declared profile units (was hardcoded metres → wrong CG for **imperial** profiles) — TECH-001/002. New hand-computed imperial canonical vector.
- `.finite()` + physical domain bounds on all math inputs; Infinity/NaN rejected instead of `success:true`+NaN — TECH-003, CS-002.
- Failed compute never reaches the UI as "NaN kg" — TECH-004.
- Fuel-type enum unified; unknown type fails closed, no silent 0.84 density — TECH-010/011/013, CS-008/009/010.

**Security** — import size (256 KB) + MIME guard before parse (CS-003/TECH-008); strict CSP meta (CS-005/TECH-018/DP-012); `serve` moved to devDeps with lockfile synced (CS-013).

**Privacy / build** — PRIVACY.md "Current State" rewritten to the truthful shipped storage surface (DP-001); vue-devtools gated to dev + prod console suppressed (DP-016/DP-011).

**UX (shipped destructive/ergonomic)** — in-app confirm + undo for delete & Reset Payload, delete disabled on active aircraft (UX-001/004, new shared `ConfirmDialog`/`UndoToast`); coarse step + presets + wider station field (UX-002).

**Traceability** — `@E2E-` tags moved to `.feature` files; phase-namespace E2E IDs; dangling `@UJ-SYS-001`/`@UJ-F-002` corrected; passing fleet-selection + offline-smoke flows un-`@wip` (PR-001/003/004; TECH-006 partial).

## Verification
type-check · oxlint · eslint incl. **P1-ISOLATION** · unit **973** · P1 **371** · integration **31** all green. `pnpm audit`: 6 dev-only transitive (no prod runtime; tracked in #261).

## Notes for review
- The remaining 3 M&B-math E2E flows stay `@wip` (need a fleet-seeding fixture + wizard navigation/save repairs); tracked in #294.
- Deploy should set host-level headers (HSTS etc.); CSP relaxes only `style-src 'unsafe-inline'` (Vue scoped styles).
- A standalone ADR is recommended for the `sourceUnit` `<mass>-<arm>` convention used for imperial arm declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)