### PR TITLE
fix(repo): mark SemVer pre-release tags as pre-releases in publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -63,12 +63,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "${{ steps.notes.outputs.file }}" ]; then
-            gh release create "v${{ steps.version.outputs.version }}" \
-              --title "v${{ steps.version.outputs.version }}" \
-              --notes-file "${{ steps.notes.outputs.file }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          # SemVer pre-release tags carry a hyphenated identifier (e.g. -alpha,
+          # -beta, -rc). Mark those as GitHub pre-releases; tag stable versions
+          # as the latest release. gh does NOT infer this from the tag name.
+          if [[ "$VERSION" == *-* ]]; then
+            RELEASE_FLAG="--prerelease"
           else
-            gh release create "v${{ steps.version.outputs.version }}" \
-              --title "v${{ steps.version.outputs.version }}" \
-              --generate-notes
+            RELEASE_FLAG="--latest"
+          fi
+          if [ -n "${{ steps.notes.outputs.file }}" ]; then
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --notes-file "${{ steps.notes.outputs.file }}" \
+              "$RELEASE_FLAG"
+          else
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --generate-notes \
+              "$RELEASE_FLAG"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Engineering
+
+- `publish-release.yml` now marks SemVer pre-release tags (`-alpha` / `-beta` / `-rc`) as GitHub pre-releases and stable tags as `latest`, instead of always publishing a stable "latest" release (`gh release create` does not infer this from the tag)
+
 ## [0.3.0-alpha] - 2026-05-24
 
 ### Added


### PR DESCRIPTION
### Summary

`publish-release.yml` always published a stable "latest" GitHub Release because `gh release create` does not infer the pre-release flag from the tag name. v0.3.0-alpha shipped marked as a stable release and needed a manual `gh release edit --prerelease` correction.

This derives the flag from the version string: hyphenated SemVer (`-alpha` / `-beta` / `-rc`) → `--prerelease`; otherwise → `--latest`.

### Related Issues

N/A — surfaced while publishing v0.3.0-alpha via the `release` skill.

### Affected Items

- **Requirements Implemented/Affected:** N/A (CI/release tooling)

### Documentation Updates

- [x] **Code Docs:** `CHANGELOG.md` Unreleased → Engineering updated

### Quality & Testing Checklist

- [x] **Target Branch:** targets `develop`
- [x] **Manual Testing:** validated against the v0.3.0-alpha publish (release published stable, confirming the gap; fix sets the flag from the tag)
- [x] **Review:** self-reviewed