### PR TITLE
docs(repo): set native sub-issue parent/child links in /issue skill

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -78,6 +78,7 @@ If user picks update:
 - draft comment or patch
 - review with user
 - exec via `add_issue_comment` (comment) or `issue_write method:update` (field)
+- if the update establishes or changes a parent (e.g. back-linking an existing `Task`), also set the **native** sub-issue relationship (see `## Parent/child linkage`) — never body-text only
 - stop after exec
 
 ## Branch 2: create new (no good match OR user chose create)
@@ -107,6 +108,7 @@ If user picks update:
 #### `Task`
 - ask if missing: `parent_issue` | `description`
 - ask if applicable: `technical_details` | `dod`
+- `parent_issue` is REQUIRED — record it in the body "Parent Feature / Issue" field **and** set the native sub-issue relationship after create (see `## Parent/child linkage`). A `Task` whose parent exists only as body text is incomplete.
 
 ### Title
 
@@ -129,7 +131,27 @@ If user picks update:
 ### Exec
 
 - `mcp__github__issue_write` `method: create` with `title | body | labels`; optional `milestone` numeric id
-- on success show: issue number | title | url | labels
+- if type is `Task`: immediately set the **native** parent/child link (see `## Parent/child linkage`) and verify it before reporting success
+- on success show: issue number | title | url | labels | parent (for `Task`)
+
+## Parent/child linkage (native sub-issues)
+
+GitHub's parent/child relationship is the **source of truth** — a body reference like `#123` is human-friendly fallback, never a substitute. Every `Task` must be attached to its parent via the sub-issues API. There is no `mcp__github__` tool for this; use `gh api` (Bash).
+
+Link child `#C` under parent `#P` (repo `naturelle137/AeroDash`):
+
+1. Resolve the child's **database id** (integer — NOT the issue number, NOT the `node_id`):
+   `gh api repos/naturelle137/AeroDash/issues/C --jq '.id'`
+2. Attach it (send the id as a number via `-F`, not `-f`):
+   `gh api --method POST repos/naturelle137/AeroDash/issues/P/sub_issues -F sub_issue_id=<child_db_id>`
+3. Verify it landed — this list MUST include `C`:
+   `gh api repos/naturelle137/AeroDash/issues/P/sub_issues --jq '.[].number'`
+
+Rules & edge cases:
+- Idempotent: if `C` already appears under `P`, skip (do not re-POST).
+- If `C` already has a *different* parent, the POST errors — surface to the user, never force-move silently.
+- Keep the body "Parent Feature / Issue #P" field populated too (readability + fallback).
+- Back-linking an existing `Task` uses the exact same POST.
 
 ## Forbidden
 
@@ -137,3 +159,4 @@ If user picks update:
 - fabricated hazard refs | requirement IDs | environment values
 - skipping dedupe
 - creating a `Task` without a parent
+- declaring a `Task`'s parent in body text only — the native sub-issue relationship MUST be set and verified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Engineering
 
 - `publish-release.yml` now marks SemVer pre-release tags (`-alpha` / `-beta` / `-rc`) as GitHub pre-releases and stable tags as `latest`, instead of always publishing a stable "latest" release (`gh release create` does not infer this from the tag)
+- `/issue` command now sets GitHub's native parent/child (sub-issue) relationship for Tasks via the sub-issues API, instead of recording the parent only as body text
 
 ## [0.3.0-alpha] - 2026-05-24
 


### PR DESCRIPTION
### Summary

- `/issue` command now establishes GitHub's **native** parent/child (sub-issue) relationship for `Task`s via the sub-issues API, instead of recording the parent only as body text. The body "Parent Feature / Issue" field is kept as a human-readable fallback.
- Adds a `## Parent/child linkage` recipe (resolve child DB id → `POST .../issues/<parent>/sub_issues` → verify), requires + verifies the link on `Task` create, extends the update/back-link path, and forbids body-text-only parenting in the `## Forbidden` rules.
- Context: this gap was found while curating tickets; affected open tickets were retro-linked natively out-of-band (#316 ↔ #317–#320; #298–#305 ↔ #306–#315). This PR only changes the command spec so future Tasks are linked automatically.

### Related Issues

N/A — tooling/process change to the `/issue` command spec; no product issue tracks this skill edit.

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: meta-tooling change; no product requirement affected)
- [x] **Architecture:** `N/A` (Reason: refines existing `/issue` tooling behaviour; no architectural surface change)
- [x] **Risk Management:** `N/A` (Reason: no hazard affected; developer tooling only)
- [x] **Journeys:** `N/A` (Reason: no user-facing journey affected)
- [x] **Code Docs:** `CHANGELOG.md` updated (Unreleased › Engineering); the `/issue` command spec itself is updated

### Safety Considerations

- [x] Checked Safety Traceability Matrix. (No traced artifact touched — change is meta-tooling)
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). (No code changed; `frontend/src/core/` untouched)

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: documentation / command-spec change; no executable code).
- [x] **Integration Tests:** `N/A` (Reason: no executable code changed).
- [x] **Manual Testing:** Performed — the documented sub-issue linking flow (`gh api .../sub_issues` + verify) was exercised live this session and confirmed working (#316 ↔ #317–#320; #298–#305 ↔ #306–#315).
- [x] **DoD:** Met — the skill now sets **and verifies** the native link on create, covers the back-link/update path, and forbids body-only parenting (no separate ticket; DoD = the stated request).
- [x] **Review:** Self-review of the command-spec diff performed.
- [x] **ADR:** No ADR required — refines existing `/issue` tooling behaviour; no P1 operation or workflow-defining change.
