### PR TITLE
fix(repo): clear high-severity dependency-audit advisories via pnpm overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Engineering
 
 - `publish-release.yml` now marks SemVer pre-release tags (`-alpha` / `-beta` / `-rc`) as GitHub pre-releases and stable tags as `latest`, instead of always publishing a stable "latest" release (`gh release create` does not infer this from the tag)
+- `pnpm` overrides force patched transitive dev dependencies (`fast-uri` ≥3.1.2, `@babel/plugin-transform-modules-systemjs` ≥7.29.4, `js-cookie` ≥3.0.7), clearing the four high-severity advisories that failed the `pnpm audit --audit-level high` CI gate
 
 ## [0.3.0-alpha] - 2026-05-24
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
       "basic-ftp": ">=5.3.1",
       "serialize-javascript": ">=7.0.3",
       "ip-address": ">=10.1.1",
-      "uuid": ">=11.1.1"
+      "uuid": ">=11.1.1",
+      "fast-uri": ">=3.1.2",
+      "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+      "js-cookie": ">=3.0.7"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ overrides:
   serialize-javascript: '>=7.0.3'
   ip-address: '>=10.1.1'
   uuid: '>=11.1.1'
+  fast-uri: '>=3.1.2'
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
+  js-cookie: '>=3.0.7'
 
 importers:
 
@@ -552,8 +555,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3056,8 +3059,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -3620,9 +3623,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
@@ -5927,7 +5930,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -6145,7 +6148,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -7716,14 +7719,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8616,7 +8619,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -9167,10 +9170,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.7
       glob: 10.5.0
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-md4@0.3.2: {}
 


### PR DESCRIPTION
### Summary

- Adds `pnpm` `overrides` forcing patched **transitive dev** dependencies so the `pnpm audit --audit-level high` gate in `.github/workflows/security.yml` passes again:
  - `fast-uri` ≥3.1.2 — GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc (via `@commitlint/cli` → `ajv`)
  - `@babel/plugin-transform-modules-systemjs` ≥7.29.4 — GHSA-fv7c-fp4j-7gwp (via `vite-plugin-pwa` → `workbox-build`)
  - `js-cookie` ≥3.0.7 — GHSA-qjx8-664m-686j (via `@vue/test-utils` → `js-beautify`)
- Lockfile refreshed accordingly. No runtime/production code touched — all four advisories were in dev-only transitive deps.
- 2 moderate advisories remain (`brace-expansion`, `qs`, both via `@stryker-mutator`) but are below the `high` gate threshold and out of scope here.

### Related Issues

N/A — pre-existing, repo-wide dependency-audit failure with no tracked issue. Surfaced while working PR #321, whose only red check was this same gate.

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: dependency-maintenance change; no requirement affected)
- [x] **Architecture:** `N/A` (Reason: no architectural surface change)
- [x] **Risk Management:** `N/A` (Reason: no hazard affected; dev-tooling dependencies only)
- [x] **Journeys:** `N/A` (Reason: no user-facing journey affected)
- [x] **Code Docs:** `CHANGELOG.md` updated (Unreleased › Engineering)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. (No traced artifact touched — dev-dependency bump)
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). (No source changed; `frontend/src/core/` untouched)

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: dependency-override change; no source/logic modified — existing suites unaffected).
- [x] **Integration Tests:** `N/A` (Reason: same — no source modified).
- [x] **Manual Testing:** Performed — `pnpm install` succeeded and `pnpm audit --audit-level high` now exits 0 locally (was exit 1 with 4 high advisories).
- [x] **DoD:** Met — the failing `pnpm audit --audit-level high` gate now passes; all 4 high advisories cleared (no separate ticket; DoD = green audit gate).
- [x] **Review:** Self-review of the `package.json` + `pnpm-lock.yaml` diff performed.
- [x] **ADR:** No ADR required — dependency version bump via overrides; no P1 operation or interface change.
