### PR TITLE
fix(repo): add id-token write permission for Claude Action OIDC

### DIFF
--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -51,6 +51,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
   MODEL_DEFAULT: claude-opus-4-7

--- a/.github/workflows/pr-iteration.yml
+++ b/.github/workflows/pr-iteration.yml
@@ -31,6 +31,7 @@ permissions:
   issues: write
   checks: read
   statuses: read
+  id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
   MODEL: claude-opus-4-7

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
   REVIEW_MODEL: claude-opus-4-7


### PR DESCRIPTION
### Summary

Hotfix for the autonomous automation: the manual overnight run failed with

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`anthropics/claude-code-action@v1` requires OIDC (`id-token: write`). The three workflows that invoke the action were missing it. This adds `id-token: write` to each; all other least-privilege scopes are unchanged.

- `overnight-implementation.yml`
- `pr-review-bot.yml`
- `pr-iteration.yml`

No logic change. Validates the Select job already worked (it correctly picked the lowest-numbered eligible issue); only the Claude-action step was blocked.

### Related Issues

Refs #316

### Quality & Testing Checklist

- [x] **Target Branch:** Targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: GitHub Actions permission fix; no unit-testable code changed).
- [x] **Integration Tests:** `N/A` (Reason: verified by re-running the workflow after merge).
- [x] **Manual Testing:** `N/A` (Reason: requires merge to default branch + secrets; re-run the dispatch to confirm).
- [x] **Review:** Self-reviewed; YAML validated.
- [x] **ADR:** No ADR change — within ADR-317-DEV's least-privilege intent (OIDC is required by the action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
