### PR TITLE
fix(repo): grant Bash + set up pnpm in overnight automation (refs #316)

### DIFF
--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -165,10 +165,21 @@ jobs:
           # and the reviewer bot; the default GITHUB_TOKEN cannot trigger them.
           token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
+
+      # Pre-install so `pnpm` is on PATH and Husky hooks are active before the
+      # agent runs the pipeline. Without a pnpm setup the agent's `pnpm install`
+      # cannot resolve the binary at all; pre-installing also primes the cache
+      # and stops the agent burning turns bootstrapping the toolchain.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Create feature branch
         run: |
@@ -204,9 +215,20 @@ jobs:
               once CI is green and the automated review is clean.
             - If you cannot complete the issue safely, stop and leave a clear summary
               of what remains; do not force a partial or unsafe change.
+          # claude-code-action does NOT grant Bash by default, and CI has no
+          # human to approve tool prompts — so without an explicit allow-list the
+          # agent's pnpm/git/gh commands are all auto-denied and it produces zero
+          # commits (observed in runs #2/#3: permission_denials_count > 0 →
+          # "No commits produced"). --allowedTools MERGES with the action's
+          # baseline (file ops + GitHub tools); we add Bash plus search/task
+          # tools needed by the /implement-issue flow. Safety is unchanged: it
+          # rests on the Draft-only + human-Lead-review + CI-gate regime
+          # (ADR-317-DEV), not on local permission gating — the Draft PR re-runs
+          # every gate and is never auto-merged.
           claude_args: |
             --model ${{ github.event.inputs.model || env.MODEL_DEFAULT }}
             --max-turns ${{ env.MAX_TURNS }}
+            --allowedTools "Bash,Edit,Write,Read,Glob,Grep,Task,TodoWrite,WebFetch,WebSearch,Skill"
 
       - name: Push branch & open Draft PR
         env:


### PR DESCRIPTION
## Problem

The overnight implementation workflow ran to completion twice (runs #2/#3) but produced **no code** and exited with `No commits produced — skipping PR`.

The logs showed Claude Code finishing successfully (`is_error: false`, 38/56 turns) but with `permission_denials_count` of **7** and **16**. Root cause: in CI there is no human to approve tool prompts, and `claude-code-action` **does not grant Bash by default** — so every `pnpm` / `git` / `gh` command the agent tried was auto-denied. It could read files but never install, test, or commit.

> The `Internal error: directory mismatch … tsconfig.json` line in the logs is a known cosmetic bug in `claude-code-action`, not the cause.

## Fix

In `.github/workflows/overnight-implementation.yml` (`implement` job):

1. **Grant tools** — add `--allowedTools "Bash,Edit,Write,Read,Glob,Grep,Task,TodoWrite,WebFetch,WebSearch,Skill"` to `claude_args`. `--allowedTools` **merges** with the action's baseline, so its GitHub/file tools are retained.
2. **Set up pnpm** — the job set up Node but never pnpm/Corepack, so `pnpm` wouldn't be on PATH even after Bash worked (latent second defect). Added `pnpm/action-setup@v5` + `cache: 'pnpm'` + a pre-`pnpm install`, mirroring `ci.yml`. This also activates Husky hooks before the agent commits.

## Safety

Unchanged per **ADR-317-DEV**: output stays **Draft-only**, P1/`safety-critical` still require human Lead review, no auto-merge, and **every CI gate re-runs on the PR**. Safety rests on that regime, not on local permission gating.

## Verification

- Workflow YAML parses; step order is pnpm → node(+cache) → install → branch → Claude → PR.
- Follow-up: re-dispatch the workflow (`workflow_dispatch`, e.g. on issue #121) and confirm a Draft PR is opened.

refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)