### PR TITLE
fix(repo): re-establish PAT git auth before pushing the Draft-PR branch (refs #316)

### DIFF
--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -286,6 +286,12 @@ jobs:
 
           > ⚠️ **Partial draft** — the agent did not report success (outcome: \`${AGENT_OUTCOME}\`, likely the turn/time budget). This is work-in-progress that a human must finish; review the diff for completeness before relying on it."
           fi
+          # claude-code-action strips the PAT auth that actions/checkout set up
+          # and repoints origin at its own claude[bot] token, which cannot push
+          # here. Plain `git push` does not read GH_TOKEN, so re-establish auth
+          # with AUTOMATION_PAT on a clean URL before pushing.
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          gh auth setup-git
           git push --set-upstream origin "feature/issue-${{ matrix.issue }}"
           TITLE=$(gh issue view "${{ matrix.issue }}" --json title --jq .title)
           BODY=$(cat <<'EOF'


### PR DESCRIPTION
## Problem (run #5)

With #326 merged, run #5 finally got the agent to **succeed** (`MAX_TURNS: 150`, `AGENT_OUTCOME: success`, commits produced) and reached the push step — which then failed:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/naturelle137/AeroDash.git/'
```

## Root cause (not the PAT)

`GH_TOKEN` was present in the step (the PAT is configured correctly). The issue is git wasn't *using* it:

1. `actions/checkout` set git auth with `AUTOMATION_PAT` via `http.https://github.com/.extraheader`.
2. `claude-code-action` then **removed** that header and repointed `origin` at its own `claude[bot]` token (log: *"Removing existing git authentication headers… Updated remote URL with authentication token"*).
3. Our push step runs plain `git push`, which **does not read the `GH_TOKEN` env var** — it used the action's leftover/defunct credential → auth failure.

## Fix

In the push step, before `git push`:
```bash
git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"  # drop the action's embedded token
gh auth setup-git                                                        # git credential helper → GH_TOKEN (= AUTOMATION_PAT)
```
The PAT's `contents:write` covers the push; `gh pr create` already uses the same token, so the Draft PR still triggers CI + the reviewer bot.

## Validation

- ✅ YAML parses (act dry-run); diff is 6 lines, scoped to the push step.
- ⚠️ This step is **the one part act can't exercise** — it's `!env.ACT`-guarded and would push to real origin. So it's validated by reasoning + the fact that `gh auth setup-git` is GitHub's documented PAT-push pattern, and **must be confirmed by a real CI dispatch**.

This is expected to be the **last blocker**: permissions (#325), turn budget (#326), and now push auth.

refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)