### PR TITLE
fix(repo): issue-closing & completion policy + discovery-ticket handling + selector robustness (refs #316)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -80,11 +80,20 @@ FRR fields (present once for all P1 work in this issue):
 
 ## Implementation cycle
 
-Mode: standalone issue OR each open child in order.
+A `Feature` is finished only when EVERY child is finished — never partial. Pick the mode:
+
+- **Standalone issue** (no children): implement it; its PR `Closes #{ISSUE_ID}`.
+- **Feature with open children — all-in-one:** implement the feature AND every open
+  child on THIS branch, in dependency order; the single PR `Closes` the feature *and*
+  every child.
+- **Sub-task (`Task`) — incremental:** implement this task; its PR `Closes #{TASK_ID}`.
+  If NO sibling remains open afterwards, this is the feature's last task — its PR ALSO
+  `Closes #{PARENT_ID}` (attest the parent DoD too). If siblings remain open, close
+  only this task and leave the parent open.
 
 Per item: read -> classify boundary -> trace discovery -> edit -> trace update -> registry update -> tests -> commit.
 
-If blocked: skip blocked item; record reason; continue.
+If a child is genuinely blocked: skip it, record the reason, leave the parent open — never fake-close a feature with unfinished children.
 
 ## Read-before-write
 
@@ -135,13 +144,13 @@ Verify after each logical unit. Coverage cmd: `pnpm --filter frontend vitest run
 ## Issue updates
 
 ### Child task done (DoD-attested)
-Comment: `changes` + `files` + `trace` + `tests` + `Part of #{PARENT_ID}`. Tick only DoD items genuinely completed.
+Comment: `changes` + `files` + `trace` + `tests` + `Part of #{PARENT_ID}`. Attest the DoD so EVERY box ends ticked `[x]`: tick items genuinely done; for an item that does not apply, tick it and mark `N/A — <reason>`; NEVER tick an item that applies but is not done (finish it, or split the residue into a follow-up `Task`). The DoD gate rejects a closing PR whose issue still has any unticked box.
 
 ### Child task skipped
-Comment reason only; no DoD checks.
+Comment reason only; no DoD checks. The parent stays open.
 
 ### Parent
-Tick only DoD items genuinely completed. Forbid ticking skipped/unverified/manual-flight items.
+Attest the parent DoD the same way — every box ends `[x]` (genuinely done, or `N/A — <reason>`); never tick skipped/unverified/manual-flight items. Only close the parent when all children are closed and every parent DoD box is ticked.
 
 Parent comment fields: implementation summary | sub-issue status | files modified | trace ids + upstreams | test results | coverage compliance (if `product`) | DoD status. Omit sub-issues field when none.
 

--- a/.cursor/commands/implement-issue.md
+++ b/.cursor/commands/implement-issue.md
@@ -29,9 +29,9 @@ argument-hint: <ISSUE_ID>
 - `p1.gate`: no code before approval
 - `p1.frr`: present once; all P1 work
 - `p1.frr.fields`: `REQ` | `H` | output impact | pure-TS guarantee | deterministic guarantee | Zod plan | formula LaTeX | unit normalization | test plan | `>=3` edge cases | ADR need
-- `cycle.mode`: standalone issue | each open child in order
+- `cycle.mode`: a `Feature` is finished only when ALL children are finished — standalone -> PR `Closes #{ISSUE_ID}`; feature all-in-one -> implement feature + every open child on ONE branch, PR `Closes` feature + each child; sub-task incremental -> PR `Closes #{TASK_ID}`, and ALSO `Closes #{PARENT_ID}` when no sibling remains open
 - `cycle.per-item`: read -> classify boundary -> trace discovery -> edit -> trace update -> registry update -> tests -> commit
-- `cycle.blocked`: skip blocked item; record reason; continue
+- `cycle.blocked`: skip genuinely-blocked item; record reason; leave parent open; never fake-close a feature with unfinished children
 - `read.before-write`: all touched source; all touched registries; relevant issue bodies
 - `code.rules`: `ARCHITECTURE.md`; `CONTRIBUTING.md`; Composition API; Pinia stores; math delegation to `core/`
 - `trace.discovery`: issue body; `docs/requirements/`; `trace/`; relevant registries; next sequential ids
@@ -56,10 +56,10 @@ argument-hint: <ISSUE_ID>
 - `commit.format`: `{type}({scope}): {description} (refs #{ISSUE_ID})`
 - `commit.unit`: one commit per implemented child; else one standalone commit
 - `commit.refs.child`: child id first; parent id optional extra ref
-- `update.child.done`: check completed DoD only; comment `changes` + `files` + `trace` + `tests` + `Part of #{PARENT_ID}`
-- `update.child.skipped`: comment reason only; no DoD checks
-- `update.parent.body`: check completed DoD only
-- `update.parent.forbid`: no skipped/unverified/manual-flight items checked
+- `update.child.done`: attest DoD so EVERY box ends `[x]` (genuinely done, or tick + `N/A — <reason>`); never tick an applies-but-undone item; comment `changes` + `files` + `trace` + `tests` + `Part of #{PARENT_ID}`
+- `update.child.skipped`: comment reason only; no DoD checks; parent stays open
+- `update.parent.body`: attest parent DoD so every box ends `[x]` (done, or `N/A — <reason>`); close parent only when all children closed
+- `update.parent.forbid`: never tick skipped/unverified/manual-flight items
 - `comment.parent.fields`: implementation summary | sub-issue status | files modified | trace ids + upstreams | test results | coverage compliance if `product` | DoD status
 - `comment.parent.subissues`: omit when none
 - `final.labels.read`: current labels first

--- a/.cursor/commands/pr.create.md
+++ b/.cursor/commands/pr.create.md
@@ -29,7 +29,7 @@ argument-hint: <target-branch> [changelog=yes|no]
 - `pr.body.template`: draft PR body from `.github/pull_request_template.md`; preserve section order
 - `pr.body.template.checklist`: obey `template.issue_state` `template.no_stray_markers` `template.na.allow` `template.na.checked` `template.checklist.complete` `template.post_merge` in applied `github-pr` rule
 - `pr.body.summary`: brief bullets only
-- `pr.body.related`: `develop` target -> `Ref #...` or `Related to #...`; `main` target -> close keywords allowed
+- `pr.body.related`: `develop` target -> `Closes #...` | `Fixes #...` (auto-closes the issue on merge); `main` target -> `Ref #...` only (issues already closed on the develop merge)
 - `pr.body.docs`: include only real requirement, architecture, risk, journey, code-doc, and changelog updates
 - `pr.body.testing`: record only checks actually run; otherwise use `N/A` with reason
 - `pr.exec.create`: `create_pull_request` with `owner=naturelle137` `repo=AeroDash` `draft=false` `maintainer_can_modify=true`

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -43,7 +43,7 @@ body:
     id: dod
     attributes:
       label: Definition of Done / Checklist
-      description: What specific tasks and conditions must be met for this feature to be considered complete? (Use - [ ] for checkboxes)
+      description: "What specific tasks and conditions must be met for this feature to be considered complete? (Use - [ ] for checkboxes.) At closing, EVERY box must end ticked [x] — done, or ticked and marked `N/A — <reason>` if it does not apply. An unticked box blocks closing (DoD Attestation Gate)."
       placeholder: "- [ ] The feature is implemented\n- [ ] Unit tests are written\n- [ ] Documentation is updated"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/sub_task.yml
+++ b/.github/ISSUE_TEMPLATE/sub_task.yml
@@ -46,6 +46,7 @@ body:
     id: dod
     attributes:
       label: Definition of Done (DoD)
+      description: "At closing, EVERY box must end ticked [x] — done, or ticked and marked `N/A — <reason>` if it does not apply. An unticked box blocks closing (DoD Attestation Gate)."
       options:
         - label: Implementation is complete.
           required: false

--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -233,9 +233,12 @@ jobs:
             `pnpm test:integration`, `pnpm build`. Fix any failures you introduced.
 
             Completion & attestation (per the implement-issue skill — NOT optional):
-            - Finish the whole ticket. Tick the issue's DoD checkboxes ONLY for items
-              you have genuinely verified done; never tick skipped, unverified, or
-              human-only items (e.g. manual flight testing).
+            - Finish the whole ticket and attest its DoD so EVERY checkbox in the issue
+              ends ticked `[x]`: tick items genuinely verified done; for an item that
+              does not apply, tick it and mark `N/A — <reason>`; never tick a skipped,
+              unverified, or human-only item (e.g. manual flight testing) — those keep
+              the issue open. The DoD gate rejects a `Closes` PR whose issue still has
+              any unticked box.
             - Author the PR description by FILLING OUT the repository PR template at
               `.github/pull_request_template.md` and writing the result to the file
               `$RUNNER_TEMP/pr-body.md` — the workflow uses that file verbatim as the
@@ -246,7 +249,13 @@ jobs:
             - In the template's "Related Issues" section use `Closes #${{ matrix.issue }}`
               ONLY when the issue is 100% complete and every DoD item is genuinely
               ticked; otherwise use `Refs #${{ matrix.issue }}` and state plainly what
-              remains. Do NOT claim `Closes` for incomplete work.
+              remains. Do NOT claim `Closes` for incomplete work. (Merging to `develop`
+              auto-closes via `Closes` — every issue is closed by its PR to develop.)
+            - Parent/child closing: a feature is finished only when EVERY child is. If
+              this issue is a sub-task and NO sibling remains open after your work, also
+              add `Closes #<parent-feature>` and attest the parent's DoD; if it is a
+              feature, only `Closes` it when all its children are already closed. Never
+              close a feature that still has unfinished children.
 
             Hard rules (ADR-317-DEV — do not violate):
             - Honour every quality gate. NEVER use --no-verify or bypass Husky/ESLint/tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,4 +334,18 @@ stateDiagram-v2
 * A **`Task`** acts as a sub-task to a parent **`Feature`** or **`Bug`**.
 * **Sub-tasks (`Task`)**: Are closed with `fixed` and moved to *Done* as soon as their PR is merged into `develop`, a `release/`, or a `hotfix/` branch.
 * **Parent Tickets (`Feature` / `Bug`)**: Can **only** be labelled `fixed`, closed, and moved to *Done* when **all** of its sub-tasks are closed. *(Note: A sub-task closed as `wont do` counts as closed, provided the rationale is documented in the ticket).*
+* **A feature is "finished" only when every child is finished.** Implement a parent feature one of two ways — never partially:
+    1. **All-in-one:** implement the feature *and* **all** its sub-tasks on the same branch; that single PR to `develop` carries `Closes #<feature>` plus `Closes #<each-sub-task>`.
+    2. **Incremental:** implement the sub-tasks first (each its own branch + PR, `Closes #<sub-task>`); the **last** sub-task's PR — opened once every sibling is already closed — *also* carries `Closes #<feature>`, closing the parent in the same merge.
+  Never close a feature while any sub-task is still open, and never leave a feature open once its last sub-task is done.
 * Tickets labelled `duplicate` or `wont do` are removed from the project board entirely.
+
+### Closing requires a complete, ticked attestation
+
+A ticket is closed (`fixed`) only when its **Definition of Done is genuinely met and attested** — and attestation means **every checkbox is ticked `[x]`**, in **both** the issue *and* the closing PR:
+
+* Tick `[x]` an item you have genuinely completed and verified.
+* If an item does **not apply** to this change, still tick it `[x]`, mark it `N/A`, and give a one-line reason. An unticked `[ ]` reads as an open obligation — even when truly N/A.
+* **Never** tick an item that applies but is not done — that is a false attestation. Finish it, or (for a sub-task) split the residue into a follow-up `Task` and keep the parent open.
+
+The **DoD Attestation Gate** (`.github/workflows/dod-gate.yml`) enforces this on the issue side — a PR that closes an issue with any unticked DoD box fails the check — and the PR template's checklist enforces it on the PR side (see `/pr.create`).

--- a/docs/development/autonomous-implementation.md
+++ b/docs/development/autonomous-implementation.md
@@ -43,7 +43,9 @@ schedule / dispatch
    > with the `scope` input, or exclude a specific issue with `automation:opt-out`.
 2. **Implement** — for each selected issue, the bot branches `feature/issue-<n>`
    from `develop`, runs the repository's `/implement-issue` flow, and opens a
-   **Draft** PR referencing the issue with `refs #<n>` (never `Closes`).
+   **Draft** PR. A genuinely complete issue uses `Closes #<n>` so merging to
+   `develop` closes the ticket; an incomplete one uses `Refs #<n>` and flags what
+   remains. Every issue is closed by its PR to `develop` — never deferred to `main`.
 
 ## Triggers
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Three governance rules were stated inconsistently across the repo. This aligns them uniformly in docs, skills, commands, issue/PR templates, and the overnight automation.

1. **Every issue is closed by its PR to `develop`** (via `Closes #`), never deferred to `main`. Fixed the *reversed* keyword logic in `.cursor/commands/pr.create.md` (it told agents to use a reference on `develop` and a closing keyword on `main` — backwards) and the stale "refs … never `Closes`" wording in `docs/development/autonomous-implementation.md`. The rest (CLAUDE.md, CONTRIBUTING, PR template, cursor rules, `pr.create`, dod-gate) was already consistent.
2. **Closing requires a complete, ticked attestation** — every checkbox ticked `[x]` in **both** the issue DoD **and** the PR; an item that does not apply is still ticked and marked `N/A — <reason>`; never tick an applies-but-undone item. Added to CONTRIBUTING, the implement-issue skill (+ cursor mirror), both issue templates, and the overnight prompt.
3. **A feature is finished only when every child is finished** — either feature + all sub-tasks on one branch (one PR closes them all), or sub-tasks incrementally with the **last** sub-task's PR also closing the parent once siblings are closed. Documented in CONTRIBUTING, the skill (+ mirror), and the overnight prompt.

### Related Issues

Refs #316

### Issue State Management (Post-Merge)

- [x] N/A — uses a reference (no closing keyword); does not auto-close an issue.

### Affected Items

- **Requirements Implemented/Affected:** `N/A` — process/governance documentation; no product `REQ-` in scope.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: process documentation; no product requirement).
- [x] **Architecture:** `N/A` (Reason: aligns wording with existing ADR-303 / ADR-317; no new decision).
- [x] **Risk Management:** `N/A` (Reason: no hazard affected).
- [x] **Journeys:** `N/A` (Reason: contributor-workflow docs, not a pilot journey).
- [x] **Code Docs:** Updated `CONTRIBUTING.md`, the implement-issue skill, issue/PR guidance, and the overnight workflow prompt.

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist

- [x] **Target Branch:** Correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: documentation/skills/templates + workflow prompt text; no app code).
- [x] **Integration Tests:** `N/A` (Reason: as above).
- [x] **Manual Testing:** markdownlint clean; workflow YAML and issue templates parse.
- [x] **DoD:** N/A — reference-only PR aligning policy wording; not a single DoD-bearing ticket.
- [x] **Review:** Performed a self-review of the diff.
- [x] **ADR:** `N/A` (Reason: no new decision; wording aligns with ADR-303 and ADR-317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)