### PR TITLE
fix(repo): discovery-ticket closing + selector defers open-PR/native-parent issues (refs #316)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -82,6 +82,13 @@ FRR fields (present once for all P1 work in this issue):
 
 A `Feature` is finished only when EVERY child is finished — never partial. Pick the mode:
 
+- **Discovery / scoping ticket** (body says "discovery/scoping", "not an
+  implementation ticket", "produce a recommendation", "file follow-up issues"):
+  its deliverable is the written recommendation + the filed follow-ups. When those
+  exist, it is DONE — its PR `Closes #{ISSUE_ID}`. File the follow-ups as
+  **independent** issues that *reference* this one in their body (e.g. "Spawned by
+  #{ISSUE_ID}") — do NOT attach them as native sub-issues, and do NOT hold this
+  ticket open as an umbrella waiting on them.
 - **Standalone issue** (no children): implement it; its PR `Closes #{ISSUE_ID}`.
 - **Feature with open children — all-in-one:** implement the feature AND every open
   child on THIS branch, in dependency order; the single PR `Closes` the feature *and*

--- a/.cursor/commands/implement-issue.md
+++ b/.cursor/commands/implement-issue.md
@@ -29,7 +29,7 @@ argument-hint: <ISSUE_ID>
 - `p1.gate`: no code before approval
 - `p1.frr`: present once; all P1 work
 - `p1.frr.fields`: `REQ` | `H` | output impact | pure-TS guarantee | deterministic guarantee | Zod plan | formula LaTeX | unit normalization | test plan | `>=3` edge cases | ADR need
-- `cycle.mode`: a `Feature` is finished only when ALL children are finished — standalone -> PR `Closes #{ISSUE_ID}`; feature all-in-one -> implement feature + every open child on ONE branch, PR `Closes` feature + each child; sub-task incremental -> PR `Closes #{TASK_ID}`, and ALSO `Closes #{PARENT_ID}` when no sibling remains open
+- `cycle.mode`: a `Feature` is finished only when ALL children are finished — discovery/scoping ticket ("not an implementation ticket" / "produce a recommendation" / "file follow-ups") -> deliverable is the recommendation + filed follow-ups; PR `Closes #{ISSUE_ID}`; file follow-ups as INDEPENDENT issues that reference it (not native sub-issues), never an umbrella; standalone -> PR `Closes #{ISSUE_ID}`; feature all-in-one -> implement feature + every open child on ONE branch, PR `Closes` feature + each child; sub-task incremental -> PR `Closes #{TASK_ID}`, and ALSO `Closes #{PARENT_ID}` when no sibling remains open
 - `cycle.per-item`: read -> classify boundary -> trace discovery -> edit -> trace update -> registry update -> tests -> commit
 - `cycle.blocked`: skip genuinely-blocked item; record reason; leave parent open; never fake-close a feature with unfinished children
 - `read.before-write`: all touched source; all touched registries; relevant issue bodies

--- a/.github/scripts/select-issues.mjs
+++ b/.github/scripts/select-issues.mjs
@@ -147,6 +147,12 @@ export function buildQueue(issues, config) {
     issueNumber = null,
   } = config;
   const openSet = asNumberSet(config.openIssueNumbers);
+  // Issue numbers that already have an open `feature/issue-<n>` PR (work in flight).
+  const withOpenPr = asNumberSet(config.issuesWithOpenPr);
+  // GitHub *native* sub-issues: { "<parentNumber>": [openChildNumbers] }. The
+  // workflow gathers these (already filtered to open) because issue bodies no
+  // longer carry the parent link reliably once native sub-issues are used.
+  const nativeChildrenByParent = config.nativeChildrenByParent ?? {};
 
   const entry = (issue, reason) => ({ number: issue.number, title: issue.title, reason });
 
@@ -169,20 +175,35 @@ export function buildQueue(issues, config) {
 
   // Reverse parent map: a parent issue with any still-open child is deferred so
   // children land first (a parent Feature only closes once its Tasks are done).
+  // Sources: (1) the child's body "Parent Feature / Issue #N" field, and
+  // (2) GitHub native sub-issues passed in via nativeChildrenByParent.
   const openChildrenOf = new Map();
+  const addChild = (parent, child) => {
+    if (parent == null) return;
+    const cur = openChildrenOf.get(parent) ?? [];
+    if (!cur.includes(child)) cur.push(child);
+    openChildrenOf.set(parent, cur);
+  };
   for (const issue of issues) {
-    const parent = parseParent(issue.body);
-    if (parent != null && openSet.has(issue.number)) {
-      if (!openChildrenOf.has(parent)) openChildrenOf.set(parent, []);
-      openChildrenOf.get(parent).push(issue.number);
-    }
+    if (openSet.has(issue.number)) addChild(parseParent(issue.body), issue.number);
   }
+  for (const [parent, kids] of Object.entries(nativeChildrenByParent)) {
+    for (const child of kids ?? []) addChild(Number(parent), Number(child));
+  }
+  // Stable ordering of children for reproducible reasons.
+  for (const [p, kids] of openChildrenOf) openChildrenOf.set(p, kids.sort((a, b) => a - b));
 
   eligible.sort(compareIssues);
 
   const queue = [];
   const deferred = [];
   for (const issue of eligible) {
+    // Defer issues whose work is already in flight in an open PR — re-implementing
+    // it wastes a run and risks a duplicate branch (this is what trapped #230).
+    if (withOpenPr.has(issue.number)) {
+      deferred.push(entry(issue, 'open PR already in progress'));
+      continue;
+    }
     // Defer parents that still have open children.
     const openChildren = openChildrenOf.get(issue.number) ?? [];
     if (openChildren.length > 0) {
@@ -245,6 +266,8 @@ async function main() {
     // Optional scope narrowing (default: just `accepted` — product + engineering).
     requiredLabels: input.requiredLabels ?? REQUIRED_LABELS,
     issueNumber: input.issueNumber ?? null,
+    issuesWithOpenPr: input.issuesWithOpenPr ?? [],
+    nativeChildrenByParent: input.nativeChildrenByParent ?? {},
   };
   const result = buildQueue(input.issues ?? [], config);
   process.stdout.write(JSON.stringify({ ...result, report: renderReport(result, config) }, null, 2));

--- a/.github/scripts/select-issues.test.mjs
+++ b/.github/scripts/select-issues.test.mjs
@@ -135,6 +135,30 @@ test('buildQueue defers a parent that still has open child tasks', () => {
   assert.equal(deferred.find((d) => d.number === 100).reason.includes('#101'), true);
 });
 
+test('buildQueue defers an issue that already has an open PR', () => {
+  const issues = [issue({ number: 230 }), issue({ number: 231, createdAt: '2026-02-01T00:00:00Z' })];
+  const { queue, deferred } = buildQueue(
+    issues,
+    cfg({ batchSize: 5, openIssueNumbers: [230, 231], issuesWithOpenPr: [230] }),
+  );
+  // 230 has a PR in flight -> deferred; 231 is free -> selected.
+  assert.deepEqual(queue.map((q) => q.number), [231]);
+  assert.match(deferred.find((d) => d.number === 230).reason, /open PR already in progress/);
+});
+
+test('buildQueue defers a parent that has open NATIVE sub-issues', () => {
+  // Parent #230 with native children #331/#332 (no body-text parent link at all).
+  const issues = [issue({ number: 230, title: 'Discovery parent' })];
+  const { queue, deferred } = buildQueue(
+    issues,
+    cfg({ batchSize: 5, openIssueNumbers: [230, 331, 332], nativeChildrenByParent: { 230: [331, 332] } }),
+  );
+  assert.deepEqual(queue.map((q) => q.number), []);
+  const d = deferred.find((x) => x.number === 230);
+  assert.equal(d.reason.includes('#331'), true);
+  assert.equal(d.reason.includes('#332'), true);
+});
+
 test('buildQueue skips ineligible issues with reasons', () => {
   const issues = [
     issue({ number: 1, state: 'closed' }),

--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -127,9 +127,28 @@ jobs:
           # All open issue numbers — used to resolve whether a dependency is unresolved.
           gh issue list --state open --json number --limit 500 --jq '[.[].number]' > open.json
 
+          # Issues whose work is already in flight in an open `feature/issue-<n>` PR —
+          # the selector defers these so a done-but-not-merged ticket isn't re-picked.
+          gh pr list --state open --json headRefName --limit 200 \
+            --jq '[.[].headRefName | select(test("^feature/issue-[0-9]+$")) | capture("issue-(?<n>[0-9]+)").n | tonumber]' \
+            > open_pr_issues.json
+
+          # GitHub NATIVE sub-issues per current-milestone candidate → defer parents
+          # that still have open children (native links, not just body-text parents).
+          echo '{}' > native_children.json
+          for n in $(jq -r --arg ms "${MS:-0}" '.[] | select((.milestone.number // 0) == ($ms|tonumber)) | .number' candidates.json); do
+            kids=$(gh api "repos/$GITHUB_REPOSITORY/issues/$n/sub_issues" \
+              --jq '[.[] | select(.state=="open") | .number]' 2>/dev/null || echo '[]')
+            [ "$kids" = '[]' ] && continue
+            jq --arg p "$n" --argjson k "$kids" '.[$p]=$k' native_children.json > native_children.tmp
+            mv native_children.tmp native_children.json
+          done
+
           jq -n \
             --slurpfile c candidates.json \
             --slurpfile o open.json \
+            --slurpfile pr open_pr_issues.json \
+            --slurpfile nc native_children.json \
             --arg ms "${MS:-}" \
             --arg batch "$BATCH" \
             --arg issue "$ISSUE" \
@@ -137,6 +156,8 @@ jobs:
             '{
                issues: $c[0],
                openIssueNumbers: $o[0],
+               issuesWithOpenPr: $pr[0],
+               nativeChildrenByParent: $nc[0],
                currentMilestone: (if $ms == "" then null else ($ms|tonumber) end),
                batchSize: ($batch|tonumber),
                requiredLabels: $required,
@@ -256,6 +277,14 @@ jobs:
               add `Closes #<parent-feature>` and attest the parent's DoD; if it is a
               feature, only `Closes` it when all its children are already closed. Never
               close a feature that still has unfinished children.
+            - EXCEPTION — discovery/scoping tickets: if this issue's body says it is a
+              discovery/scoping ticket ("not an implementation ticket", "produce a
+              recommendation", "file follow-up issues"), its deliverable is the written
+              recommendation + the filed follow-ups. Produce those, then `Closes
+              #${{ matrix.issue }}`. File each follow-up as an INDEPENDENT issue that
+              references this one in its body (e.g. "Spawned by #${{ matrix.issue }}") —
+              do NOT attach them as native sub-issues and do NOT keep this ticket open
+              as an umbrella.
 
             Hard rules (ADR-317-DEV — do not violate):
             - Honour every quality gate. NEVER use --no-verify or bypass Husky/ESLint/tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,6 +338,7 @@ stateDiagram-v2
     1. **All-in-one:** implement the feature *and* **all** its sub-tasks on the same branch; that single PR to `develop` carries `Closes #<feature>` plus `Closes #<each-sub-task>`.
     2. **Incremental:** implement the sub-tasks first (each its own branch + PR, `Closes #<sub-task>`); the **last** sub-task's PR — opened once every sibling is already closed — *also* carries `Closes #<feature>`, closing the parent in the same merge.
   Never close a feature while any sub-task is still open, and never leave a feature open once its last sub-task is done.
+* **Discovery / scoping tickets are the exception to the umbrella rule.** A ticket whose deliverable is an *evaluation or recommendation* — it says so ("discovery / scoping ticket", "not an implementation ticket", "produce a recommendation", "file follow-up issues") — is **finished once its recommendation is written and its follow-ups are filed**. Close it then with `Closes #`; do **not** hold it open as an umbrella. The follow-ups it spawns are **independent** issues that merely *reference* it (e.g. "Spawned by #N") — they are **not** native sub-issues and must **not** block its closure.
 * Tickets labelled `duplicate` or `wont do` are removed from the project board entirely.
 
 ### Closing requires a complete, ticked attestation


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Root-causes the loop where the overnight bot kept re-selecting a *done-but-open* discovery ticket and reporting "nothing to do". Two improvements:

1. **Discovery/scoping tickets close on completion.** A ticket whose deliverable is an evaluation/recommendation ("not an implementation ticket", "produce a recommendation", "file follow-ups") is finished once its write-up exists and its follow-ups are filed — its PR uses a closing keyword then. Its follow-ups are **independent** issues that *reference* it (not native sub-issues), so it is never held open as an umbrella. This is distinct from implementation-features, which close only when all children close. Encoded in `CONTRIBUTING.md`, the implement-issue skill (+ cursor mirror), and the overnight prompt.
2. **Selector robustness (`select-issues.mjs` + workflow + tests).** The queue now defers (a) issues that already have an open `feature/issue-<n>` PR (work in flight), and (b) parents with open **native** GitHub sub-issues (previously only body-text parents were detected). The workflow's queue step gathers both signals.

Validated under `act` against live data: the build-queue step ran clean and correctly **deferred 7 performance Features** (`#298`–`#305`) as native parents of open sub-issues; **`#230`** no longer appears in the queue (it is done). Selector unit tests: **20/20 pass** (+2 new).

### Related Issues

Refs #316

### Issue State Management (Post-Merge)

- [x] N/A — uses a reference (no closing keyword); does not auto-close an issue.

### Affected Items

- **Requirements Implemented/Affected:** `N/A` — CI automation + process docs; no product `REQ-` in scope.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: automation/process; no product requirement).
- [x] **Architecture:** `N/A` (Reason: refines ADR-303 / ADR-317 wording; no new decision).
- [x] **Risk Management:** `N/A` (Reason: no hazard affected).
- [x] **Journeys:** `N/A` (Reason: developer-workflow automation, not a pilot journey).
- [x] **Code Docs:** Updated `CONTRIBUTING.md`, the implement-issue skill, and the overnight workflow.

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist

- [x] **Target Branch:** Correctly targets `develop`.
- [x] **Unit Tests:** Added 2 selector tests; `node --test` 20/20 pass.
- [x] **Integration Tests:** `N/A` (Reason: no app integration surface; selector is a pure unit-tested module).
- [x] **Manual Testing:** Ran the `select` job under `act` against live GitHub data — native-parent deferral confirmed.
- [x] **DoD:** N/A — reference-only PR (one increment toward epic #316).
- [x] **Review:** Performed a self-review of the diff.
- [x] **ADR:** `N/A` (Reason: aligns with existing ADR-303/ADR-317; no new decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)