### PR TITLE
fix(repo): make DoD attestation gate Dependabot-aware

### DIFF
--- a/.github/workflows/dod-gate.yml
+++ b/.github/workflows/dod-gate.yml
@@ -33,16 +33,20 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
 
-            // Dependency bots (Dependabot/Renovate) paste upstream changelogs
-            // into the PR body. Those contain closing keywords + issue numbers
-            // from OTHER repos (e.g. "closes #14729" from vuejs/core), which the
-            // scraper below would try to resolve against AeroDash and crash on a
-            // 404. Bot PRs never close AeroDash issues, so there is nothing to
-            // attest — pass the check explicitly so it satisfies branch
-            // protection instead of skipping the job (a skipped required check
-            // never reports and blocks the PR forever).
-            if (pr.user && pr.user.type === 'Bot') {
-              core.info(`PR authored by bot "${pr.user.login}"; DoD attestation not applicable.`);
+            // Dependabot pastes upstream changelogs into the PR body. Those
+            // contain closing keywords + issue numbers from OTHER repos (e.g.
+            // "closes #14729" from vuejs/core), which the scraper below would
+            // try to resolve against AeroDash and crash on a 404. Dependabot
+            // PRs never close AeroDash issues, so there is nothing to attest —
+            // pass the check explicitly so it satisfies branch protection
+            // instead of skipping the job (a skipped required check never
+            // reports and blocks the PR forever).
+            //
+            // Scoped to Dependabot deliberately. If another bot ever needs the
+            // same exemption, add its login here explicitly rather than
+            // broadening this to all bots.
+            if (pr.user && pr.user.login === 'dependabot[bot]') {
+              core.info(`PR authored by ${pr.user.login}; DoD attestation not applicable.`);
               return;
             }
 

--- a/.github/workflows/dod-gate.yml
+++ b/.github/workflows/dod-gate.yml
@@ -32,6 +32,20 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
+
+            // Dependency bots (Dependabot/Renovate) paste upstream changelogs
+            // into the PR body. Those contain closing keywords + issue numbers
+            // from OTHER repos (e.g. "closes #14729" from vuejs/core), which the
+            // scraper below would try to resolve against AeroDash and crash on a
+            // 404. Bot PRs never close AeroDash issues, so there is nothing to
+            // attest — pass the check explicitly so it satisfies branch
+            // protection instead of skipping the job (a skipped required check
+            // never reports and blocks the PR forever).
+            if (pr.user && pr.user.type === 'Bot') {
+              core.info(`PR authored by bot "${pr.user.login}"; DoD attestation not applicable.`);
+              return;
+            }
+
             const rawBody = pr.body || '';
 
             // Strip code regions so example text like `Closes #116` in prose
@@ -61,9 +75,21 @@ jobs:
 
             const failures = [];
             for (const n of issueRefs) {
-              const { data: issue } = await github.rest.issues.get({
-                owner, repo, issue_number: n,
-              });
+              let issue;
+              try {
+                ({ data: issue } = await github.rest.issues.get({
+                  owner, repo, issue_number: n,
+                }));
+              } catch (err) {
+                // A number scraped from a pasted cross-repo reference (e.g.
+                // "owner/repo#123") won't exist here. Don't crash the gate —
+                // warn and move on rather than blocking the PR on a 404.
+                if (err.status === 404) {
+                  core.warning(`Issue #${n} not found in ${owner}/${repo}; likely a cross-repo reference — skipping.`);
+                  continue;
+                }
+                throw err;
+              }
               const issueBody = issue.body || '';
 
               // Extract the DoD block. Heading variants accepted.


### PR DESCRIPTION
## What

Make the **DoD Attestation Gate** (`.github/workflows/dod-gate.yml`) Dependabot-aware so it stops failing on dependency PRs.

## Why

The gate scrapes closing keywords + issue numbers from the PR **body** and verifies each referenced issue's DoD checklist. Dependabot pastes the upstream changelog into the body, which contains closing keywords + issue numbers from **other** repositories (e.g. a `vuejs/core` entry like `closes #14729`).

The gate resolved those foreign numbers against AeroDash, hit a `404`, and the unhandled error **crashed the step** — so `verify-dod-attestation` failed on every open Dependabot PR (#253–#258). This is the reason no Dependabot pipeline is currently green.

## Fix

1. **Pass the check explicitly for bot-authored PRs** (`pr.user.type === 'Bot'`). Bots never close AeroDash issues, so there is nothing to attest. It returns success rather than skipping the job, so the check still satisfies branch protection as a required status.
2. **Treat a `404` issue lookup as a warning + skip** instead of an unhandled throw, so a stray cross-repo reference can never crash the gate on human PRs either.

## Impact

- Unblocks the 6 open Dependabot PRs (and all future ones) from the false `verify-dod-attestation` failure.
- The remaining real signal on those PRs — the HIGH `fast-uri` advisory in `pnpm audit` — is resolved separately by the group-bump PR #258 (which regenerates the lockfile to `fast-uri@3.1.2`, matching the existing `pnpm.overrides`).

## Testing

- Behaviour-only change to a `github-script` step; validated against the failing run (it was crashing on a non-existent issue number scraped from a Vue changelog).
- For human PRs with no closing keywords (like this one), the gate short-circuits with "nothing to verify".
