### PR TITLE
chore(repo): align all three automation bots at MAX_TURNS=150 (refs #316)

### DIFF
--- a/.github/workflows/pr-iteration.yml
+++ b/.github/workflows/pr-iteration.yml
@@ -47,8 +47,10 @@ env:
   MAX_CORRECTIONS: '2'
   # A correction round runs the full pipeline + fixes; 40 turns proved too small
   # for the implementer (see overnight-implementation.yml), so give corrections
-  # comparable headroom. Kept below timeout-minutes so the turn cap binds first.
-  MAX_TURNS: '80'
+  # comparable headroom. Aligned with overnight-implementation.yml and
+  # pr-review-bot.yml at 150 so all three bots share one budget knob; kept
+  # below the 60-min job timeout so the turn cap still binds first.
+  MAX_TURNS: '150'
 
 jobs:
   orchestrate:

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -26,7 +26,14 @@ permissions:
 
 env:
   REVIEW_MODEL: claude-opus-4-7
-  MAX_TURNS: '30'
+  # A full structured review (read diff, walk affected files, cross-check P1
+  # isolation + traceability + safety, write findings, submit via `gh pr
+  # review`) needs comparable headroom to the implementer and iteration bots.
+  # 30 proved too small: the reviewer on PR #346 (25 files / +2916 lines) hit
+  # `error_max_turns` mid-review and posted no review at all, which leaves the
+  # ready-gate stuck. Aligned with overnight-implementation.yml and
+  # pr-iteration.yml at 150 so all three bots share one budget knob.
+  MAX_TURNS: '150'
 
 jobs:
   review:


### PR DESCRIPTION
### Summary

- Bumps `pr-review-bot.yml` `MAX_TURNS` 30 → 150 and `pr-iteration.yml` `MAX_TURNS` 80 → 150 so all three autonomous bots share one budget knob (overnight implementer was already at 150 from #326). Inline rationale added to both workflows referencing the sibling files.
- Motivation: PR #346 (25 files / +2916 lines) hit `error_max_turns` in the reviewer after 271 s — no review was posted, so the iteration bot's ready-gate had nothing to flip on and the PR was stuck. A review does the same shape of work as a corrections round (read diff, walk affected files, cross-check P1 isolation / traceability / safety, write findings, submit via `gh pr review`); giving it the smallest cap of the three was the silent asymmetry that caused the failure.
- Pure CI/meta change. No product code, requirements, ADRs, journeys, or risk-register entries touched. Behaviour for already-green PRs is unchanged — the cap binds only when the agent would otherwise need more turns than it had.

**Follow-up (not in this PR — surfaced so it isn't forgotten):** `pull_request` events use the workflow file from the PR's head SHA, so this bump only takes effect on PR #346 after `develop` is merged into `feature/issue-108` (or this commit is cherry-picked there). The `synchronize` event then re-fires the reviewer with the new cap; the existing implementation commit on #346 is preserved.

### Related Issues

- Refs #316 — the autonomous-pipeline parent still has four open children (#317, #318, #319, #320); per the close-on-develop policy aligned in #339, the umbrella is closed by the LAST sub-task PR, not by this tuning PR.

### Issue State Management (Post-Merge)

- [ ] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A` — CI/meta tuning, no product requirement touched.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: engineering-only CI tuning; no product requirement is created or modified.)
- [x] **Architecture:** `N/A` (Reason: complies with ADR-317-DEV operational-defaults table; no architectural shift requires a new ADR.)
- [x] **Risk Management:** `N/A` (Reason: bot turn-budget is a developer-pipeline knob; bots remain Draft-only with mandatory human Lead review for P1, so no new hazard is introduced.)
- [x] **Journeys:** `N/A` (Reason: no pilot-facing behaviour — automation-pipeline tuning only.)
- [x] **Code Docs:** `N/A` (Reason: rationale lives in the inline comments of both workflow files alongside the bumped `MAX_TURNS` constant; CHANGELOG entry omitted at maintainer's request as this is an internal CI knob with no user-visible effect.)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. — No safety tag, REQ, hazard, or journey is added/modified/removed; the matrix is unchanged.
- [x] No new hazards introduced. — Bots remain Draft-only, never auto-merge, never approve; P1/safety-critical still requires human Lead review (ADR-317-DEV invariants 1–3). A higher turn cap lets the reviewer **complete** its read-only review, which strengthens — not weakens — the human-in-the-loop signal.
- [x] Existing mitigations preserved. — Branch protection, DoD gate, traceability gate, P1-ISOLATION lint, and Lead-review requirement are untouched; only the per-run turn quota changes.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). — No file under `frontend/src/core/` is touched; the change is confined to `.github/workflows/`.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (features/bugs) OR `main` (releases/hotfixes). — `feature/raise-bot-turn-budget` → `develop`.
- [x] **Unit Tests:** Added/updated and passing locally OR `N/A` (Reason: workflow YAML is declarative CI configuration; not executable application code reachable from Vitest. The semantics of the `--max-turns` flag are owned by `anthropics/claude-code-action`, validated upstream.)
- [x] **Integration Tests:** Passing OR `N/A` (Reason: same — no integration surface to exercise for a YAML constant change.)
- [x] **Manual Testing:** Performed successfully (Mandatory for `main`) OR `N/A` (Reason: PR targets `develop`, not `main`; the change is verified by the live behaviour after merge — next reviewer / corrections / overnight run executes under the new cap. Local YAML lints clean via `pnpm lint` markdown step; lint-staged ran on commit.)
- [x] **DoD:** All Definition of Done items from the linked Feature/Bug are met. — Operational-defaults tuning for the umbrella #316 (no per-ticket DoD; rationale captured in commit message + inline comments).
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** Does this change require an Architectural Decision Record (ADR) update/creation? If yes, it is included. — `N/A`. ADR-317-DEV defines "bounded effort per issue (timeout + `--max-turns`)" as an operational default, explicitly tunable without an ADR change; this PR adjusts the value, not the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)