### PR TITLE
fix(repo): iteration orchestrator no longer waits on its sibling reviewer check (refs #316)

### DIFF
--- a/.github/workflows/pr-iteration.yml
+++ b/.github/workflows/pr-iteration.yml
@@ -20,6 +20,14 @@ on:
     # React to EVERY PR-gating workflow, not just CI. A red DoD/Security/E2E/
     # Traceability/branching gate must also drive a correction — otherwise a PR
     # whose CI is green but another gate is red sits red forever with no action.
+    # `Autonomous PR Reviewer` is listed defensively: a `pull_request_review`
+    # event fires while the reviewer workflow's own check is still in_progress
+    # (the review is submitted a few seconds before the workflow run reports
+    # `completed`), and the orchestrator's pending-gate (below) used to count
+    # that check as pending and refuse to act. The race is fixed at the source
+    # by excluding the reviewer's check from the pending-set, but listing the
+    # workflow here also makes the loop self-healing for any other transient
+    # race that ever leaves the orchestrator with a `wait` verdict.
     workflows:
       - CI
       - DoD Attestation Gate
@@ -27,6 +35,7 @@ on:
       - Traceability Gate
       - E2E Tests (Playwright)
       - Enforce Branching Model
+      - Autonomous PR Reviewer
     types: [completed]
 
 # Serialise per branch across BOTH trigger types so the correction budget is honoured.
@@ -111,11 +120,20 @@ jobs:
             const reviewClean = Boolean(last) && last.state !== 'CHANGES_REQUESTED';
 
             // 5) Aggregate check state on the current head — EVERY gate, not just CI.
-            //    Exclude this workflow's own check to avoid a self-referential race.
+            //    Exclude this workflow's own check to avoid a self-referential race,
+            //    AND exclude the reviewer's check ('Automated review' from
+            //    pr-review-bot.yml): on a `pull_request_review.submitted` trigger the
+            //    review is posted ~20s BEFORE the reviewer workflow itself reports
+            //    `completed`, so the orchestrator would otherwise see its sibling
+            //    check as pending, decide `wait`, and never re-fire (PR #346 was
+            //    stuck this way until this fix). The reviewer's verdict is already
+            //    consumed via the `reviews` API above; its check-run status carries
+            //    no extra information the orchestrator needs.
             const checks = await github.paginate(github.rest.checks.listForRef, {
               owner, repo, ref: headSha, per_page: 100,
             });
-            const relevant = checks.filter((c) => c.name !== 'Iterate / ready-gate');
+            const SELF_CHECKS = new Set(['Iterate / ready-gate', 'Automated review']);
+            const relevant = checks.filter((c) => !SELF_CHECKS.has(c.name));
             const bad = new Set(['failure', 'cancelled', 'timed_out', 'action_required']);
             const pending = relevant.some((c) => c.status !== 'completed');
             const failed = relevant.some((c) => bad.has(c.conclusion));


### PR DESCRIPTION
### Summary

PR #346's iteration loop sat dead after a CHANGES_REQUESTED review and no correction round ran. Orchestrator log was unambiguous:

```
draft=true pending=true failed=true ciGreen=false changesRequested=true reviewClean=false used=0/2 -> none
'checks still pending — waiting'
```

Cause is a sibling-workflow race. On a `pull_request_review.submitted` trigger, the review is posted ~20 s **before** the reviewer workflow's own check (`name: "Automated review"`) flips to `status: completed`. The orchestrator's `listForRef` query sees its sibling reviewer check as `in_progress` → `pending=true` → short-circuits to `wait` → exits cleanly. Then nothing wakes it up: the prior `workflow_run.workflows` list didn't include the reviewer's workflow, so the reviewer's eventual completion produced no follow-up dispatch.

Two complementary fixes, both small:

1. **Source race fix** — extend the existing self-check filter to also exclude the reviewer's check by name. Same pattern that already excludes `Iterate / ready-gate`; the reviewer's verdict is consumed via `listReviews` above, so its check-run status carries no extra information for the decision. With PR #346's actual state at decision time (CI green, DoD green, Security green, E2E green, CodeQL SAST green, only the unrelated CodeQL Default-Setup check failing, review `CHANGES_REQUESTED`), this would correctly resolve to `action=correct` and trigger the first of two correction rounds.

2. **Self-healing** — add `Autonomous PR Reviewer` to `workflow_run.workflows`. With #1 the orchestrator decides correctly on the first pass; #2 also re-fires the orchestrator when the reviewer's workflow completes, catching any other transient race that ever leaves the loop in `wait`. `workflow_run` only fires for workflows on the default branch; verified `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` → `develop`, so this is immediately effective on merge.

**Follow-up (not in this PR — surfaced so it isn't forgotten):** both triggers use the `pr-iteration.yml` file from the PR's head SHA. So this fix only takes effect on PR #346 after `develop` is merged into `feature/issue-108`. Once that lands, the next reviewer completion (re-requesting / re-submitting / pushing a commit / or simply waiting for the natural re-fire from #2) re-evaluates the orchestrator with the new logic; with `CHANGES_REQUESTED` + CI green except the unrelated CodeQL Default-Setup check, the bot will decide `action=correct` and run its first correction round (of two).

### Related Issues

- Refs #316 — autonomous-pipeline umbrella; closes none of its four open children (#317, #318, #319, #320), so the umbrella stays open per the close-on-develop policy aligned in #339.

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A` — CI/meta tuning, no product requirement touched.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: engineering-only CI tuning; no product requirement is created or modified.)
- [x] **Architecture:** `N/A` (Reason: complies with ADR-317-DEV invariants 1–3; the orchestrator's decision algorithm tightens (no longer counts sibling reviewer-bot check as pending) and the auto-trigger surface widens (adds reviewer completion) — neither changes the policy, only fixes a race in its implementation.)
- [x] **Risk Management:** `N/A` (Reason: the orchestrator never merges, never approves, never marks Ready for P1; this fix only removes a stuck-wait state and adds a redundant trigger. Existing mitigations (Draft-only, MAX_CORRECTIONS=2, mandatory human Lead review for P1) are unchanged.)
- [x] **Journeys:** `N/A` (Reason: no pilot-facing behaviour — automation-pipeline tuning only.)
- [x] **Code Docs:** `N/A` (Reason: rationale lives in the inline comments next to both changes in `pr-iteration.yml`; no user-visible change to document elsewhere.)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. — No safety tag, REQ, hazard, or journey is added/modified/removed; the matrix is unchanged.
- [x] No new hazards introduced. — The orchestrator's decision tree is unchanged; what changes is the set of checks fed into the `pending` predicate (now excludes the reviewer's own check, mirroring the existing self-exclusion) and an additional `workflow_run` trigger that re-fires the same orchestrator with the same decision logic. Bot↔bot loop protection from #348 (`allowed_bots: 'claude'`) still applies — only the reviewer can initiate a correction round.
- [x] Existing mitigations preserved. — Branch protection, DoD/Traceability/Security/E2E gates, P1-ISOLATION lint, `MAX_CORRECTIONS=2`, `MAX_TURNS=150` per round, action-level `allowed_bots: 'claude'`, and the Lead-review requirement are all untouched.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). — No file under `frontend/src/core/` is touched; the change is confined to `.github/workflows/pr-iteration.yml` (+20 / -2).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (features/bugs) OR `main` (releases/hotfixes). — `feature/iteration-orchestrator-race-fix` → `develop`.
- [x] **Unit Tests:** Added/updated and passing locally OR `N/A` (Reason: the changed code is an in-workflow `actions/github-script` block — declarative CI configuration plus a small filter against the GitHub Checks API. It has no Vitest entry point and no in-repo module to import. The exact race is reproduced verbatim in [iteration run #26433782280](https://github.com/naturelle137/AeroDash/actions/runs/26433782280) and resolved at the level of the filter the script already maintains.)
- [x] **Integration Tests:** Passing OR `N/A` (Reason: same — no integration surface to exercise for a workflow constant change.)
- [x] **Manual Testing:** Performed successfully (Mandatory for `main`) OR `N/A` (Reason: PR targets `develop`, not `main`; verified by the live behaviour after the follow-up `develop → feature/issue-108` merge re-fires iteration with the new orchestrator logic. The exact failure mode and the orchestrator decision line (`pending=true ... -> none`) are quoted verbatim from the failing run's log; the workflow-run scope is `develop`, confirmed default branch via `gh repo view`.)
- [x] **DoD:** All Definition of Done items from the linked Feature/Bug are met. — Operational fix for the umbrella #316 (no per-ticket DoD; rationale captured in commit message + inline workflow comments).
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** Does this change require an Architectural Decision Record (ADR) update/creation? If yes, it is included. — `N/A`. ADR-317-DEV §5 already specifies the orchestrator's decision protocol; this PR fixes a race in **how** it queries check state, not what state it acts on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)