### PR TITLE
fix(repo): raise overnight automation turn/time budget to 250 turns / 150 min (refs #316)

### DIFF
--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -58,13 +58,14 @@ env:
   BATCH_SIZE_DEFAULT: '1'
   # Per-issue budgets (ADR-317-DEV operational defaults). 40 turns proved far
   # too small: run #4 hit `error_max_turns` mid-implementation (the agent was
-  # working, not stuck). A full /implement-issue + lint/type-check/test/build +
-  # fix loop needs a much larger cap, so the turn budget — not the wall clock —
-  # is the binding limit and the graceful-degradation push step below can run.
-  MAX_TURNS: '150'
+  # working, not stuck), and 150 likewise hit the cap on a real run. A full
+  # /implement-issue + lint/type-check/test/build + fix loop needs a much
+  # larger cap, so the turn budget — not the wall clock — is the binding
+  # limit and the graceful-degradation push step below can run.
+  MAX_TURNS: '250'
   # Mirrors the job-level `timeout-minutes` below. GitHub does not expose the
   # workflow `env` context to a job-level `timeout-minutes`, so keep them in sync.
-  RUN_TIMEOUT_MINUTES: '90'
+  RUN_TIMEOUT_MINUTES: '150'
 
 jobs:
   # ── Deterministic, dependency-aware selection + run report ──────────────────
@@ -179,7 +180,7 @@ jobs:
     # Keep in sync with RUN_TIMEOUT_MINUTES. Must exceed the wall-clock time
     # MAX_TURNS can consume, so the agent's own turn cap is hit first and the
     # graceful-degradation push step runs (a hard job timeout cancels everything).
-    timeout-minutes: 90
+    timeout-minutes: 150
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/docs/architecture/adr/317-DEV-autonomous-ai-contribution.md
+++ b/docs/architecture/adr/317-DEV-autonomous-ai-contribution.md
@@ -110,8 +110,8 @@ following **non-negotiable invariants**:
 | Batch size | `1` | `BATCH_SIZE` env / `batch_size` dispatch input |
 | Model | `claude-opus-4-7` | `MODEL` env / `model` dispatch input |
 | Max corrections | `2` | `MAX_CORRECTIONS` env (`pr-iteration.yml`) |
-| Per-issue time budget | `90` min | `timeout-minutes` per job (mirrors `RUN_TIMEOUT_MINUTES`) |
-| Per-issue turn budget | `150` turns | `--max-turns` in `claude_args` |
+| Per-issue time budget | `150` min | `timeout-minutes` per job (mirrors `RUN_TIMEOUT_MINUTES`) |
+| Per-issue turn budget | `250` turns | `--max-turns` in `claude_args` |
 | Opt-out label | `automation:opt-out` | selection filter |
 | Global kill switch | repo variable `AUTOMATION_ENABLED` ≠ `true` ⇒ no-op | guard step |
 
@@ -120,7 +120,11 @@ following **non-negotiable invariants**:
 > (`error_max_turns`) and produced no Draft. Budgets were raised to `150` turns /
 > `90` min, the turn cap kept below the wall-clock cap so it binds first, and the
 > push step made resilient to agent failure (`continue-on-error` + always-run)
-> so partial work still lands as a flagged Draft per invariant 5.
+> so partial work still lands as a flagged Draft per invariant 5. A subsequent
+> overnight run again hit `error_max_turns` at the `150` cap, so budgets were
+> raised again to `250` turns / `150` min (preserving the same invariant: the
+> wall-clock cap exceeds the time `MAX_TURNS` can consume at the realised
+> ~36 s/turn rate, so the turn cap binds first).
 >
 > **Loop-closure revision (post-pilot):** the first complete run (#121 → PR #328)
 > reached a stuck red Draft that the loop never acted on, exposing three defects


### PR DESCRIPTION
### Summary

Most recent overnight run failed with `error_max_turns` at the `150`-turn cap: the agent was still implementing (not stuck) when the budget ran out, same failure mode as the original `40`-turn cap that motivated the previous bump (PR #326). Raise the per-issue budgets:

- `MAX_TURNS` `150` → `250` (`--max-turns` passed to `claude-code-action`).
- `RUN_TIMEOUT_MINUTES` `90` → `150`, plus matching job-level `timeout-minutes` `90` → `150`.

The realised per-turn rate from the failed run (`150` turns in ~`90` min, i.e. ~`36 s/turn`) projects `250` turns to ~`150` min of wall-clock, so the wall-clock cap is bumped in lockstep with the turn cap. This preserves the ADR-317-DEV invariant that the **turn budget — not the job timeout — binds first**, so the graceful-degradation push step still runs and partial work lands as a flagged Draft (invariant 5). Bumping turns alone would invert that invariant.

ADR-317-DEV operational-defaults table and budget-revision note are updated to match.

### Related Issues

- Refs #316 (operational tuning of the overnight automation pipeline; no specific issue to close).

### Affected Items

- **Requirements Implemented/Affected:** `N/A` — operational CI/automation tuning only; no product requirement is affected.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: no requirement is affected by changing CI budgets).
- [x] **Architecture:** Updated `ADR-317-DEV` (operational defaults table + budget-revision note) in `docs/architecture/adr/317-DEV-autonomous-ai-contribution.md`.
- [x] **Risk Management:** `N/A` (Reason: bumping CI budget does not introduce or modify a hazard).
- [x] **Journeys:** `N/A` (Reason: no user journey is affected).
- [x] **Code Docs:** `N/A` (Reason: internal CI/automation change; not user-facing — matches precedent of PR #326 which also did not touch CHANGELOG).

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved (the turn-cap-binds-first invariant for the graceful-degradation push step is preserved by bumping the wall-clock cap in lockstep with the turn cap).
- [x] P1 isolation maintained (no source-code changes; CI workflow + ADR only).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: change is to a GitHub Actions workflow `env` value and an ADR; no production code or selection-script logic is touched, so there is nothing the existing unit suite would meaningfully assert).
- [x] **Integration Tests:** `N/A` (Reason: same as above — nothing for the integration suite to exercise).
- [x] **Manual Testing:** `N/A` (Reason: real behaviour is only observable on the next nightly `overnight-implementation.yml` run; budget values themselves are statically verifiable in the diff).
- [x] **DoD:** No linked Feature/Bug — operational tuning of an existing automation defined in ADR-317-DEV.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** ADR-317-DEV operational-defaults table and budget-revision note are updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
