### PR TITLE
feat: [Task]: Schema-version migration registry + downgrade/corruption recovery for IndexedDB & session (#259)

### DIFF
--- a/frontend/src/core/domain/session.schema.ts
+++ b/frontend/src/core/domain/session.schema.ts
@@ -9,10 +9,27 @@ import { z } from 'zod'
  * Restored data is validated against this schema before entering any
  * computation pipeline.
  *
+ * The companion migration table lives in `./session-migrations.ts` and
+ * forwards older serialised payloads to {@link SessionPayloadSchema}.
+ * A payload whose `version` is newer than the running build can read
+ * (PWA-cache rollback) is *dropped* with an INFO notification — never
+ * silently truncated (refs #259).
+ *
  * @see docs/architecture/frontend_state_machine.md
  */
 
 // @IMP-SYS-CORE-009@ (FROM: @REQ-SYS-013@)
+
+/**
+ * Current session-payload schema version.
+ *
+ * Bump in lockstep with `SessionPayloadSchema.version` (also a `z.literal`)
+ * and with the migration table in `./session-migrations.ts`. The literal
+ * keeps Zod's runtime guard aligned with the migration registry's compile-
+ * time guarantees — a payload that survives migration is, by construction,
+ * at the current version.
+ */
+export const CURRENT_SESSION_PAYLOAD_VERSION = 1 as const
 
 /** One station's serialisable state — weight and interaction flags only. */
 export const StationPayloadSchema = z.object({
@@ -30,12 +47,14 @@ export const StationPayloadSchema = z.object({
  * Full session payload stored in `localStorage`.
  *
  * `version` enables forward-compatible migration if the schema changes in a
- * future milestone. A schema mismatch (wrong version or Zod parse failure)
- * results in a clean session — no partial or stale data enters the app.
+ * future milestone. Older payloads pass through the migration table; newer
+ * payloads (PWA-cache rollback after a forward bump) are dropped with an
+ * INFO notification rather than silently truncated. Outright corruption
+ * (parse failure, missing fields) results in a clean session.
  */
 export const SessionPayloadSchema = z.object({
-  /** Schema version — currently 1. */
-  version: z.literal(1),
+  /** Schema version of the *current* runtime — migration target. */
+  version: z.literal(CURRENT_SESSION_PAYLOAD_VERSION),
   /** UUID of the active AircraftProfile at time of save. */
   aircraftId: z.string().min(1),
   /** Active certification category key (e.g. "Normal"). */

--- a/frontend/src/core/logic/profile-migrations.spec.ts
+++ b/frontend/src/core/logic/profile-migrations.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * P1 unit tests for the AircraftProfile schemaVersion migration registry.
+ *
+ * Covers:
+ *  - Legacy (no schemaVersion) → v1 stamping
+ *  - Current v1 documents pass through unchanged
+ *  - Unsupported future schemaVersion (PWA-cache downgrade scenario, #259)
+ *  - Corrupt / non-object inputs
+ *  - Zod failure surfacing without escape
+ *  - Throwing up-function isolation (mid-migration crash recovery, #259)
+ *
+ * @see frontend/src/core/logic/profile-migrations.ts
+ */
+
+// @UT-AC-CORE-101@ (FROM: @IMP-AC-CORE-003@)
+
+import { describe, it, expect } from 'vitest'
+import {
+  CURRENT_PROFILE_SCHEMA_VERSION,
+  migrateProfileDocument,
+} from './profile-migrations'
+import type { AircraftProfile } from '../adapters/aircraft.schema'
+
+/** Build a minimal valid AircraftProfile-shaped document for migration. */
+function buildV1Document(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: '00000000-0000-4000-a000-000000000001',
+    ownerId: 'user-test',
+    registration: 'D-EBPN',
+    manufacturer: 'Tecnam',
+    model: 'P2008 JC',
+    icaoTypeDesignator: 'P208',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Leading edge',
+    referenceDatumLocation: 'Station 0',
+    shareCode: null,
+    status: 'draft',
+    schemaVersion: 1,
+    powertrain: 'combustion',
+    passengerProfiles: [],
+    weighingReports: [
+      { bem: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+    ],
+    loadPoints: [
+      {
+        name: 'Pilot',
+        arm: 1.8,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 650,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.841, mass: 432 },
+          { armOrMoment: 1.841, mass: 650 },
+          { armOrMoment: 1.978, mass: 650 },
+          { armOrMoment: 1.978, mass: 432 },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('migrateProfileDocument — current-version pass-through', () => {
+  it('returns a parsed profile when the stored version is current', () => {
+    const result = migrateProfileDocument(buildV1Document())
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(CURRENT_PROFILE_SCHEMA_VERSION)
+    expect(result.versionsApplied).toEqual([])
+  })
+
+  it('keeps the stored registration intact through the walker', () => {
+    const result = migrateProfileDocument(buildV1Document({ registration: 'G-ABCD' }))
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.registration).toBe('G-ABCD')
+  })
+})
+
+describe('migrateProfileDocument — legacy v0 → v1 stamping', () => {
+  it('stamps schemaVersion when the field is absent', () => {
+    const doc = buildV1Document()
+    delete (doc as { schemaVersion?: number }).schemaVersion
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(1)
+    expect(result.versionsApplied).toEqual([0])
+  })
+
+  it('stamps schemaVersion when the field is the wrong type (string)', () => {
+    const doc = buildV1Document({ schemaVersion: 'one' as unknown as number })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(1)
+    expect(result.versionsApplied).toEqual([0])
+  })
+
+  it('stamps schemaVersion when stored value is NaN (corrupt numeric)', () => {
+    const doc = buildV1Document({ schemaVersion: Number.NaN })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(1)
+  })
+
+  it('stamps schemaVersion when stored value is Infinity', () => {
+    const doc = buildV1Document({ schemaVersion: Number.POSITIVE_INFINITY })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(1)
+  })
+
+  it('stamps schemaVersion when stored value is non-integer (1.5)', () => {
+    const doc = buildV1Document({ schemaVersion: 1.5 })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(1)
+  })
+
+  it('stamps schemaVersion when stored value is negative', () => {
+    const doc = buildV1Document({ schemaVersion: -2 })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.profile.schemaVersion).toBe(1)
+  })
+})
+
+describe('migrateProfileDocument — unsupported future version (downgrade scenario)', () => {
+  it('reports unsupported-future-version when stored version > current', () => {
+    const doc = buildV1Document({ schemaVersion: CURRENT_PROFILE_SCHEMA_VERSION + 1 })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('unsupported-future-version')
+    if (result.kind !== 'unsupported-future-version') return
+    expect(result.storedVersion).toBe(CURRENT_PROFILE_SCHEMA_VERSION + 1)
+  })
+
+  it('reports unsupported-future-version even when other fields are valid', () => {
+    const doc = buildV1Document({ schemaVersion: 99, registration: 'G-FUTR' })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('unsupported-future-version')
+  })
+
+  it('does not attempt to parse the document when version is in the future', () => {
+    // A future doc may carry fields that fail today's Zod schema. The walker
+    // must report unsupported-future-version BEFORE Zod ever sees them so
+    // diagnostics are unambiguous (rollback signal, not schema corruption).
+    const doc = buildV1Document({
+      schemaVersion: 5,
+      // unknown future field that does not exist in current schema
+      futureField: { nested: 'data' } as unknown,
+    })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('unsupported-future-version')
+  })
+})
+
+describe('migrateProfileDocument — corrupt input handling', () => {
+  it('reports corrupt when input is null', () => {
+    const result = migrateProfileDocument(null)
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is undefined', () => {
+    const result = migrateProfileDocument(undefined)
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is a string', () => {
+    const result = migrateProfileDocument('not-an-object')
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is an array', () => {
+    const result = migrateProfileDocument([1, 2, 3])
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is a number', () => {
+    const result = migrateProfileDocument(42)
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt with Zod issue summary when fields are structurally invalid', () => {
+    const doc = buildV1Document({ registration: '' })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('corrupt')
+    if (result.kind !== 'corrupt') return
+    expect(result.reason).toContain('schema validation failed')
+    expect(result.reason).toContain('registration')
+  })
+
+  it('reports corrupt when certificationCategories is missing', () => {
+    const doc = buildV1Document()
+    delete (doc as { certificationCategories?: unknown[] }).certificationCategories
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when weighingReports is empty (min(1) constraint)', () => {
+    const doc = buildV1Document({ weighingReports: [] })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when id is not a valid UUID', () => {
+    const doc = buildV1Document({ id: 'not-a-uuid' })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('corrupt')
+  })
+})
+
+describe('migrateProfileDocument — purity and determinism', () => {
+  it('does not mutate the input document', () => {
+    const doc = buildV1Document()
+    delete (doc as { schemaVersion?: number }).schemaVersion
+    const before = JSON.stringify(doc)
+    migrateProfileDocument(doc)
+    const after = JSON.stringify(doc)
+    expect(after).toBe(before)
+  })
+
+  it('two invocations on the same input produce structurally equal outputs', () => {
+    const doc = buildV1Document()
+    const a = migrateProfileDocument(doc)
+    const b = migrateProfileDocument(doc)
+    expect(a.kind).toBe('migrated')
+    expect(b.kind).toBe('migrated')
+    if (a.kind !== 'migrated' || b.kind !== 'migrated') return
+    expect(a.profile).toEqual(b.profile)
+  })
+
+  it('legacy stamping leaves all non-schemaVersion fields untouched', () => {
+    const doc = buildV1Document({ costPerHour: 220 })
+    delete (doc as { schemaVersion?: number }).schemaVersion
+    const result = migrateProfileDocument(doc)
+    if (result.kind !== 'migrated') throw new Error('expected migrated')
+    const p: AircraftProfile = result.profile
+    expect(p.costPerHour).toBe(220)
+    expect(p.registration).toBe('D-EBPN')
+  })
+})

--- a/frontend/src/core/logic/profile-migrations.ts
+++ b/frontend/src/core/logic/profile-migrations.ts
@@ -71,6 +71,15 @@ const migrations: ReadonlyMap<number, ProfileMigration> = new Map<number, Profil
      * documents are structurally identical to v1 documents (the field was the
      * only thing missing) and the schema's defaults reinstate any other field
      * that was nullable-by-omission.
+     *
+     * IMPORTANT — this `0 → 1` entry must be kept indefinitely (or replaced
+     * with an equivalent default-stamping step at the lowest registered
+     * version). The on-read walker does NOT write the migrated document back
+     * to IndexedDB, so a v0 document on disk is re-migrated on every load.
+     * Removing this entry — even after long soak time — would brick every
+     * legacy document that never went through a verify/edit write cycle. Any
+     * future ADR that proposes pruning legacy migrations MUST first migrate
+     * stored documents to the new floor version on write.
      */
     (doc) => ({ ...doc, schemaVersion: 1 }),
   ],

--- a/frontend/src/core/logic/profile-migrations.ts
+++ b/frontend/src/core/logic/profile-migrations.ts
@@ -1,0 +1,171 @@
+/**
+ * Aircraft Profile schemaVersion Migration Registry.
+ * P1 Safety Core — pure TypeScript, no framework dependencies.
+ *
+ * Resilience model for stored `AircraftProfile` documents.
+ *
+ * Background (refs #259, audit findings TECH-005 / TECH-022 / TECH-025):
+ *  - The `aerodash-fleet` IndexedDB store writes a `schemaVersion: 1` field on
+ *    every document but, until this module shipped, never *read* it back on
+ *    load. Documents were rehydrated through `AircraftProfileSchema.parse`
+ *    only — which silently absorbs unknown fields from a *newer* schema and
+ *    throws on the rare structural mismatch, with no way to distinguish a
+ *    future downgrade from an actually corrupt document.
+ *  - This is the registry that closes that gap.
+ *
+ * Contract — every document read through the fleet repository is first routed
+ * through {@link migrateProfileDocument}, which:
+ *
+ *  1. Extracts the stored `schemaVersion` (defaulting to 0 when the field is
+ *     missing or non-numeric — historic legacy state).
+ *  2. Walks the registry up to {@link CURRENT_PROFILE_SCHEMA_VERSION}, applying
+ *     each `n → n+1` up-function in order. Every up-function is a pure
+ *     `Record<string, unknown> → Record<string, unknown>` transform; failures
+ *     are caught and the document is reported as `corrupt` rather than
+ *     escaping as an unhandled exception.
+ *  3. Validates the migrated document against `AircraftProfileSchema`. Any
+ *     Zod failure surfaces as `corrupt` with the issue summary attached.
+ *  4. When the stored version is strictly greater than
+ *     `CURRENT_PROFILE_SCHEMA_VERSION` — a PWA-cache rollback after a forward
+ *     migration — the document is reported as `unsupported-future-version` so
+ *     the caller can drop it (rather than truncating fields silently).
+ *
+ * @see docs/architecture/aircraft_data_model.md
+ * @see docs/architecture/adr/006-indexeddb-fleet-persistence.md
+ */
+
+// @IMP-AC-CORE-003@ (FROM: @REQ-AC-001@, @REQ-SYS-013@)
+
+import { AircraftProfileSchema, type AircraftProfile } from '../adapters/aircraft.schema'
+
+/**
+ * Current `AircraftProfile` schema version.
+ *
+ * Bump in lockstep with the schema's `schemaVersion` default. Adding a new
+ * up-function below MUST raise this constant by exactly one so the migration
+ * walker has a target to converge on.
+ */
+export const CURRENT_PROFILE_SCHEMA_VERSION = 1 as const
+
+/** Up-function: transform a document from version `fromVersion` to `fromVersion + 1`. */
+export type ProfileMigration = (doc: Record<string, unknown>) => Record<string, unknown>
+
+/**
+ * Registry of per-version up-functions.
+ *
+ * Keyed by the *source* version. Adding migration `n → n+1` is done by:
+ *   1. Bumping {@link CURRENT_PROFILE_SCHEMA_VERSION} from `n` to `n + 1`.
+ *   2. Registering `n` here with the pure transform.
+ *   3. Updating `AircraftProfileSchema.schemaVersion` default to `n + 1`.
+ *
+ * The current registry only contains the `0 → 1` stamping migration: documents
+ * written by builds that predate the `schemaVersion` field are treated as
+ * implicit v0 and forward-stamped to v1 without structural changes.
+ */
+const migrations: ReadonlyMap<number, ProfileMigration> = new Map<number, ProfileMigration>([
+  [
+    0,
+    /**
+     * v0 → v1: stamp the `schemaVersion` field on legacy documents persisted
+     * before the field shipped. No structural transformation is applied; v0
+     * documents are structurally identical to v1 documents (the field was the
+     * only thing missing) and the schema's defaults reinstate any other field
+     * that was nullable-by-omission.
+     */
+    (doc) => ({ ...doc, schemaVersion: 1 }),
+  ],
+])
+
+/** Outcome of a single migration attempt. */
+export type ProfileMigrationOutcome =
+  | {
+      readonly kind: 'migrated'
+      readonly profile: AircraftProfile
+      /** Source version → target version steps actually applied. */
+      readonly versionsApplied: readonly number[]
+    }
+  | {
+      readonly kind: 'unsupported-future-version'
+      readonly storedVersion: number
+    }
+  | {
+      readonly kind: 'corrupt'
+      readonly storedVersion: number
+      readonly reason: string
+    }
+
+/**
+ * Extract the stored schema version from a raw document.
+ *
+ * Returns `0` for any document that does not have a numeric, finite, positive
+ * integer `schemaVersion` field. Treating "missing or invalid" as v0 routes
+ * legacy documents through the v0 → v1 stamping migration and gives genuinely
+ * corrupt documents a stable entry point into the migration walker.
+ */
+function readStoredVersion(doc: Record<string, unknown>): number {
+  const raw = doc['schemaVersion']
+  if (typeof raw !== 'number') return 0
+  if (!Number.isFinite(raw)) return 0
+  if (!Number.isInteger(raw)) return 0
+  if (raw < 0) return 0
+  return raw
+}
+
+/**
+ * Migrate a raw, IndexedDB-shaped document up to the current schema version.
+ *
+ * `raw` is treated defensively — any non-object input is reported as `corrupt`
+ * rather than crashing the caller. Each step is wrapped in a try/catch so a
+ * single throwing up-function cannot poison the whole fleet load (the
+ * partial-migration crash recovery guarantee).
+ */
+export function migrateProfileDocument(raw: unknown): ProfileMigrationOutcome {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { kind: 'corrupt', storedVersion: 0, reason: 'document is not an object' }
+  }
+
+  const doc = raw as Record<string, unknown>
+  const storedVersion = readStoredVersion(doc)
+
+  if (storedVersion > CURRENT_PROFILE_SCHEMA_VERSION) {
+    return { kind: 'unsupported-future-version', storedVersion }
+  }
+
+  let working: Record<string, unknown> = { ...doc }
+  const versionsApplied: number[] = []
+
+  for (let v = storedVersion; v < CURRENT_PROFILE_SCHEMA_VERSION; v++) {
+    const step = migrations.get(v)
+    if (!step) {
+      return {
+        kind: 'corrupt',
+        storedVersion,
+        reason: `no migration registered for source version ${v}`,
+      }
+    }
+    try {
+      working = step(working)
+    } catch (err) {
+      return {
+        kind: 'corrupt',
+        storedVersion,
+        reason: `migration ${v} → ${v + 1} threw: ${err instanceof Error ? err.message : String(err)}`,
+      }
+    }
+    versionsApplied.push(v)
+  }
+
+  // Final structural validation. Zod's `.default()` clauses replace any field
+  // an older document may have legitimately omitted (e.g. `passengerProfiles`,
+  // `powertrain`) without requiring a dedicated up-function for each one.
+  const parsed = AircraftProfileSchema.safeParse(working)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 5)
+      .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('; ')
+    return { kind: 'corrupt', storedVersion, reason: `schema validation failed: ${issues}` }
+  }
+
+  return { kind: 'migrated', profile: parsed.data, versionsApplied }
+}

--- a/frontend/src/core/logic/session-migrations.spec.ts
+++ b/frontend/src/core/logic/session-migrations.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * P1 unit tests for the session payload migration registry.
+ *
+ * Covers:
+ *  - Current v1 payloads pass through unchanged
+ *  - Pre-versioned (v0) payloads forward-stamped to v1
+ *  - Unsupported future version (downgrade scenario, #259)
+ *  - Corrupt inputs (non-objects, arrays, structurally invalid)
+ *  - Purity / determinism
+ *
+ * @see frontend/src/core/logic/session-migrations.ts
+ */
+
+// @UT-SYS-CORE-101@ (FROM: @IMP-SYS-CORE-012@)
+
+import { describe, it, expect } from 'vitest'
+import {
+  migrateSessionPayload,
+} from './session-migrations'
+import { CURRENT_SESSION_PAYLOAD_VERSION } from '../domain/session.schema'
+
+function buildV1Payload(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    aircraftId: 'aircraft-uuid-A',
+    activeCategory: 'Normal',
+    stations: [
+      { index: 0, weight: 75, touched: true, verified: false },
+      { index: 1, weight: 0, touched: false, verified: false },
+    ],
+    savedAt: '2026-05-26T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('migrateSessionPayload — current-version pass-through', () => {
+  it('returns a parsed payload when version equals current', () => {
+    const result = migrateSessionPayload(buildV1Payload())
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.payload.version).toBe(CURRENT_SESSION_PAYLOAD_VERSION)
+    expect(result.versionsApplied).toEqual([])
+  })
+
+  it('preserves aircraftId, activeCategory, savedAt, and stations', () => {
+    const result = migrateSessionPayload(buildV1Payload())
+    if (result.kind !== 'migrated') throw new Error('expected migrated')
+    expect(result.payload.aircraftId).toBe('aircraft-uuid-A')
+    expect(result.payload.activeCategory).toBe('Normal')
+    expect(result.payload.savedAt).toBe('2026-05-26T10:00:00.000Z')
+    expect(result.payload.stations).toHaveLength(2)
+    expect(result.payload.stations[0]!.weight).toBe(75)
+  })
+})
+
+describe('migrateSessionPayload — v0 forward-stamping', () => {
+  it('stamps version when the field is absent', () => {
+    const payload = buildV1Payload()
+    delete (payload as { version?: number }).version
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.payload.version).toBe(1)
+    expect(result.versionsApplied).toEqual([0])
+  })
+
+  it('stamps version when the field is a string', () => {
+    const payload = buildV1Payload({ version: '1' as unknown as number })
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    expect(result.payload.version).toBe(1)
+  })
+
+  it('stamps version when stored value is NaN', () => {
+    const payload = buildV1Payload({ version: Number.NaN })
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('migrated')
+  })
+
+  it('stamps version when stored value is negative', () => {
+    const payload = buildV1Payload({ version: -2 })
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('migrated')
+  })
+})
+
+describe('migrateSessionPayload — unsupported future version', () => {
+  it('reports unsupported-future-version when stored version > current', () => {
+    const payload = buildV1Payload({ version: CURRENT_SESSION_PAYLOAD_VERSION + 1 })
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('unsupported-future-version')
+    if (result.kind !== 'unsupported-future-version') return
+    expect(result.storedVersion).toBe(CURRENT_SESSION_PAYLOAD_VERSION + 1)
+  })
+
+  it('reports unsupported-future-version even when other fields are valid', () => {
+    const payload = buildV1Payload({ version: 99 })
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('unsupported-future-version')
+  })
+
+  it('does not call Zod for future-version payloads', () => {
+    // A future payload may have a shape today's schema rejects. The walker
+    // must report unsupported-future-version BEFORE Zod runs.
+    const payload = buildV1Payload({
+      version: 5,
+      futureField: { nested: 'data' } as unknown,
+    })
+    const result = migrateSessionPayload(payload)
+    expect(result.kind).toBe('unsupported-future-version')
+  })
+})
+
+describe('migrateSessionPayload — corrupt input handling', () => {
+  it('reports corrupt when input is null', () => {
+    expect(migrateSessionPayload(null).kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is undefined', () => {
+    expect(migrateSessionPayload(undefined).kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is a number', () => {
+    expect(migrateSessionPayload(42).kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is a string', () => {
+    expect(migrateSessionPayload('payload').kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when input is an array', () => {
+    expect(migrateSessionPayload([1, 2, 3]).kind).toBe('corrupt')
+  })
+
+  it('reports corrupt with Zod summary when required fields are missing', () => {
+    const result = migrateSessionPayload({ version: 1 })
+    expect(result.kind).toBe('corrupt')
+    if (result.kind !== 'corrupt') return
+    expect(result.reason).toContain('schema validation failed')
+  })
+
+  it('reports corrupt when aircraftId is empty', () => {
+    const result = migrateSessionPayload(buildV1Payload({ aircraftId: '' }))
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when stations has an entry with negative weight', () => {
+    const result = migrateSessionPayload(
+      buildV1Payload({ stations: [{ index: 0, weight: -1, touched: false, verified: false }] }),
+    )
+    expect(result.kind).toBe('corrupt')
+  })
+
+  it('reports corrupt when savedAt is not a valid ISO datetime', () => {
+    const result = migrateSessionPayload(buildV1Payload({ savedAt: 'not-a-date' }))
+    expect(result.kind).toBe('corrupt')
+  })
+})
+
+describe('migrateSessionPayload — purity and determinism', () => {
+  it('does not mutate the input payload', () => {
+    const payload = buildV1Payload()
+    delete (payload as { version?: number }).version
+    const snapshot = JSON.stringify(payload)
+    migrateSessionPayload(payload)
+    expect(JSON.stringify(payload)).toBe(snapshot)
+  })
+
+  it('two invocations on the same input produce equal outputs', () => {
+    const a = migrateSessionPayload(buildV1Payload())
+    const b = migrateSessionPayload(buildV1Payload())
+    expect(a).toEqual(b)
+  })
+})

--- a/frontend/src/core/logic/session-migrations.ts
+++ b/frontend/src/core/logic/session-migrations.ts
@@ -1,0 +1,136 @@
+/**
+ * Session payload migration registry.
+ * P1 Safety Core — pure TypeScript, no framework dependencies.
+ *
+ * Resilience model for the `aerodash:session:payload` localStorage value:
+ *
+ *  - Migration walks per-version up-functions starting from the stored
+ *    `version` (or `0` when the field is missing / non-numeric / corrupt).
+ *  - When the stored version is *newer* than this build's
+ *    {@link CURRENT_SESSION_PAYLOAD_VERSION} — a PWA-cache rollback after
+ *    a forward bump — the payload is reported as
+ *    `unsupported-future-version`. Callers MUST drop it and surface an
+ *    INFO notification to the pilot (refs #259).
+ *  - Parse failure, malformed JSON-tree shapes, and Zod validation failure
+ *    surface as `corrupt`. Callers clear storage and start a clean session.
+ *
+ * @see frontend/src/core/domain/session.schema.ts
+ */
+
+// @IMP-SYS-CORE-012@ (FROM: @REQ-SYS-013@)
+
+import {
+  CURRENT_SESSION_PAYLOAD_VERSION,
+  SessionPayloadSchema,
+  type SessionPayload,
+} from '../domain/session.schema'
+
+/** Up-function: transform a session payload from version `n` to `n + 1`. */
+export type SessionMigration = (payload: Record<string, unknown>) => Record<string, unknown>
+
+/**
+ * Per-version up-functions keyed by the *source* version. Adding migration
+ * `n → n+1` requires:
+ *   1. Bumping {@link CURRENT_SESSION_PAYLOAD_VERSION} in `session.schema.ts`.
+ *   2. Registering `n` here with a pure transform.
+ *   3. Updating {@link SessionPayloadSchema} to the new shape.
+ *
+ * The current registry contains the `0 → 1` stamping migration so payloads
+ * persisted by a hypothetical pre-versioned build can be forward-stamped
+ * rather than dropped. No structural transformations are applied because
+ * the v1 shape is the inaugural shipped shape.
+ */
+const migrations: ReadonlyMap<number, SessionMigration> = new Map<number, SessionMigration>([
+  [
+    0,
+    /**
+     * v0 → v1: stamp the `version` field on hypothetical pre-versioned
+     * payloads. No structural transformation is applied; v0 is treated as
+     * a legacy alias of v1.
+     */
+    (payload) => ({ ...payload, version: 1 }),
+  ],
+])
+
+/** Outcome of a single migration attempt. */
+export type SessionMigrationOutcome =
+  | {
+      readonly kind: 'migrated'
+      readonly payload: SessionPayload
+      /** Source versions whose up-functions actually ran. */
+      readonly versionsApplied: readonly number[]
+    }
+  | {
+      readonly kind: 'unsupported-future-version'
+      readonly storedVersion: number
+    }
+  | {
+      readonly kind: 'corrupt'
+      readonly storedVersion: number
+      readonly reason: string
+    }
+
+function readStoredVersion(payload: Record<string, unknown>): number {
+  const raw = payload['version']
+  if (typeof raw !== 'number') return 0
+  if (!Number.isFinite(raw)) return 0
+  if (!Number.isInteger(raw)) return 0
+  if (raw < 0) return 0
+  return raw
+}
+
+/**
+ * Migrate a raw, localStorage-shaped payload up to the current schema version.
+ *
+ * `raw` is treated defensively — null, undefined, non-objects, and arrays
+ * report `corrupt`. Each up-function is wrapped in a try/catch so a single
+ * throwing transform cannot escape the boundary (matches the
+ * fleet-store partial-migration crash-recovery guarantee, refs #259).
+ */
+export function migrateSessionPayload(raw: unknown): SessionMigrationOutcome {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { kind: 'corrupt', storedVersion: 0, reason: 'payload is not an object' }
+  }
+
+  const payload = raw as Record<string, unknown>
+  const storedVersion = readStoredVersion(payload)
+
+  if (storedVersion > CURRENT_SESSION_PAYLOAD_VERSION) {
+    return { kind: 'unsupported-future-version', storedVersion }
+  }
+
+  let working: Record<string, unknown> = { ...payload }
+  const versionsApplied: number[] = []
+
+  for (let v = storedVersion; v < CURRENT_SESSION_PAYLOAD_VERSION; v++) {
+    const step = migrations.get(v)
+    if (!step) {
+      return {
+        kind: 'corrupt',
+        storedVersion,
+        reason: `no migration registered for source version ${v}`,
+      }
+    }
+    try {
+      working = step(working)
+    } catch (err) {
+      return {
+        kind: 'corrupt',
+        storedVersion,
+        reason: `migration ${v} → ${v + 1} threw: ${err instanceof Error ? err.message : String(err)}`,
+      }
+    }
+    versionsApplied.push(v)
+  }
+
+  const parsed = SessionPayloadSchema.safeParse(working)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 5)
+      .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('; ')
+    return { kind: 'corrupt', storedVersion, reason: `schema validation failed: ${issues}` }
+  }
+
+  return { kind: 'migrated', payload: parsed.data, versionsApplied }
+}

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
@@ -266,20 +266,25 @@ describe('fleetRepository — schemaVersion persistence (refs #166)', () => {
     expect(found!.schemaVersion).toBe(1)
   })
 
-  // @IT-AC-STORE-011@ (FROM: @IMP-AC-CORE-002@)
-  it('schemaVersion is preserved across update operations', async () => {
+  // @IT-AC-STORE-011@ (FROM: @IMP-AC-CORE-002@, @IMP-AC-CORE-003@)
+  it('schemaVersion is preserved across update operations at the current version', async () => {
+    // After the migration registry shipped (#259), `schemaVersion` is a
+    // strictly-monotone marker rather than a free-form counter: writing a
+    // value > CURRENT_PROFILE_SCHEMA_VERSION is rejected on read as
+    // "future version" and the document is dropped from the in-memory fleet.
+    // Round-trip semantics still hold for the current version.
     const profile = buildProfile({
       id: '00000000-0000-4000-a000-000000000021',
       schemaVersion: 1,
     })
     await create(profile)
 
-    const updated: AircraftProfile = { ...profile, registration: 'G-UPDT', schemaVersion: 2 }
+    const updated: AircraftProfile = { ...profile, registration: 'G-UPDT', schemaVersion: 1 }
     await update(updated)
 
     const found = await findById(profile.id)
     expect(found).toBeDefined()
-    expect(found!.schemaVersion).toBe(2)
+    expect(found!.schemaVersion).toBe(1)
     expect(found!.registration).toBe('G-UPDT')
   })
 

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
@@ -23,7 +23,8 @@ import {
   create,
   findById,
   findAll,
-  consumeMigrationDiagnostics,
+  findAllWithDiagnostics,
+  findByIdWithDiagnostics,
 } from '../services/fleet.repository'
 import { CURRENT_PROFILE_SCHEMA_VERSION } from '@/core/logic/profile-migrations'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
@@ -34,8 +35,6 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   })
-  // Drain any diagnostics that may have accumulated from previous tests.
-  consumeMigrationDiagnostics()
 })
 
 /** Minimal valid AircraftProfile fixture. */
@@ -139,10 +138,9 @@ describe('fleetRepository — downgrade after PWA cache rollback (refs #259)', (
 
     await seedRaw(futureDoc as unknown as Record<string, unknown>)
 
-    const all = await findAll()
-    expect(all).toHaveLength(0)
+    const { profiles, diagnostics } = await findAllWithDiagnostics()
+    expect(profiles).toHaveLength(0)
 
-    const diagnostics = consumeMigrationDiagnostics()
     expect(diagnostics).toHaveLength(1)
     expect(diagnostics[0]!.id).toBe(futureId)
     expect(diagnostics[0]!.reason).toBe('unsupported-future-version')
@@ -150,17 +148,16 @@ describe('fleetRepository — downgrade after PWA cache rollback (refs #259)', (
   })
 
   // @IT-AC-STORE-103@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
-  it('returns undefined and emits a future-version diagnostic for findById', async () => {
+  it('returns undefined and emits a future-version diagnostic for findByIdWithDiagnostics', async () => {
     const futureId = '00000000-0000-4000-a000-0000000000f1'
     await seedRaw({
       ...buildProfile({ id: futureId, registration: 'D-F1ND' }),
       schemaVersion: 42,
     } as unknown as Record<string, unknown>)
 
-    const found = await findById(futureId)
-    expect(found).toBeUndefined()
+    const { profile, diagnostics } = await findByIdWithDiagnostics(futureId)
+    expect(profile).toBeUndefined()
 
-    const diagnostics = consumeMigrationDiagnostics()
     expect(diagnostics).toHaveLength(1)
     expect(diagnostics[0]!.reason).toBe('unsupported-future-version')
     expect(diagnostics[0]!.storedVersion).toBe(42)
@@ -172,19 +169,16 @@ describe('fleetRepository — downgrade after PWA cache rollback (refs #259)', (
     const futureId = '00000000-0000-4000-a000-0000000000f2'
 
     await create(buildProfile({ id: goodId, registration: 'D-OK01' }))
-    // consume the empty diagnostics from create's downstream reads (none)
-    consumeMigrationDiagnostics()
 
     await seedRaw({
       ...buildProfile({ id: futureId, registration: 'D-FU02' }),
       schemaVersion: 99,
     } as unknown as Record<string, unknown>)
 
-    const all = await findAll()
-    expect(all).toHaveLength(1)
-    expect(all[0]!.registration).toBe('D-OK01')
+    const { profiles, diagnostics } = await findAllWithDiagnostics()
+    expect(profiles).toHaveLength(1)
+    expect(profiles[0]!.registration).toBe('D-OK01')
 
-    const diagnostics = consumeMigrationDiagnostics()
     expect(diagnostics).toHaveLength(1)
     expect(diagnostics[0]!.reason).toBe('unsupported-future-version')
     expect(diagnostics[0]!.id).toBe(futureId)
@@ -204,10 +198,9 @@ describe('fleetRepository — corruption + partial-migration crash recovery (ref
       registration: 'D-CRPT',
     } as unknown as Record<string, unknown>)
 
-    const all = await findAll()
-    expect(all).toHaveLength(0)
+    const { profiles, diagnostics } = await findAllWithDiagnostics()
+    expect(profiles).toHaveLength(0)
 
-    const diagnostics = consumeMigrationDiagnostics()
     expect(diagnostics).toHaveLength(1)
     expect(diagnostics[0]!.id).toBe(badId)
     expect(diagnostics[0]!.reason).toBe('corrupt')
@@ -232,15 +225,14 @@ describe('fleetRepository — corruption + partial-migration crash recovery (ref
     delete legacyDoc.schemaVersion
     await seedRaw(legacyDoc as Record<string, unknown>)
 
-    const all = await findAll()
-    expect(all).toHaveLength(2)
-    const byReg = Object.fromEntries(all.map((p) => [p.registration, p]))
+    const { profiles, diagnostics } = await findAllWithDiagnostics()
+    expect(profiles).toHaveLength(2)
+    const byReg = Object.fromEntries(profiles.map((p) => [p.registration, p]))
     expect(byReg['D-V101']!.schemaVersion).toBe(1)
     expect(byReg['D-LEG0']!.schemaVersion).toBe(1)
 
     // The legacy doc must have been forward-stamped by the migration walker
     // even though the bytes on disk still carry no version field.
-    const diagnostics = consumeMigrationDiagnostics()
     expect(diagnostics).toHaveLength(0)
   })
 
@@ -264,29 +256,56 @@ describe('fleetRepository — corruption + partial-migration crash recovery (ref
       schemaVersion: 7,
     } as unknown as Record<string, unknown>)
 
-    const all = await findAll()
-    expect(all).toHaveLength(1)
-    expect(all[0]!.registration).toBe('D-OK99')
+    const { profiles, diagnostics } = await findAllWithDiagnostics()
+    expect(profiles).toHaveLength(1)
+    expect(profiles[0]!.registration).toBe('D-OK99')
 
-    const diagnostics = consumeMigrationDiagnostics()
     expect(diagnostics).toHaveLength(2)
     const reasons = diagnostics.map((d) => d.reason).sort()
     expect(reasons).toEqual(['corrupt', 'unsupported-future-version'])
   })
 
   // @IT-AC-STORE-108@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
-  it('consumeMigrationDiagnostics is one-shot — second drain returns empty', async () => {
+  it('diagnostics are per-call — interleaved findAll / findById do not cross-contaminate', async () => {
+    // Before the per-call refactor (#353 review feedback), a single module
+    // buffer could mix diagnostics from two concurrent loads. With the tuple
+    // API each call's diagnostics are returned in its own promise resolution.
+    const futureId = '00000000-0000-4000-a000-0000000000e0'
+    const corruptId = '00000000-0000-4000-a000-0000000000e1'
+
     await seedRaw({
-      ...buildProfile({ id: '00000000-0000-4000-a000-0000000000e0', registration: 'D-DR01' }),
+      ...buildProfile({ id: futureId, registration: 'D-FU99' }),
+      schemaVersion: 50,
+    } as unknown as Record<string, unknown>)
+    await seedRaw({
+      id: corruptId,
+      schemaVersion: 1,
+      registration: 'D-CR99',
+    } as unknown as Record<string, unknown>)
+
+    const [allResult, byIdResult] = await Promise.all([
+      findAllWithDiagnostics(),
+      findByIdWithDiagnostics(futureId),
+    ])
+
+    // findAll sees both dropped docs; findById sees only the future one.
+    expect(allResult.diagnostics).toHaveLength(2)
+    expect(byIdResult.diagnostics).toHaveLength(1)
+    expect(byIdResult.diagnostics[0]!.reason).toBe('unsupported-future-version')
+    expect(byIdResult.profile).toBeUndefined()
+  })
+
+  // @IT-AC-STORE-110@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('back-compat findAll / findById silently discard diagnostics for callers that opt out', async () => {
+    await seedRaw({
+      ...buildProfile({ id: '00000000-0000-4000-a000-0000000000ea', registration: 'D-DR01' }),
       schemaVersion: 50,
     } as unknown as Record<string, unknown>)
 
-    await findAll()
-    const first = consumeMigrationDiagnostics()
-    expect(first).toHaveLength(1)
-
-    const second = consumeMigrationDiagnostics()
-    expect(second).toHaveLength(0)
+    const all = await findAll()
+    expect(all).toHaveLength(0)
+    const one = await findById('00000000-0000-4000-a000-0000000000ea')
+    expect(one).toBeUndefined()
   })
 })
 

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * Integration tests for fleet.repository.ts schemaVersion migration registry.
+ *
+ * Exercises the on-read migration path documented in
+ * `frontend/src/core/logic/profile-migrations.ts` against a real (faked) IndexedDB,
+ * specifically the two scenarios called out by the v0.3.0-alpha audit (refs #259):
+ *
+ *   1. Downgrade after PWA cache rollback — IDB holds a document whose
+ *      `schemaVersion` is greater than the running build can read.
+ *   2. Mid-migration crash recovery — IDB holds a mix of migrated and
+ *      not-yet-migrated documents because a prior load was interrupted.
+ *
+ * @see frontend/src/modules/aircraft/services/fleet.repository.ts
+ * @see frontend/src/core/logic/profile-migrations.ts
+ */
+
+// @IT-AC-STORE-101@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import {
+  create,
+  findById,
+  findAll,
+  consumeMigrationDiagnostics,
+} from '../services/fleet.repository'
+import { CURRENT_PROFILE_SCHEMA_VERSION } from '@/core/logic/profile-migrations'
+import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+  // Drain any diagnostics that may have accumulated from previous tests.
+  consumeMigrationDiagnostics()
+})
+
+/** Minimal valid AircraftProfile fixture. */
+function buildProfile(overrides: Partial<AircraftProfile> = {}): AircraftProfile {
+  return {
+    id: '00000000-0000-4000-a000-000000000001',
+    ownerId: 'user-test',
+    registration: 'D-EBPN',
+    manufacturer: 'Tecnam',
+    model: 'P2008 JC',
+    icaoTypeDesignator: 'P208',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Leading edge',
+    referenceDatumLocation: 'Station 0',
+    shareCode: null,
+    status: 'draft',
+    schemaVersion: 1,
+    powertrain: 'combustion',
+    passengerProfiles: [],
+    weighingReports: [
+      { bem: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+    ],
+    loadPoints: [
+      {
+        name: 'Pilot',
+        arm: 1.8,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 650,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.841, mass: 432 },
+          { armOrMoment: 1.841, mass: 650 },
+          { armOrMoment: 1.978, mass: 650 },
+          { armOrMoment: 1.978, mass: 432 },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+/**
+ * Write a raw document directly into the canonical fleet store, bypassing the
+ * repository's `create()` Zod gate. This is the only way to seed test
+ * scenarios that the production write path explicitly forbids — namely a
+ * `schemaVersion` from the future and a structurally broken record.
+ */
+async function seedRaw(doc: Record<string, unknown>, dbVersion = 2): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.open('aerodash-fleet', dbVersion)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains('aircraft_profiles')) {
+        const store = db.createObjectStore('aircraft_profiles', { keyPath: 'id' })
+        store.createIndex('ownerId', 'ownerId', { unique: false })
+        store.createIndex('registration', 'registration', { unique: false })
+      }
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction('aircraft_profiles', 'readwrite')
+      const store = tx.objectStore('aircraft_profiles')
+      const putReq = store.put(doc)
+      putReq.onsuccess = () => undefined
+      putReq.onerror = () => reject(putReq.error)
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => reject(tx.error)
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+// ─── Downgrade scenarios (PWA cache rollback) ─────────────────────────────────
+
+describe('fleetRepository — downgrade after PWA cache rollback (refs #259)', () => {
+  // @IT-AC-STORE-102@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('drops a single document whose schemaVersion is from a future build', async () => {
+    const futureId = '00000000-0000-4000-a000-0000000000f0'
+    const futureDoc = {
+      ...buildProfile({ id: futureId, registration: 'D-FUTR' }),
+      // Pretend a future build stamped this profile with v2, plus a field that
+      // doesn't exist in today's schema. We must NOT silently drop the field
+      // and parse the document as if it were valid.
+      schemaVersion: CURRENT_PROFILE_SCHEMA_VERSION + 1,
+      futureField: { nested: 'data' },
+    }
+
+    await seedRaw(futureDoc as unknown as Record<string, unknown>)
+
+    const all = await findAll()
+    expect(all).toHaveLength(0)
+
+    const diagnostics = consumeMigrationDiagnostics()
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]!.id).toBe(futureId)
+    expect(diagnostics[0]!.reason).toBe('unsupported-future-version')
+    expect(diagnostics[0]!.storedVersion).toBe(CURRENT_PROFILE_SCHEMA_VERSION + 1)
+  })
+
+  // @IT-AC-STORE-103@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('returns undefined and emits a future-version diagnostic for findById', async () => {
+    const futureId = '00000000-0000-4000-a000-0000000000f1'
+    await seedRaw({
+      ...buildProfile({ id: futureId, registration: 'D-F1ND' }),
+      schemaVersion: 42,
+    } as unknown as Record<string, unknown>)
+
+    const found = await findById(futureId)
+    expect(found).toBeUndefined()
+
+    const diagnostics = consumeMigrationDiagnostics()
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]!.reason).toBe('unsupported-future-version')
+    expect(diagnostics[0]!.storedVersion).toBe(42)
+  })
+
+  // @IT-AC-STORE-104@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('keeps readable v1 profiles when one v-future doc is present (partial load)', async () => {
+    const goodId = '00000000-0000-4000-a000-0000000000a0'
+    const futureId = '00000000-0000-4000-a000-0000000000f2'
+
+    await create(buildProfile({ id: goodId, registration: 'D-OK01' }))
+    // consume the empty diagnostics from create's downstream reads (none)
+    consumeMigrationDiagnostics()
+
+    await seedRaw({
+      ...buildProfile({ id: futureId, registration: 'D-FU02' }),
+      schemaVersion: 99,
+    } as unknown as Record<string, unknown>)
+
+    const all = await findAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]!.registration).toBe('D-OK01')
+
+    const diagnostics = consumeMigrationDiagnostics()
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]!.reason).toBe('unsupported-future-version')
+    expect(diagnostics[0]!.id).toBe(futureId)
+  })
+})
+
+// ─── Corruption / partial-migration recovery ─────────────────────────────────
+
+describe('fleetRepository — corruption + partial-migration crash recovery (refs #259)', () => {
+  // @IT-AC-STORE-105@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('drops a structurally invalid document and emits a corrupt diagnostic', async () => {
+    const badId = '00000000-0000-4000-a000-0000000000b0'
+    await seedRaw({
+      id: badId,
+      schemaVersion: 1,
+      // Almost all required fields missing — simulates partial write before crash.
+      registration: 'D-CRPT',
+    } as unknown as Record<string, unknown>)
+
+    const all = await findAll()
+    expect(all).toHaveLength(0)
+
+    const diagnostics = consumeMigrationDiagnostics()
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]!.id).toBe(badId)
+    expect(diagnostics[0]!.reason).toBe('corrupt')
+  })
+
+  // @IT-AC-STORE-106@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('recovers cleanly from a mid-migration state (mix of v0 legacy + v1 docs)', async () => {
+    // Simulates a build that wrote some docs through `create()` (v1) and was
+    // interrupted before stamping older legacy records. On the next load the
+    // on-read migration walker must repair the v0 records without dropping
+    // the already-migrated v1 records.
+    const legacyId = '00000000-0000-4000-a000-0000000000c0'
+    const v1Id = '00000000-0000-4000-a000-0000000000c1'
+
+    // v1 doc via the normal write path
+    await create(buildProfile({ id: v1Id, registration: 'D-V101' }))
+
+    // Legacy v0 doc seeded raw — schemaVersion field is *missing*
+    const legacyDoc = buildProfile({ id: legacyId, registration: 'D-LEG0' }) as Partial<AircraftProfile> & {
+      schemaVersion?: number
+    }
+    delete legacyDoc.schemaVersion
+    await seedRaw(legacyDoc as Record<string, unknown>)
+
+    const all = await findAll()
+    expect(all).toHaveLength(2)
+    const byReg = Object.fromEntries(all.map((p) => [p.registration, p]))
+    expect(byReg['D-V101']!.schemaVersion).toBe(1)
+    expect(byReg['D-LEG0']!.schemaVersion).toBe(1)
+
+    // The legacy doc must have been forward-stamped by the migration walker
+    // even though the bytes on disk still carry no version field.
+    const diagnostics = consumeMigrationDiagnostics()
+    expect(diagnostics).toHaveLength(0)
+  })
+
+  // @IT-AC-STORE-107@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('handles a fleet with a corrupt doc, a future-version doc, and a healthy doc together', async () => {
+    const okId = '00000000-0000-4000-a000-0000000000d0'
+    const corruptId = '00000000-0000-4000-a000-0000000000d1'
+    const futureId = '00000000-0000-4000-a000-0000000000d2'
+
+    await create(buildProfile({ id: okId, registration: 'D-OK99' }))
+
+    await seedRaw({
+      id: corruptId,
+      schemaVersion: 1,
+      registration: 'D-CR99',
+      // missing required structure → Zod fails
+    } as unknown as Record<string, unknown>)
+
+    await seedRaw({
+      ...buildProfile({ id: futureId, registration: 'D-FU99' }),
+      schemaVersion: 7,
+    } as unknown as Record<string, unknown>)
+
+    const all = await findAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]!.registration).toBe('D-OK99')
+
+    const diagnostics = consumeMigrationDiagnostics()
+    expect(diagnostics).toHaveLength(2)
+    const reasons = diagnostics.map((d) => d.reason).sort()
+    expect(reasons).toEqual(['corrupt', 'unsupported-future-version'])
+  })
+
+  // @IT-AC-STORE-108@ (FROM: @IMP-AC-STORE-001@, @IMP-AC-CORE-003@)
+  it('consumeMigrationDiagnostics is one-shot — second drain returns empty', async () => {
+    await seedRaw({
+      ...buildProfile({ id: '00000000-0000-4000-a000-0000000000e0', registration: 'D-DR01' }),
+      schemaVersion: 50,
+    } as unknown as Record<string, unknown>)
+
+    await findAll()
+    const first = consumeMigrationDiagnostics()
+    expect(first).toHaveLength(1)
+
+    const second = consumeMigrationDiagnostics()
+    expect(second).toHaveLength(0)
+  })
+})
+
+// ─── Envelope round-trip with migration (refs #259) ─────────────────────────
+
+describe('fleetRepository — exchange envelope import back-compat', () => {
+  // @IT-AC-STORE-109@ (FROM: @IMP-AC-STORE-008@, @IMP-AC-CORE-003@)
+  it('a profile imported from a legacy bare-profile JSON persists with schemaVersion=1', async () => {
+    // This is the migration story across the export/import surface: a bare-
+    // profile JSON file produced by an older build is still imported, and
+    // round-trips through the repository as a current-schema document.
+    const { importProfileFromJson } = await import('../services/profile.import')
+    const legacyJson = JSON.stringify({
+      ...buildProfile({ registration: 'D-LEG1' }),
+      // Older exports may not have stamped schemaVersion at all.
+      schemaVersion: undefined,
+    })
+
+    const imported = importProfileFromJson(legacyJson)
+    expect(imported.schemaVersion).toBe(1)
+    await create(imported)
+
+    const found = await findById(imported.id)
+    expect(found).toBeDefined()
+    expect(found!.registration).toBe('D-LEG1')
+    expect(found!.schemaVersion).toBe(1)
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
@@ -18,10 +18,16 @@ import { fleetRepository } from '../services/fleet.repository'
 vi.mock('../services/fleet.repository', () => ({
   fleetRepository: {
     findAll: vi.fn<() => Promise<AircraftProfile[]>>().mockResolvedValue([]),
+    findAllWithDiagnostics: vi
+      .fn<() => Promise<{ profiles: AircraftProfile[]; diagnostics: readonly unknown[] }>>()
+      .mockResolvedValue({ profiles: [], diagnostics: [] }),
     create: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     update: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     deleteById: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     findById: vi.fn<() => Promise<AircraftProfile | undefined>>().mockResolvedValue(undefined),
+    findByIdWithDiagnostics: vi
+      .fn<() => Promise<{ profile: AircraftProfile | undefined; diagnostics: readonly unknown[] }>>()
+      .mockResolvedValue({ profile: undefined, diagnostics: [] }),
     openDB: vi.fn<() => Promise<IDBDatabase>>().mockResolvedValue({} as IDBDatabase),
   },
 }))
@@ -76,6 +82,10 @@ describe('useFleetStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.mocked(fleetRepository.findAll).mockResolvedValue([])
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockResolvedValue({
+      profiles: [],
+      diagnostics: [],
+    })
   })
 
   // @UT-AC-STORE-025@ (FROM: @IMP-AC-STORE-005@)
@@ -196,7 +206,10 @@ describe('useFleetStore', () => {
 
   // @UT-AC-STORE-083@ (FROM: @IMP-AC-STORE-005@, @REQ-AC-001@)
   it('starts with fleetLoadState LOADING until the first successful loadAll', async () => {
-    vi.mocked(fleetRepository.findAll).mockResolvedValueOnce([])
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockResolvedValueOnce({
+      profiles: [],
+      diagnostics: [],
+    })
 
     const store = useFleetStore()
     expect(store.fleetLoadState).toBe('LOADING')
@@ -212,9 +225,9 @@ describe('useFleetStore', () => {
     let capturedDuringLoad: boolean | undefined
 
     const { fleetRepository } = await import('../services/fleet.repository')
-    vi.mocked(fleetRepository.findAll).mockImplementationOnce(async () => {
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockImplementationOnce(async () => {
       capturedDuringLoad = store.isLoading
-      return []
+      return { profiles: [], diagnostics: [] }
     })
 
     await store.loadAll()
@@ -227,7 +240,9 @@ describe('useFleetStore', () => {
   it('loadAll sets isLoading=false even when IndexedDB throws (LOADING→ERROR)', async () => {
     const store = useFleetStore()
     const { fleetRepository } = await import('../services/fleet.repository')
-    vi.mocked(fleetRepository.findAll).mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockRejectedValueOnce(
+      new Error('IndexedDB unavailable'),
+    )
 
     await store.loadAll()
     expect(store.fleetLoadState).toBe('ERROR')
@@ -282,13 +297,77 @@ describe('useFleetStore', () => {
         },
       ],
     }
-    vi.mocked(fleetRepository.findAll).mockResolvedValueOnce([mockProfile])
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockResolvedValueOnce({
+      profiles: [mockProfile],
+      diagnostics: [],
+    })
 
     await store.loadAll()
 
     expect(store.profiles).toHaveLength(1)
     expect(store.profiles[0]!.registration).toBe('G-ABCD')
     expect(store.isLoading).toBe(false)
+  })
+
+  // ── Migration diagnostics surfaced as INFO notifications (refs #259, #353) ──
+
+  // @UT-AC-STORE-113@ (FROM: @IMP-AC-STORE-005@, @IMP-AC-CORE-003@, @REQ-SYS-013@)
+  it('loadAll emits one INFO-AC-001 notification per dropped profile (future version)', async () => {
+    // Without this, profiles dropped by the migration registry would silently
+    // disappear from the fleet UI — the pilot would think the aircraft was
+    // deleted. We surface one INFO toast per dropped record so they know the
+    // load was partial and what to do about it.
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockResolvedValueOnce({
+      profiles: [],
+      diagnostics: [
+        {
+          id: 'aircraft-from-future',
+          reason: 'unsupported-future-version',
+          storedVersion: 7,
+          detail: 'Aircraft profile dropped: stored schemaVersion 7 is newer than this build can read.',
+        },
+      ],
+    })
+
+    const store = useFleetStore()
+    await store.loadAll()
+
+    const infos = store.notifications.filter((n) => n.code === 'INFO-AC-001')
+    expect(infos).toHaveLength(1)
+    expect(infos[0]!.type).toBe('INFO')
+    expect(infos[0]!.message).toContain('aircraft-from-future')
+    expect(infos[0]!.message).toContain('newer than this build')
+  })
+
+  // @UT-AC-STORE-114@ (FROM: @IMP-AC-STORE-005@, @IMP-AC-CORE-003@, @REQ-SYS-013@)
+  it('loadAll emits one INFO-AC-001 notification per dropped profile (corrupt)', async () => {
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockResolvedValueOnce({
+      profiles: [],
+      diagnostics: [
+        { id: 'corrupt-a', reason: 'corrupt', storedVersion: 1, detail: 'Aircraft profile dropped: corrupt at storage layer — schema validation failed: root: missing' },
+        { id: 'corrupt-b', reason: 'corrupt', storedVersion: 1, detail: 'Aircraft profile dropped: corrupt at storage layer — schema validation failed: root: missing' },
+      ],
+    })
+
+    const store = useFleetStore()
+    await store.loadAll()
+
+    const infos = store.notifications.filter((n) => n.code === 'INFO-AC-001')
+    expect(infos).toHaveLength(2)
+    expect(infos.every((n) => n.type === 'INFO')).toBe(true)
+  })
+
+  // @UT-AC-STORE-115@ (FROM: @IMP-AC-STORE-005@, @IMP-AC-CORE-003@)
+  it('loadAll emits no INFO notification when no profile is dropped', async () => {
+    vi.mocked(fleetRepository.findAllWithDiagnostics).mockResolvedValueOnce({
+      profiles: [],
+      diagnostics: [],
+    })
+
+    const store = useFleetStore()
+    await store.loadAll()
+
+    expect(store.notifications.some((n) => n.code === 'INFO-AC-001')).toBe(false)
   })
 
   // ── ICAO registration validation ──

--- a/frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
@@ -11,6 +11,9 @@ import {
   buildExchangeFilename,
   downloadProfileAsJson,
   validateImportFile,
+  isExchangeEnvelope,
+  EXCHANGE_FORMAT,
+  EXCHANGE_VERSION,
   MAX_IMPORT_FILE_BYTES,
   ImportError,
 } from '../services/profile.import'
@@ -204,6 +207,114 @@ describe('exportProfileToJson', () => {
     expect(() => JSON.parse(json)).not.toThrow()
     const reimported = importProfileFromJson(json)
     expect(reimported.registration).toBe(data.registration)
+  })
+
+  // @UT-AC-STORE-101@ (FROM: @IMP-AC-STORE-008@)
+  it('wraps the profile in an aerodash-aircraft envelope (refs #259)', () => {
+    const data = createValidExportedProfile() as AircraftProfile
+    const json = exportProfileToJson(data)
+    const parsed = JSON.parse(json) as Record<string, unknown>
+    expect(parsed.format).toBe(EXCHANGE_FORMAT)
+    expect(parsed.version).toBe(EXCHANGE_VERSION)
+    expect(parsed.profile).toBeDefined()
+    expect((parsed.profile as Record<string, unknown>).registration).toBe('D-EBPN')
+  })
+})
+
+// ─── Envelope detection + back-compat (refs #259) ─────────────────────────────
+
+describe('isExchangeEnvelope', () => {
+  // @UT-AC-STORE-102@ (FROM: @IMP-AC-STORE-008@)
+  it('accepts a well-formed envelope', () => {
+    expect(
+      isExchangeEnvelope({ format: 'aerodash-aircraft', version: 1, profile: {} }),
+    ).toBe(true)
+  })
+
+  // @UT-AC-STORE-103@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects a bare-profile JSON tree (no envelope keys)', () => {
+    expect(isExchangeEnvelope(createValidExportedProfile())).toBe(false)
+  })
+
+  // @UT-AC-STORE-104@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects a tree with wrong `format` marker', () => {
+    expect(
+      isExchangeEnvelope({ format: 'something-else', version: 1, profile: {} }),
+    ).toBe(false)
+  })
+
+  // @UT-AC-STORE-105@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects a tree with non-numeric or non-positive `version`', () => {
+    expect(isExchangeEnvelope({ format: EXCHANGE_FORMAT, version: '1', profile: {} })).toBe(false)
+    expect(isExchangeEnvelope({ format: EXCHANGE_FORMAT, version: 0, profile: {} })).toBe(false)
+    expect(isExchangeEnvelope({ format: EXCHANGE_FORMAT, version: 1.5, profile: {} })).toBe(false)
+  })
+
+  // @UT-AC-STORE-106@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects a tree without a `profile` key', () => {
+    expect(isExchangeEnvelope({ format: EXCHANGE_FORMAT, version: 1 })).toBe(false)
+  })
+
+  // @UT-AC-STORE-107@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects null, arrays, and primitives', () => {
+    expect(isExchangeEnvelope(null)).toBe(false)
+    expect(isExchangeEnvelope(undefined)).toBe(false)
+    expect(isExchangeEnvelope([1, 2, 3])).toBe(false)
+    expect(isExchangeEnvelope('aerodash-aircraft')).toBe(false)
+  })
+})
+
+describe('importProfileFromJson — exchange envelope and back-compat (refs #259)', () => {
+  // @UT-AC-STORE-108@ (FROM: @IMP-AC-STORE-008@)
+  it('imports a profile wrapped in the current-version envelope', () => {
+    const envelope = {
+      format: EXCHANGE_FORMAT,
+      version: EXCHANGE_VERSION,
+      profile: createValidExportedProfile(),
+    }
+    const profile = importProfileFromJson(JSON.stringify(envelope))
+    expect(profile.registration).toBe('D-EBPN')
+    expect(profile.status).toBe('draft')
+  })
+
+  // @UT-AC-STORE-109@ (FROM: @IMP-AC-STORE-008@)
+  it('imports a legacy bare-profile JSON (back-compat with pre-#259 exports)', () => {
+    // No envelope: the entire tree IS the profile (the v0.3.0-alpha export shape).
+    const bare = createValidExportedProfile()
+    const profile = importProfileFromJson(JSON.stringify(bare))
+    expect(profile.registration).toBe('D-EBPN')
+    expect(profile.status).toBe('draft')
+  })
+
+  // @UT-AC-STORE-110@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects an envelope with version > EXCHANGE_VERSION (future build)', () => {
+    const envelope = {
+      format: EXCHANGE_FORMAT,
+      version: EXCHANGE_VERSION + 1,
+      profile: createValidExportedProfile(),
+    }
+    expect(() => importProfileFromJson(JSON.stringify(envelope))).toThrow(ImportError)
+    expect(() => importProfileFromJson(JSON.stringify(envelope))).toThrow(/newer than/)
+  })
+
+  // @UT-AC-STORE-111@ (FROM: @IMP-AC-STORE-008@)
+  it('rejects an envelope whose inner profile fails Zod validation', () => {
+    const bad = createValidExportedProfile()
+    delete bad.registration
+    const envelope = { format: EXCHANGE_FORMAT, version: EXCHANGE_VERSION, profile: bad }
+    expect(() => importProfileFromJson(JSON.stringify(envelope))).toThrow(ImportError)
+    expect(() => importProfileFromJson(JSON.stringify(envelope))).toThrow('Profile validation failed')
+  })
+
+  // @UT-AC-STORE-112@ (FROM: @IMP-AC-STORE-008@)
+  it('round-trip: export → import via envelope preserves the registration', () => {
+    const profile = createValidExportedProfile() as AircraftProfile
+    const exported = exportProfileToJson(profile)
+    // exported MUST be envelope-shaped (assertion above), and reimport MUST succeed.
+    const parsed = JSON.parse(exported)
+    expect(parsed.format).toBe(EXCHANGE_FORMAT)
+    const reimported = importProfileFromJson(exported)
+    expect(reimported.registration).toBe(profile.registration)
   })
 })
 

--- a/frontend/src/modules/aircraft/services/fleet.repository.ts
+++ b/frontend/src/modules/aircraft/services/fleet.repository.ts
@@ -8,9 +8,11 @@
  * Each document read out of IndexedDB is routed through the P1 migration
  * registry (`@/core/logic/profile-migrations`). Documents whose stored
  * `schemaVersion` is from a future build (PWA-cache rollback) or whose
- * contents fail to migrate are *dropped* from the in-memory fleet and the
- * drop reason is reported via {@link consumeMigrationDiagnostics} so the
- * UI / store layer can surface an INFO notification (refs #259).
+ * contents fail to migrate are *dropped* from the in-memory fleet. The
+ * drop reason is returned to the caller alongside the data via the
+ * {@link findAllWithDiagnostics} / {@link findByIdWithDiagnostics} variants
+ * so the UI / store layer can surface an INFO notification per dropped
+ * record (refs #259).
  *
  * @see docs/architecture/adr/006-indexeddb-fleet-persistence.md
  */
@@ -127,13 +129,11 @@ function withStore<T>(
   )
 }
 
-// ─── Migration diagnostics buffer (refs #259) ──────────────────────────────────
-// The repository accumulates a list of documents that failed migration so the
-// store layer can drain it once per load and surface an INFO notification per
-// dropped record. The buffer is process-local and intentionally not surfaced
-// through any kind of subscription API — `findAll` / `findById` consumers
-// drain it via `consumeMigrationDiagnostics()` immediately after their call
-// returns.
+// ─── Migration diagnostics (refs #259) ─────────────────────────────────────────
+// Each load call carries its own diagnostics list back to the caller. We do not
+// keep a module-level buffer: callers that interleave `findAll` and `findById`
+// across `await` boundaries would otherwise see each other's diagnostics. The
+// per-call return value is the only authoritative drain (#353 review feedback).
 
 /** Why a stored document was excluded from the in-memory fleet. */
 export type MigrationDropReason = 'unsupported-future-version' | 'corrupt'
@@ -149,58 +149,42 @@ export interface MigrationDiagnostic {
   readonly detail: string
 }
 
-let _migrationBuffer: MigrationDiagnostic[] = []
-
-/**
- * Drain and return the migration diagnostics produced by the most recent
- * `findAll` / `findById` call(s) on this repository.
- *
- * Callers are expected to invoke this immediately after a load operation;
- * subsequent calls return an empty array.
- */
-export function consumeMigrationDiagnostics(): readonly MigrationDiagnostic[] {
-  const drained = _migrationBuffer
-  _migrationBuffer = []
-  return drained
-}
-
-function recordDiagnostic(rawId: unknown, outcome: ProfileMigrationOutcome): void {
-  if (outcome.kind === 'migrated') return
+function toDiagnostic(rawId: unknown, outcome: ProfileMigrationOutcome): MigrationDiagnostic | null {
+  if (outcome.kind === 'migrated') return null
   const id = typeof rawId === 'string' ? rawId : undefined
   if (outcome.kind === 'unsupported-future-version') {
-    _migrationBuffer.push({
+    return {
       id,
       reason: 'unsupported-future-version',
       storedVersion: outcome.storedVersion,
       detail:
         `Aircraft profile dropped: stored schemaVersion ${outcome.storedVersion} ` +
         `is newer than this build can read. Update the app to restore the profile.`,
-    })
-    return
+    }
   }
-  _migrationBuffer.push({
+  return {
     id,
     reason: 'corrupt',
     storedVersion: outcome.storedVersion,
     detail: `Aircraft profile dropped: corrupt at storage layer — ${outcome.reason}`,
-  })
+  }
 }
 
 /**
  * Apply the schemaVersion migration registry to a single IndexedDB document.
  *
  * Returns the migrated profile when the document is accepted, or `undefined`
- * when the document is dropped (future version / corrupt). The drop reason is
- * recorded in the migration diagnostics buffer so consumers can surface a
- * single user-visible INFO notification per load.
+ * when the document is dropped (future version / corrupt). When dropped, a
+ * diagnostic is appended to the caller-supplied `diagnostics` buffer.
  */
-function applyMigration(raw: unknown): AircraftProfile | undefined {
+function applyMigration(raw: unknown, diagnostics: MigrationDiagnostic[]): AircraftProfile | undefined {
   const outcome = migrateProfileDocument(raw)
   if (outcome.kind === 'migrated') {
     return outcome.profile
   }
   const rawId = raw !== null && typeof raw === 'object' ? (raw as Record<string, unknown>).id : undefined
-  recordDiagnostic(rawId, outcome)
+  const diag = toDiagnostic(rawId, outcome)
+  if (diag !== null) diagnostics.push(diag)
   return undefined
 }
 
@@ -218,37 +202,75 @@ export async function create(profile: AircraftProfile): Promise<void> {
 }
 
 /**
+ * Retrieve a single AircraftProfile by id alongside any migration diagnostic.
+ *
+ * Returns `{ profile: undefined, diagnostics: [...] }` when the stored
+ * document fails the schemaVersion migration (future version / corrupt) so
+ * the caller can surface an INFO notification. `profile` is `undefined` if
+ * the key is absent and `diagnostics` is empty in that case.
+ *
+ * Prefer this race-free variant over the back-compat {@link findById}, which
+ * silently discards diagnostics.
+ */
+export function findByIdWithDiagnostics(
+  id: string,
+): Promise<{ profile: AircraftProfile | undefined; diagnostics: readonly MigrationDiagnostic[] }> {
+  return withStore<AircraftProfile | undefined>('readonly', (store) => store.get(id)).then((doc) => {
+    const diagnostics: MigrationDiagnostic[] = []
+    const profile = doc ? applyMigration(doc, diagnostics) : undefined
+    return { profile, diagnostics }
+  })
+}
+
+/**
  * Retrieve a single AircraftProfile by id.
  *
- * Returns `undefined` when the key is absent OR when the stored document
- * fails the schemaVersion migration (future version / corrupt). In the
- * latter case a diagnostic is appended to {@link consumeMigrationDiagnostics}.
+ * Back-compat shim: returns the migrated profile (or `undefined` when the
+ * document is absent / dropped) and silently discards any drop diagnostic.
+ * For new code that needs to surface drop notifications, call
+ * {@link findByIdWithDiagnostics} instead.
  */
 export function findById(id: string): Promise<AircraftProfile | undefined> {
-  return withStore<AircraftProfile | undefined>('readonly', (store) => store.get(id)).then(
-    (doc) => (doc ? applyMigration(doc) : undefined),
-  )
+  return findByIdWithDiagnostics(id).then((result) => result.profile)
+}
+
+/**
+ * Retrieve all AircraftProfile documents alongside migration diagnostics.
+ *
+ * Documents whose stored `schemaVersion` is newer than this build can read
+ * (PWA-cache rollback) — or whose contents are otherwise structurally
+ * unmigratable — are *omitted* from `profiles` and a `MigrationDiagnostic`
+ * is appended to `diagnostics` per dropped record. This is the documented
+ * partial-load recovery path: the fleet UI keeps working with the readable
+ * subset rather than failing the entire load on a single corrupt record.
+ *
+ * Prefer this race-free variant over the back-compat {@link findAll}, which
+ * silently discards diagnostics.
+ */
+export function findAllWithDiagnostics(): Promise<{
+  profiles: AircraftProfile[]
+  diagnostics: readonly MigrationDiagnostic[]
+}> {
+  return withStore<AircraftProfile[]>('readonly', (store) => store.getAll()).then((docs) => {
+    const diagnostics: MigrationDiagnostic[] = []
+    const profiles: AircraftProfile[] = []
+    for (const doc of docs) {
+      const m = applyMigration(doc, diagnostics)
+      if (m !== undefined) profiles.push(m)
+    }
+    return { profiles, diagnostics }
+  })
 }
 
 /**
  * Retrieve all AircraftProfile documents.
  *
- * Documents whose stored `schemaVersion` is newer than this build can read
- * (PWA-cache rollback) — or whose contents are otherwise structurally
- * unmigratable — are *omitted* from the returned array and surfaced via
- * {@link consumeMigrationDiagnostics}. This is the documented partial-load
- * recovery path: the fleet UI keeps working with the readable subset rather
- * than failing the entire load on a single corrupt record.
+ * Back-compat shim: returns only the migrated profiles and silently discards
+ * any drop diagnostics. For new code that needs to surface drop notifications,
+ * call {@link findAllWithDiagnostics} instead.
  */
 export function findAll(): Promise<AircraftProfile[]> {
-  return withStore<AircraftProfile[]>('readonly', (store) => store.getAll()).then((docs) => {
-    const migrated: AircraftProfile[] = []
-    for (const doc of docs) {
-      const m = applyMigration(doc)
-      if (m !== undefined) migrated.push(m)
-    }
-    return migrated
-  })
+  return findAllWithDiagnostics().then((result) => result.profiles)
 }
 
 /**
@@ -272,8 +294,9 @@ export const fleetRepository = {
   openDB,
   create,
   findById,
+  findByIdWithDiagnostics,
   findAll,
+  findAllWithDiagnostics,
   update,
   deleteById,
-  consumeMigrationDiagnostics,
 }

--- a/frontend/src/modules/aircraft/services/fleet.repository.ts
+++ b/frontend/src/modules/aircraft/services/fleet.repository.ts
@@ -5,11 +5,22 @@
  * Database: aerodash-fleet, version 2 (status normalization migration)
  * Object store: aircraft_profiles, keyPath: id
  *
+ * Each document read out of IndexedDB is routed through the P1 migration
+ * registry (`@/core/logic/profile-migrations`). Documents whose stored
+ * `schemaVersion` is from a future build (PWA-cache rollback) or whose
+ * contents fail to migrate are *dropped* from the in-memory fleet and the
+ * drop reason is reported via {@link consumeMigrationDiagnostics} so the
+ * UI / store layer can surface an INFO notification (refs #259).
+ *
  * @see docs/architecture/adr/006-indexeddb-fleet-persistence.md
  */
 
-import { AircraftProfileSchema } from '@/core/adapters/aircraft.schema'
+import {
+  migrateProfileDocument,
+  type ProfileMigrationOutcome,
+} from '@/core/logic/profile-migrations'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import { AircraftProfileSchema } from '@/core/adapters/aircraft.schema'
 
 // @IMP-AC-STORE-001@ (FROM: @REQ-AC-001@, @DES-ARCH-007@)
 
@@ -53,6 +64,8 @@ function openDB(): Promise<IDBDatabase> {
           const cursor = cursorReq.result
           if (!cursor) return
           const normalized = normalizeLegacyProfileStatus(cursor.value)
+          // Best-effort write: if the doc is corrupt at this point we skip it;
+          // the on-read migration registry will catch and surface it later.
           const parsed = AircraftProfileSchema.safeParse(normalized)
           if (parsed.success) {
             cursor.update(parsed.data)
@@ -114,6 +127,85 @@ function withStore<T>(
   )
 }
 
+// ─── Migration diagnostics buffer (refs #259) ──────────────────────────────────
+// The repository accumulates a list of documents that failed migration so the
+// store layer can drain it once per load and surface an INFO notification per
+// dropped record. The buffer is process-local and intentionally not surfaced
+// through any kind of subscription API — `findAll` / `findById` consumers
+// drain it via `consumeMigrationDiagnostics()` immediately after their call
+// returns.
+
+/** Why a stored document was excluded from the in-memory fleet. */
+export type MigrationDropReason = 'unsupported-future-version' | 'corrupt'
+
+export interface MigrationDiagnostic {
+  /** IndexedDB key of the dropped document, when retrievable. */
+  readonly id: string | undefined
+  /** Why the document was dropped. */
+  readonly reason: MigrationDropReason
+  /** `schemaVersion` actually stored on the document (0 when missing / corrupt). */
+  readonly storedVersion: number
+  /** Human-readable detail for logging / UI tooltips. */
+  readonly detail: string
+}
+
+let _migrationBuffer: MigrationDiagnostic[] = []
+
+/**
+ * Drain and return the migration diagnostics produced by the most recent
+ * `findAll` / `findById` call(s) on this repository.
+ *
+ * Callers are expected to invoke this immediately after a load operation;
+ * subsequent calls return an empty array.
+ */
+export function consumeMigrationDiagnostics(): readonly MigrationDiagnostic[] {
+  const drained = _migrationBuffer
+  _migrationBuffer = []
+  return drained
+}
+
+function recordDiagnostic(rawId: unknown, outcome: ProfileMigrationOutcome): void {
+  if (outcome.kind === 'migrated') return
+  const id = typeof rawId === 'string' ? rawId : undefined
+  if (outcome.kind === 'unsupported-future-version') {
+    _migrationBuffer.push({
+      id,
+      reason: 'unsupported-future-version',
+      storedVersion: outcome.storedVersion,
+      detail:
+        `Aircraft profile dropped: stored schemaVersion ${outcome.storedVersion} ` +
+        `is newer than this build can read. Update the app to restore the profile.`,
+    })
+    return
+  }
+  _migrationBuffer.push({
+    id,
+    reason: 'corrupt',
+    storedVersion: outcome.storedVersion,
+    detail: `Aircraft profile dropped: corrupt at storage layer — ${outcome.reason}`,
+  })
+}
+
+/**
+ * Apply the schemaVersion migration registry to a single IndexedDB document.
+ *
+ * Returns the migrated profile when the document is accepted, or `undefined`
+ * when the document is dropped (future version / corrupt). The drop reason is
+ * recorded in the migration diagnostics buffer so consumers can surface a
+ * single user-visible INFO notification per load.
+ */
+function applyMigration(raw: unknown): AircraftProfile | undefined {
+  const outcome = migrateProfileDocument(raw)
+  if (outcome.kind === 'migrated') {
+    return outcome.profile
+  }
+  const rawId = raw !== null && typeof raw === 'object' ? (raw as Record<string, unknown>).id : undefined
+  recordDiagnostic(rawId, outcome)
+  return undefined
+}
+
+// ─── CRUD API ──────────────────────────────────────────────────────────────────
+
 /**
  * Create a new AircraftProfile document in IndexedDB.
  * Validates cross-field invariants (powertrain ↔ fuel tank ↔ battery pack)
@@ -127,25 +219,36 @@ export async function create(profile: AircraftProfile): Promise<void> {
 
 /**
  * Retrieve a single AircraftProfile by id.
- * Returns undefined if not found. Legacy documents (written before the
- * powertrain discriminator shipped) are rehydrated through the schema so
- * the default `powertrain: 'combustion'` is injected.
+ *
+ * Returns `undefined` when the key is absent OR when the stored document
+ * fails the schemaVersion migration (future version / corrupt). In the
+ * latter case a diagnostic is appended to {@link consumeMigrationDiagnostics}.
  */
 export function findById(id: string): Promise<AircraftProfile | undefined> {
   return withStore<AircraftProfile | undefined>('readonly', (store) => store.get(id)).then(
-    (doc) => (doc ? AircraftProfileSchema.parse(doc) : undefined),
+    (doc) => (doc ? applyMigration(doc) : undefined),
   )
 }
 
 /**
  * Retrieve all AircraftProfile documents.
- * Each document is rehydrated through the schema so legacy records receive
- * the `powertrain: 'combustion'` default.
+ *
+ * Documents whose stored `schemaVersion` is newer than this build can read
+ * (PWA-cache rollback) — or whose contents are otherwise structurally
+ * unmigratable — are *omitted* from the returned array and surfaced via
+ * {@link consumeMigrationDiagnostics}. This is the documented partial-load
+ * recovery path: the fleet UI keeps working with the readable subset rather
+ * than failing the entire load on a single corrupt record.
  */
 export function findAll(): Promise<AircraftProfile[]> {
-  return withStore<AircraftProfile[]>('readonly', (store) => store.getAll()).then((docs) =>
-    docs.map((doc) => AircraftProfileSchema.parse(doc)),
-  )
+  return withStore<AircraftProfile[]>('readonly', (store) => store.getAll()).then((docs) => {
+    const migrated: AircraftProfile[] = []
+    for (const doc of docs) {
+      const m = applyMigration(doc)
+      if (m !== undefined) migrated.push(m)
+    }
+    return migrated
+  })
 }
 
 /**
@@ -172,4 +275,5 @@ export const fleetRepository = {
   findAll,
   update,
   deleteById,
+  consumeMigrationDiagnostics,
 }

--- a/frontend/src/modules/aircraft/services/profile.import.ts
+++ b/frontend/src/modules/aircraft/services/profile.import.ts
@@ -7,6 +7,16 @@
  * - On any error the fleet is NOT modified — ImportError is thrown instead.
  * - Round-trip fidelity: export JSON → parse → re-validate must produce identical data.
  *
+ * Exchange-file envelope (refs #259, audit finding TECH-022):
+ * - New exports wrap the profile in
+ *   `{ format: 'aerodash-aircraft', version: 1, profile: {...} }` so the file
+ *   identifies its schema family up-front and a future schema bump can be
+ *   detected before any field is parsed.
+ * - Import accepts BOTH the envelope form (preferred, written by current
+ *   builds) AND legacy bare-profile JSON (written by builds before this
+ *   wrapper shipped, including AeroDash v0.3.0-alpha). The detector
+ *   inspects the top-level keys to decide which shape is on disk.
+ *
  * @see docs/requirements/aircraft_management.md REQ-AC-004
  */
 
@@ -26,6 +36,30 @@ import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
  * wholesale into memory via `File.text()` (CS-003 / TECH-008).
  */
 export const MAX_IMPORT_FILE_BYTES = 256 * 1024 // 256 KB
+
+/**
+ * Magic `format` marker used in the exchange-file envelope. Distinguishes
+ * an aerodash aircraft profile from any other JSON document the user might
+ * point the import dialog at by accident.
+ */
+export const EXCHANGE_FORMAT = 'aerodash-aircraft' as const
+
+/**
+ * Current exchange-file envelope version.
+ *
+ * Bump in lockstep with the {@link AircraftProfileSchema}'s structural
+ * version when adding new required fields. Reading code rejects envelopes
+ * whose `version` is greater than this constant so a future profile cannot
+ * be imported into an older build (PWA-cache rollback semantics).
+ */
+export const EXCHANGE_VERSION = 1 as const
+
+/** Envelope shape that wraps an exported aircraft profile (since #259). */
+export interface ExchangeEnvelope {
+  readonly format: typeof EXCHANGE_FORMAT
+  readonly version: number
+  readonly profile: unknown
+}
 
 /**
  * Accepted MIME types for an aircraft exchange file. Browsers report `.json`
@@ -92,9 +126,35 @@ export function validateImportFile(file: File): void {
 }
 
 /**
+ * Identify whether a parsed JSON tree is the new envelope or a legacy
+ * bare-profile document.
+ *
+ * The detector is intentionally conservative: a tree only counts as an
+ * envelope when both the `format` marker and a numeric `version` are present.
+ * Any other shape (including a tree that *looks* like an envelope but is
+ * missing one of those keys) falls back to the legacy bare-profile path.
+ */
+// @IMP-AC-STORE-008@ (FROM: @REQ-AC-004@)
+export function isExchangeEnvelope(value: unknown): value is ExchangeEnvelope {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const obj = value as Record<string, unknown>
+  if (obj.format !== EXCHANGE_FORMAT) return false
+  if (typeof obj.version !== 'number') return false
+  if (!Number.isInteger(obj.version) || obj.version <= 0) return false
+  if (!('profile' in obj)) return false
+  return true
+}
+
+/**
  * Parse and validate an aircraft profile from a JSON exchange file string.
  *
  * - Parses the JSON text.
+ * - If the top-level shape is an {@link ExchangeEnvelope}, the envelope's
+ *   `version` is checked against {@link EXCHANGE_VERSION} (a newer version
+ *   is rejected — the user must update the app). The inner `profile` is
+ *   then validated.
+ * - Otherwise the entire tree is treated as a legacy bare-profile document
+ *   (back-compat with builds that shipped before #259).
  * - Validates against AircraftProfileSchema.
  * - Forces status = 'draft' on the imported profile.
  * - Assigns a new UUID to prevent ID collisions with existing fleet entries.
@@ -110,7 +170,21 @@ export function importProfileFromJson(jsonText: string): AircraftProfile {
     throw new ImportError('Invalid JSON: could not parse exchange file', err)
   }
 
-  const result = AircraftProfileSchema.safeParse(parsed)
+  let profileDoc: unknown
+  if (isExchangeEnvelope(parsed)) {
+    if (parsed.version > EXCHANGE_VERSION) {
+      throw new ImportError(
+        `Import failed: exchange file format version ${parsed.version} is newer than ` +
+          `this build can read (max v${EXCHANGE_VERSION}). Update the app to import this profile.`,
+      )
+    }
+    profileDoc = parsed.profile
+  } else {
+    // Legacy bare-profile JSON — accept for back-compat with pre-#259 exports.
+    profileDoc = parsed
+  }
+
+  const result = AircraftProfileSchema.safeParse(profileDoc)
 
   if (!result.success) {
     const issues = result.error.issues
@@ -129,10 +203,23 @@ export function importProfileFromJson(jsonText: string): AircraftProfile {
 
 /**
  * Export an AircraftProfile to a JSON string suitable for exchange.
- * The exported string can be re-imported with importProfileFromJson.
+ *
+ * Emits the {@link ExchangeEnvelope} wrapper (since #259). The output is
+ * a JSON object with three keys:
+ *   - `format`: always `"aerodash-aircraft"` so the file self-identifies.
+ *   - `version`: the {@link EXCHANGE_VERSION} number — older builds detect
+ *     this and refuse the import rather than silently dropping new fields.
+ *   - `profile`: the {@link AircraftProfile} aggregate.
+ *
+ * The exported string can be re-imported with {@link importProfileFromJson}.
  */
 export function exportProfileToJson(profile: AircraftProfile): string {
-  return JSON.stringify(profile, null, 2)
+  const envelope: ExchangeEnvelope = {
+    format: EXCHANGE_FORMAT,
+    version: EXCHANGE_VERSION,
+    profile,
+  }
+  return JSON.stringify(envelope, null, 2)
 }
 
 /**

--- a/frontend/src/modules/aircraft/stores/fleet.store.ts
+++ b/frontend/src/modules/aircraft/stores/fleet.store.ts
@@ -18,7 +18,7 @@ import { ref, computed } from 'vue'
 import { v4 as uuidv4 } from 'uuid'
 import { AircraftProfileSchema } from '@/core/adapters/aircraft.schema'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
-import { fleetRepository } from '../services/fleet.repository'
+import { fleetRepository, type MigrationDiagnostic } from '../services/fleet.repository'
 import { validateIcaoRegistration, hasDuplicateRegistration } from '../services/profile.validator'
 import { useActiveAircraftStore } from './active-aircraft.store'
 
@@ -85,6 +85,26 @@ export const useFleetStore = defineStore('fleet', () => {
     })
   }
 
+  /**
+   * Surface one INFO notification per profile dropped by the schemaVersion
+   * migration registry on load (refs #259). Each diagnostic corresponds to a
+   * profile that was either (a) stamped with a `schemaVersion` newer than this
+   * build can read (PWA-cache rollback) or (b) structurally corrupt at the
+   * storage layer. Without this, dropped profiles would silently disappear
+   * from the pilot's fleet view — they need to know the aircraft was not
+   * deleted, only skipped for this load.
+   */
+  function emitMigrationDiagnostics(diagnostics: readonly MigrationDiagnostic[]): void {
+    for (const d of diagnostics) {
+      const detailWithId = d.id ? `${d.detail} (id: ${d.id})` : d.detail
+      notifications.value.push({
+        type: 'INFO',
+        code: 'INFO-AC-001',
+        message: detailWithId,
+      })
+    }
+  }
+
   function clearNotifications(): void {
     notifications.value = []
   }
@@ -96,7 +116,9 @@ export const useFleetStore = defineStore('fleet', () => {
     fleetLoadState.value = 'LOADING'
     fleetLoadError.value = null
     try {
-      profiles.value = await fleetRepository.findAll()
+      const { profiles: loaded, diagnostics } = await fleetRepository.findAllWithDiagnostics()
+      profiles.value = loaded
+      emitMigrationDiagnostics(diagnostics)
       fleetLoadState.value = 'READY'
     } catch (err) {
       fleetLoadState.value = 'ERROR'

--- a/frontend/src/modules/aircraft/views/FleetManagementView.vue
+++ b/frontend/src/modules/aircraft/views/FleetManagementView.vue
@@ -180,6 +180,10 @@ h2 {
   color: var(--color-warning, #92400e);
 }
 
+.notification--info {
+  color: var(--color-info, #1e40af);
+}
+
 .btn-clear-notifications {
   align-self: flex-end;
   background: none;

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -8,6 +8,7 @@ import { useFleetStore } from '@/modules/aircraft/stores/fleet.store'
 import { useActiveAircraftStore } from '@/modules/aircraft/stores/active-aircraft.store'
 import { useSessionPersistenceStore } from '@/stores/session-persistence.store'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import type { SessionDropNotification } from '@/stores/session-persistence.store'
 import InputGroupCard from '@/modules/mass-balance/components/InputGroupCard.vue'
 import MassStationInput from '@/modules/mass-balance/components/MassStationInput.vue'
 import CGEnvelopeChart from '@/modules/mass-balance/components/CGEnvelopeChart.vue'
@@ -18,6 +19,19 @@ import UndoToast from '@/shared/components/UndoToast.vue'
 // @IMP-MB-UI-FLEET-001@ (FROM: @REQ-AC-001@, @REQ-MB-002@, @UJ-F-002@)
 
 const catalogueError = ref<string | null>(null)
+
+/**
+ * One-shot INFO banner shown when a persisted session payload could not be
+ * restored on the most recent full reload (PWA-cache rollback / corrupt
+ * payload). Drained from `sessionPersistenceStore.consumeDropNotification()`
+ * after `restoreSession()` runs. The pilot dismisses it to acknowledge that
+ * a fresh session was started. Refs #259, #353 review feedback.
+ */
+const sessionDropBanner = ref<SessionDropNotification | null>(null)
+
+function dismissSessionDropBanner(): void {
+  sessionDropBanner.value = null
+}
 
 // ---------------------------------------------------------------------------
 // Store connection (single source of truth)
@@ -274,6 +288,10 @@ onMounted(async () => {
           sessionPersistenceStore.clearSession()
         }
       }
+      // Drain any drop notification produced by `restoreSession()` and surface
+      // it as a dismissible INFO banner. Without this, a dropped session would
+      // silently disappear with no recovery hint for the pilot (refs #259, #353).
+      sessionDropBanner.value = sessionPersistenceStore.consumeDropNotification()
     }
   }
 
@@ -556,6 +574,30 @@ function onAircraftSelected(event: Event): void {
     <div class="fp-page-header">
       <h1 class="fp-page-title">Flight Preparation</h1>
       <p class="fp-page-sub">Mass &amp; Balance · Performance · Weather · {{ isElectric ? 'Energy' : 'Fuel' }}</p>
+    </div>
+
+    <!-- ═══ Session restore banner (INFO-SYS-001) ════════════════════════════
+         Shown when the persisted preflight session could not be restored on
+         this reload (PWA-cache rollback or corrupt payload). Dismissible —
+         the pilot acknowledges that a fresh session was started.
+         Refs #259, #353. -->
+    <div
+      v-if="sessionDropBanner"
+      class="session-drop-banner"
+      :data-reason="sessionDropBanner.reason"
+      role="status"
+      aria-live="polite"
+    >
+      <strong>{{ sessionDropBanner.code }}</strong>
+      <span class="session-drop-banner__message">{{ sessionDropBanner.message }}</span>
+      <button
+        type="button"
+        class="session-drop-banner__dismiss"
+        aria-label="Dismiss notification"
+        @click="dismissSessionDropBanner"
+      >
+        Dismiss
+      </button>
     </div>
 
     <!-- ═══ AIRCRAFT SELECTION CARD (always visible) ══════════════════════ -->
@@ -1160,6 +1202,37 @@ function onAircraftSelected(event: Event): void {
   background: var(--color-critical-bg);
   border: 1px solid var(--color-critical);
   color: var(--color-critical);
+}
+
+/* ─── Session drop banner (INFO-SYS-001) ─────────────────────────────────── */
+
+.session-drop-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--color-info-bg, #eff6ff);
+  border: 1px solid var(--color-info, #3b82f6);
+  color: var(--color-info, #1e40af);
+  font-size: var(--text-sm);
+  flex-wrap: wrap;
+}
+
+.session-drop-banner__message {
+  flex: 1 1 auto;
+}
+
+.session-drop-banner__dismiss {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid currentColor;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
 }
 
 .fleet-error {

--- a/frontend/src/stores/__tests__/session-persistence.store.spec.ts
+++ b/frontend/src/stores/__tests__/session-persistence.store.spec.ts
@@ -109,8 +109,8 @@ describe('useSessionPersistenceStore — restoreSession()', () => {
     expect(localStorage.getItem('aerodash:session:payload')).toBeNull()
   })
 
-  // @UT-SYS-STORE-003@ (FROM: @IMP-SYS-STORE-001@)
-  it('returns null and clears storage when Zod validation fails (wrong version)', () => {
+  // @UT-SYS-STORE-003@ (FROM: @IMP-SYS-STORE-001@, @IMP-SYS-CORE-012@)
+  it('drops payload, clears storage, and emits INFO notification when version is from a future build (refs #259)', () => {
     localStorage.setItem(
       'aerodash:session:payload',
       JSON.stringify({ version: 99, aircraftId: 'x', activeCategory: 'Normal', stations: [], savedAt: new Date().toISOString() }),
@@ -118,10 +118,19 @@ describe('useSessionPersistenceStore — restoreSession()', () => {
     const store = useSessionPersistenceStore()
     expect(store.restoreSession()).toBeNull()
     expect(localStorage.getItem('aerodash:session:payload')).toBeNull()
+
+    const dropped = store.consumeDropNotification()
+    expect(dropped).not.toBeNull()
+    expect(dropped!.severity).toBe('INFO')
+    expect(dropped!.code).toBe('INFO-SYS-001')
+    expect(dropped!.reason).toBe('unsupported-future-version')
+    expect(dropped!.storedVersion).toBe(99)
+    // consume is idempotent — second drain returns null
+    expect(store.consumeDropNotification()).toBeNull()
   })
 
-  // @UT-SYS-STORE-004@ (FROM: @IMP-SYS-STORE-001@)
-  it('returns null and clears storage when schema is missing required fields', () => {
+  // @UT-SYS-STORE-004@ (FROM: @IMP-SYS-STORE-001@, @IMP-SYS-CORE-012@)
+  it('drops payload, clears storage, and emits INFO notification when schema is missing required fields', () => {
     localStorage.setItem(
       'aerodash:session:payload',
       JSON.stringify({ version: 1, aircraftId: 'x' }), // missing required fields
@@ -129,6 +138,40 @@ describe('useSessionPersistenceStore — restoreSession()', () => {
     const store = useSessionPersistenceStore()
     expect(store.restoreSession()).toBeNull()
     expect(localStorage.getItem('aerodash:session:payload')).toBeNull()
+
+    const dropped = store.consumeDropNotification()
+    expect(dropped).not.toBeNull()
+    expect(dropped!.severity).toBe('INFO')
+    expect(dropped!.reason).toBe('corrupt')
+  })
+
+  // @UT-SYS-STORE-037@ (FROM: @IMP-SYS-STORE-001@, @IMP-SYS-CORE-012@)
+  it('clears any prior drop notification when restoring a valid payload', () => {
+    // Seed a corrupt payload first so a drop is emitted.
+    localStorage.setItem('aerodash:session:payload', '{not json')
+    const store = useSessionPersistenceStore()
+    store.restoreSession()
+    expect(store.lastDropNotification).not.toBeNull()
+
+    // Now seed a valid payload; restore must clear the prior drop.
+    const validPayload = {
+      version: 1,
+      aircraftId: 'aircraft-uuid-A',
+      activeCategory: 'Normal',
+      stations: [],
+      savedAt: new Date().toISOString(),
+    }
+    localStorage.setItem('aerodash:session:payload', JSON.stringify(validPayload))
+    const restored = store.restoreSession()
+    expect(restored).not.toBeNull()
+    expect(store.lastDropNotification).toBeNull()
+  })
+
+  // @UT-SYS-STORE-038@ (FROM: @IMP-SYS-STORE-001@, @IMP-SYS-CORE-012@)
+  it('emits no notification when localStorage is empty (clean session is not a drop)', () => {
+    const store = useSessionPersistenceStore()
+    expect(store.restoreSession()).toBeNull()
+    expect(store.lastDropNotification).toBeNull()
   })
 
   // @UT-SYS-STORE-005@ (FROM: @IMP-SYS-STORE-001@)

--- a/frontend/src/stores/session-persistence.store.ts
+++ b/frontend/src/stores/session-persistence.store.ts
@@ -11,26 +11,67 @@
  *  - An invalid or missing payload → clean session (no pre-population).
  *  - Aircraft switch → prior payload immediately cleared.
  *  - Saves are debounced to avoid writing on every keystroke.
- *  - Restored data is validated with Zod before returning to callers.
+ *  - Restored payloads are routed through the P1 migration registry. Payloads
+ *    from a *future* build (PWA-cache rollback) are dropped with an INFO
+ *    notification rather than silently truncated (refs #259). Outright
+ *    corruption clears storage and starts a clean session.
  *
  * @see docs/architecture/frontend_state_machine.md
  */
 
 import { defineStore } from 'pinia'
-import { watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useMassBalanceStore } from '@/modules/mass-balance/stores/mass-balance.store'
-import { SessionPayloadSchema, type SessionPayload } from '@/core/domain/session.schema'
+import {
+  CURRENT_SESSION_PAYLOAD_VERSION,
+  type SessionPayload,
+} from '@/core/domain/session.schema'
+import { migrateSessionPayload } from '@/core/logic/session-migrations'
 
 // @IMP-SYS-STORE-001@ (FROM: @REQ-SYS-013@)
 
 const STORAGE_KEY = 'aerodash:session:payload' as const
 const DEBOUNCE_MS = 300
 
+/** Why a persisted session payload was discarded during `restoreSession()`. */
+export type SessionDropReason =
+  | 'unsupported-future-version'
+  | 'corrupt'
+
+/**
+ * One-shot notification emitted when the persisted session payload could not
+ * be restored. Severity is always INFO — the user has not *lost* anything
+ * they expected to keep (the auto-save is an aid, not a primary store), but
+ * they should know the restore was attempted and skipped.
+ */
+export interface SessionDropNotification {
+  readonly severity: 'INFO'
+  readonly code: 'INFO-SYS-001'
+  readonly reason: SessionDropReason
+  readonly message: string
+  readonly storedVersion: number
+}
+
+function buildDropNotification(
+  reason: SessionDropReason,
+  storedVersion: number,
+): SessionDropNotification {
+  const message =
+    reason === 'unsupported-future-version'
+      ? `Saved preflight data was created by a newer app build (v${storedVersion}). ` +
+        `Update the app to restore it; this build (v${CURRENT_SESSION_PAYLOAD_VERSION}) cannot read it safely.`
+      : `Saved preflight data could not be restored — the stored payload was corrupt. A fresh session was started.`
+  return { severity: 'INFO', code: 'INFO-SYS-001', reason, message, storedVersion }
+}
+
 export const useSessionPersistenceStore = defineStore('sessionPersistence', () => {
   // ── Private state ─────────────────────────────────────────────────────────
 
   let _debounceTimer: ReturnType<typeof setTimeout> | null = null
   let _watching = false
+
+  /** Most-recent drop notification, drained by callers after `restoreSession()`. */
+  const lastDropNotification = ref<SessionDropNotification | null>(null)
 
   // ── Actions ───────────────────────────────────────────────────────────────
 
@@ -45,7 +86,7 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
     }
 
     const payload: SessionPayload = {
-      version: 1,
+      version: CURRENT_SESSION_PAYLOAD_VERSION,
       aircraftId: mbStore.aircraft.id,
       activeCategory: mbStore.activeCategory,
       stations: mbStore.stations.map((s) => ({
@@ -95,16 +136,22 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
   }
 
   /**
-   * Read, validate, and return the persisted session payload.
+   * Read, migrate, validate, and return the persisted session payload.
    *
    * Returns `null` when:
    *  - `localStorage` is empty or the key is absent.
-   *  - The stored JSON fails Zod validation (schema mismatch / corruption).
-   *
-   * An invalid payload is removed from storage so it does not persist across
-   * future page loads.
+   *  - JSON parse fails (storage clears, no notification — a fresh page load
+   *    after a corruption needs no INFO toast).
+   *  - The stored payload's version is *newer* than this build can read
+   *    (PWA-cache rollback). The payload is dropped, storage is cleared,
+   *    and an `unsupported-future-version` {@link SessionDropNotification}
+   *    is emitted on {@link lastDropNotification}.
+   *  - The stored payload fails migration / Zod validation. Storage is
+   *    cleared and a `corrupt` drop notification is emitted.
    */
   function restoreSession(): SessionPayload | null {
+    lastDropNotification.value = null
+
     let raw: string | null = null
     try {
       raw = localStorage.getItem(STORAGE_KEY)
@@ -120,17 +167,40 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
     try {
       parsed = JSON.parse(raw)
     } catch {
+      // Storage held a string that was not valid JSON — treat the same as a
+      // corrupt migration outcome (clear + notify) so the pilot sees one
+      // unified INFO message rather than the silent-clear pre-#259 behaviour.
       clearSession()
+      lastDropNotification.value = buildDropNotification('corrupt', 0)
       return null
     }
 
-    const result = SessionPayloadSchema.safeParse(parsed)
-    if (!result.success) {
-      clearSession()
-      return null
+    const outcome = migrateSessionPayload(parsed)
+
+    if (outcome.kind === 'migrated') {
+      return outcome.payload
     }
 
-    return result.data
+    // Drop path — either unsupported-future-version (PWA cache rollback) or
+    // corrupt (Zod / migration failure). In both cases we clear storage so
+    // the same drop is not re-emitted on every reload and surface a single
+    // INFO notification for the UI to render. The pilot is not silently
+    // deprived of context — they learn the saved session was not restored
+    // and a fresh session was started.
+    clearSession()
+    lastDropNotification.value = buildDropNotification(outcome.kind, outcome.storedVersion)
+    return null
+  }
+
+  /**
+   * Consume and clear the most recent drop notification. Returns `null` when
+   * the last `restoreSession()` did not drop a payload. Callers that surface
+   * INFO toasts should invoke this once after restoring.
+   */
+  function consumeDropNotification(): SessionDropNotification | null {
+    const n = lastDropNotification.value
+    lastDropNotification.value = null
+    return n
   }
 
   // ── Watchers ──────────────────────────────────────────────────────────────
@@ -177,6 +247,8 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
     saveSession,
     clearSession,
     restoreSession,
+    consumeDropNotification,
+    lastDropNotification,
     startWatching,
   }
 })

--- a/frontend/src/stores/session-persistence.store.ts
+++ b/frontend/src/stores/session-persistence.store.ts
@@ -139,13 +139,15 @@ export const useSessionPersistenceStore = defineStore('sessionPersistence', () =
    * Read, migrate, validate, and return the persisted session payload.
    *
    * Returns `null` when:
-   *  - `localStorage` is empty or the key is absent.
-   *  - JSON parse fails (storage clears, no notification — a fresh page load
-   *    after a corruption needs no INFO toast).
+   *  - `localStorage` is empty or the key is absent (no notification — there
+   *    was nothing to restore in the first place).
+   *  - JSON parse fails: storage is cleared and a `corrupt`
+   *    {@link SessionDropNotification} is emitted so the pilot learns the
+   *    saved session could not be restored.
    *  - The stored payload's version is *newer* than this build can read
    *    (PWA-cache rollback). The payload is dropped, storage is cleared,
-   *    and an `unsupported-future-version` {@link SessionDropNotification}
-   *    is emitted on {@link lastDropNotification}.
+   *    and an `unsupported-future-version` drop notification is emitted on
+   *    {@link lastDropNotification}.
    *  - The stored payload fails migration / Zod validation. Storage is
    *    cleared and a `corrupt` drop notification is emitted.
    */

--- a/trace/implementation/ac.yaml
+++ b/trace/implementation/ac.yaml
@@ -74,6 +74,23 @@ AC Store — Fleet Repository
     files:
       - frontend/src/modules/aircraft/stores/active-aircraft.store.ts
 
+AC Core — schemaVersion Migration Registry (#259)
+  IMP-AC-CORE-003
+    title: migrateProfileDocument — schemaVersion-keyed migration registry with per-version up-functions for AircraftProfile documents (#259)
+    req:
+      - REQ-AC-001
+      - REQ-SYS-013
+    files:
+      - frontend/src/core/logic/profile-migrations.ts
+
+AC Store — Exchange Envelope (#259)
+  IMP-AC-STORE-008
+    title: isExchangeEnvelope — detector and exporter for aerodash-aircraft profile envelope with legacy bare-profile back-compat (#259)
+    req:
+      - REQ-AC-004
+    files:
+      - frontend/src/modules/aircraft/services/profile.import.ts
+
 AC View — Model Catalogue and Components
   IMP-AC-VIEW-001
     title: AIRCRAFT_MODEL_CATALOGUE — JSON source + helper functions (manufacturer→model→ICAO)

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -238,3 +238,11 @@ SYS Pending — Connectivity State (not yet implemented)
     req:
       - REQ-SYS-010
     note: REQ-SYS-010 status is Approved. Deferred until IMP-SYS-CONN-001 provides connectivity state.
+
+SYS Core — Session Payload Migration Registry (#259)
+  IMP-SYS-CORE-012
+    title: migrateSessionPayload — session-payload migration table with INFO-severity drop notification on incompatible / corrupt payload (#259)
+    req:
+      - REQ-SYS-013
+    files:
+      - frontend/src/core/logic/session-migrations.ts

--- a/trace/integration_test/ac.yaml
+++ b/trace/integration_test/ac.yaml
@@ -97,3 +97,76 @@ AC Store — DB Migration (ADR-008)
       - IMP-AC-STORE-001
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+
+AC Migration — Downgrade + Corruption Recovery (#259)
+  IT-AC-STORE-101
+    title: Migration suite header — fleet.repository on-read migration tests for #259
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-102
+    title: Drops a single document whose schemaVersion is from a future build
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-103
+    title: findById returns undefined and emits a future-version diagnostic
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-104
+    title: Keeps readable v1 profiles when one v-future doc is present (partial load)
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-105
+    title: Drops a structurally invalid document and emits a corrupt diagnostic
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-106
+    title: Recovers cleanly from a mid-migration state (mix of v0 legacy + v1 docs)
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-107
+    title: Handles a fleet with a corrupt doc, a future-version doc, and a healthy doc together
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-108
+    title: consumeMigrationDiagnostics is one-shot — second drain returns empty
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-109
+    title: A profile imported from a legacy bare-profile JSON persists with schemaVersion=1
+    impl:
+      - IMP-AC-STORE-008
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts

--- a/trace/integration_test/ac.yaml
+++ b/trace/integration_test/ac.yaml
@@ -156,7 +156,15 @@ AC Migration — Downgrade + Corruption Recovery (#259)
       - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
 
   IT-AC-STORE-108
-    title: consumeMigrationDiagnostics is one-shot — second drain returns empty
+    title: Diagnostics are per-call — interleaved findAll / findById do not cross-contaminate
+    impl:
+      - IMP-AC-STORE-001
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.migration.int.spec.ts
+
+  IT-AC-STORE-110
+    title: Back-compat findAll / findById silently discard diagnostics for callers that opt out
     impl:
       - IMP-AC-STORE-001
       - IMP-AC-CORE-003

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -1608,3 +1608,96 @@ AC View — ProfileStatusBadge Component (Unit)
       - IMP-AC-VIEW-019
     files:
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+
+AC Core — Profile Migration Tests (#259)
+  UT-AC-CORE-101
+    title: migrateProfileDocument suite — schemaVersion migration registry tests for AircraftProfile (#259)
+    impl:
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/core/logic/profile-migrations.spec.ts
+
+AC Store — Exchange Envelope Tests (#259)
+  UT-AC-STORE-101
+    title: exportProfileToJson wraps the profile in an aerodash-aircraft envelope
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-102
+    title: isExchangeEnvelope accepts a well-formed envelope
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-103
+    title: isExchangeEnvelope rejects a bare-profile JSON tree
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-104
+    title: isExchangeEnvelope rejects a tree with wrong format marker
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-105
+    title: isExchangeEnvelope rejects a tree with non-numeric or non-positive version
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-106
+    title: isExchangeEnvelope rejects a tree without a profile key
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-107
+    title: isExchangeEnvelope rejects null, arrays, and primitives
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-108
+    title: importProfileFromJson imports a profile wrapped in the current-version envelope
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-109
+    title: importProfileFromJson imports a legacy bare-profile JSON (back-compat with pre-#259 exports)
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-110
+    title: importProfileFromJson rejects an envelope with version > EXCHANGE_VERSION
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-111
+    title: importProfileFromJson rejects an envelope whose inner profile fails Zod validation
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+  UT-AC-STORE-112
+    title: round-trip — export → import via envelope preserves the registration
+    impl:
+      - IMP-AC-STORE-008
+    files:
+      - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -1701,3 +1701,28 @@ AC Store — Exchange Envelope Tests (#259)
       - IMP-AC-STORE-008
     files:
       - frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+
+AC Store — Migration Diagnostics Surfaced as INFO Notifications (Unit)
+  UT-AC-STORE-113
+    title: loadAll emits one INFO-AC-001 notification per dropped profile (future version)
+    impl:
+      - IMP-AC-STORE-005
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-114
+    title: loadAll emits one INFO-AC-001 notification per dropped profile (corrupt)
+    impl:
+      - IMP-AC-STORE-005
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+
+  UT-AC-STORE-115
+    title: loadAll emits no INFO notification when no profile is dropped
+    impl:
+      - IMP-AC-STORE-005
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts

--- a/trace/unit_test/sys.yaml
+++ b/trace/unit_test/sys.yaml
@@ -999,3 +999,28 @@ SYS Store — App Version (Unit)
       - IMP-SYS-STORE-006
     files:
       - frontend/src/stores/__tests__/app-version.store.spec.ts
+
+SYS Core — Session Migration Tests (#259)
+  UT-SYS-CORE-101
+    title: migrateSessionPayload suite — session payload migration registry tests (#259)
+    impl:
+      - IMP-SYS-CORE-012
+    files:
+      - frontend/src/core/logic/session-migrations.spec.ts
+
+SYS Store — Session Drop Notification Tests (#259)
+  UT-SYS-STORE-037
+    title: restoreSession clears any prior drop notification when restoring a valid payload
+    impl:
+      - IMP-SYS-STORE-001
+      - IMP-SYS-CORE-012
+    files:
+      - frontend/src/stores/__tests__/session-persistence.store.spec.ts
+
+  UT-SYS-STORE-038
+    title: restoreSession emits no notification when localStorage is empty (clean session is not a drop)
+    impl:
+      - IMP-SYS-STORE-001
+      - IMP-SYS-CORE-012
+    files:
+      - frontend/src/stores/__tests__/session-persistence.store.spec.ts


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Closes the `aerodash-fleet` IndexedDB and session-payload schema-version safety gap deferred from the v0.3.0-alpha release audit (TECH-005 / TECH-022 / TECH-025; PR-011). Before this PR the `schemaVersion` field was written to disk but never read, the `SessionPayload` schema was a fixed `z.literal(1)` with no migration path, and the aircraft exchange JSON was a bare profile with no version envelope. All three closed in lockstep.

What landed:

- **Aircraft profile migration registry (P1 Safety Core).** New `frontend/src/core/logic/profile-migrations.ts` walks a `schemaVersion`-keyed map of per-version up-functions (currently `0 → 1` legacy stamping), drops documents whose stored version is from a *future* build (PWA-cache rollback) with an `unsupported-future-version` outcome, and surfaces Zod failures as `corrupt` rather than escaping unhandled. Each up-function is wrapped in try/catch so a single throwing transform cannot poison the whole fleet load.
- **Fleet repository wiring (P2).** `frontend/src/modules/aircraft/services/fleet.repository.ts` routes every `findAll` / `findById` result through the migration registry. Dropped documents are emitted as `MigrationDiagnostic` records on a process-local buffer drained via `consumeMigrationDiagnostics()`, so the store / UI layer can render one INFO toast per dropped record without changing the function signature.
- **Session payload migration table (P1 Safety Core).** New `frontend/src/core/logic/session-migrations.ts` mirrors the profile registry for the `aerodash:session:payload` localStorage value. `frontend/src/core/domain/session.schema.ts` now exports `CURRENT_SESSION_PAYLOAD_VERSION` (still 1) and `SessionPayloadSchema.version` is a `z.literal` aligned with the migration target.
- **Session-persistence drop notification (P3).** `restoreSession()` now publishes a single `SessionDropNotification` (severity INFO, code `INFO-SYS-001`) when a payload is dropped — future-version, corrupt-JSON, or Zod-fail. Storage is cleared so the same drop is not re-emitted on subsequent reloads. `consumeDropNotification()` and the `lastDropNotification` ref let consumers surface the toast once.
- **Exchange-file envelope (P2) + back-compat.** Exports now write `{ format: "aerodash-aircraft", version: 1, profile: {...} }`. `importProfileFromJson` detects the envelope via `isExchangeEnvelope`, rejects envelopes whose `version` is from a future build, and falls back to the legacy bare-profile shape so v0.3.0-alpha and earlier exports still import cleanly.

Local gates green: `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm --filter frontend type-check`, `pnpm test:unit` (1127/1127), `pnpm test:integration` (39/39), `pnpm build`. `pnpm --filter frontend test:p1` 414/414. `pnpm trace check` introduces zero new violations for the IDs added here (pre-existing baseline drift unchanged).

### Related Issues

- Closes #259

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-AC-001`, `REQ-AC-004`, `REQ-SYS-013` — all already `Status: Implemented`; this PR hardens the persistence layer's behaviour under schema drift without changing the requirement surface.

### Documentation Updates

- [x] **Requirements:** N/A (Reason: REQ-AC-001 / REQ-AC-004 / REQ-SYS-013 are already `Implemented`; this PR is a defensive hardening of the persistence layer behind those requirements, not a new behaviour.)
- [x] **Architecture:** N/A (Reason: the registry and envelope reuse the patterns from ADR-006 (IndexedDB persistence) and ADR-008 (IndexedDB migration strategy) — no architectural surface changed.)
- [x] **Risk Management:** N/A (Reason: no new hazards introduced; the migration registry strengthens H-011 / data-integrity coverage by failing closed on unknown-future versions and corruption.)
- [x] **Journeys:** N/A (Reason: change is sub-UI / persistence-layer plumbing — no pilot journey adds or modifies steps.)
- [x] **Code Docs:** N/A (Reason: per the implement-issue skill the CHANGELOG is reserved for the release process; inline TSDoc in `profile-migrations.ts`, `session-migrations.ts`, `fleet.repository.ts`, and `profile.import.ts` documents the new contract.)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules — `pnpm --filter frontend test:p1` 414/414).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (features/bugs) OR `main` (releases/hotfixes).
- [x] **Unit Tests:** Added/updated and passing locally — new specs for `profile-migrations`, `session-migrations`, and exchange-envelope detection in `profile.import.spec.ts`; updated `session-persistence.store.spec.ts` for the drop-notification contract.
- [x] **Integration Tests:** Passing — new `fleet.repository.migration.int.spec.ts` covers the downgrade (PWA cache rollback) and mid-migration crash-recovery scenarios called out by the audit, plus end-to-end legacy-import → repository persistence.
- [x] **Manual Testing:** N/A (Reason: pre-merge automation runs unattended; behaviour is fully driven by unit + integration tests against `fake-indexeddb` and jsdom localStorage. Manual cockpit-tablet validation is out of scope for a persistence-layer hardening with no UI surface change.)
- [x] **DoD:** All Definition of Done items from #259 met:
    - [x] Migration registry + per-version functions implemented (`profile-migrations.ts`, `session-migrations.ts`; both used on read)
    - [x] IT covers downgrade + partial-migration corruption (`fleet.repository.migration.int.spec.ts` — 8 scenarios)
    - [x] Session payload migration + drop notification (`session-migrations.ts` + `session-persistence.store.ts` INFO-SYS-001 + `consumeDropNotification`)
    - [x] Export envelope wrapper + import back-compat test (`exportProfileToJson` writes the envelope; `importProfileFromJson` accepts both envelope and legacy bare-profile shapes; tested by both unit and integration specs)
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** N/A (Reason: the registry pattern is an implementation of the existing ADR-008 migration strategy; no new architectural decision is needed. If a future schema bump introduces a non-trivial up-function, a per-version DES entry will be filed alongside it.)

