### PR TITLE
fix(repo): allow claude[bot] to initiate review-bot + overnight workflows (Closes #350)

### DIFF
--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -238,6 +238,14 @@ jobs:
           # the action skips the OIDC exchange when github_token is set. Empty on
           # CI ⇒ unchanged production behaviour.
           github_token: ${{ env.ACT == 'true' && secrets.GITHUB_TOKEN || '' }}
+          # The action's bot-actor safety gate refuses non-human initiators by
+          # default. The cron trigger runs as `github-actions` so it is unaffected
+          # today, but `workflow_dispatch` invocations made via the GitHub API by
+          # `claude[bot]` (or any future bot-driven rerun) would be rejected. We
+          # whitelist ONLY `claude` for parity with the other two automation
+          # workflows (pr-iteration.yml from #348, pr-review-bot.yml from #350) —
+          # never `*`, which is documented as unsafe on public repos.
+          allowed_bots: 'claude'
           prompt: |
             You are running unattended in CI on branch feature/issue-${{ matrix.issue }}.
             ${{ env.ACT == 'true' && 'LOCAL ACT TEST RUN — make NO remote/GitHub changes: no project-board claim or move, no issue assignment, no label edits, no issue comments, no PR or sub-issue creation, and do NOT git push to any remote. Only read from GitHub, edit files, run the pipeline, and commit locally. (This line is empty on real CI.)' || '' }}

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -70,6 +70,21 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # API-key alternative: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # This workflow triggers on `pull_request: synchronize` (and `opened`/
+          # `reopened`). When the iteration / overnight-implementation bot pushes
+          # a correction commit on a Draft PR, the synchronize event's initiator
+          # is `claude[bot]` — and the action's bot-actor safety gate refuses
+          # non-human initiators by default (prevents bot↔bot loops; see the
+          # action's docs/security.md). That leaves the ready-gate stuck on the
+          # previous, stale `CHANGES_REQUESTED` review.
+          #
+          # Allow ONLY `claude` — never `*`, which is documented as unsafe on
+          # public repos because external Apps could invoke the action with
+          # attacker-controlled prompts. Dependabot / github-actions / other
+          # bots commenting or pushing on a bot branch still cannot initiate a
+          # review round under this allow-list. Mirrors the same fix landed for
+          # `pr-iteration.yml` in #348; addresses #350.
+          allowed_bots: 'claude'
           prompt: |
             Review pull request #${{ github.event.pull_request.number }} in this
             repository and post a single structured PR review.


### PR DESCRIPTION
### Summary

Adds `allowed_bots: 'claude'` to the two automation workflows that still default-rejected non-human initiators, mirroring the patch landed for `pr-iteration.yml` in #348:

- **`.github/workflows/pr-review-bot.yml`** — REQUIRED. The `pull_request: synchronize` event fired by an iteration / overnight-implementation correction commit lists `claude[bot]` as the initiator. The action's default bot-actor safety gate refuses non-human initiators, so the re-review never runs and the ready-gate stalls on the previous (stale) `CHANGES_REQUESTED` review. **Concrete recurrence on PR #353 today.**
- **`.github/workflows/overnight-implementation.yml`** — PREVENTIVE. The nightly `schedule` cron runs as `github-actions` so it is unaffected today, but a `workflow_dispatch` rerun initiated by `claude[bot]` via the GitHub API would hit the same gate. Patching for parity with the other two workflows keeps the policy consistent across all three Claude-action invocations.

Whitelist is `claude` only — **never `*`**, which the action documents as unsafe on public repos (external Apps could invoke with attacker-controlled prompts). Dependabot / github-actions / other bots commenting or pushing on a bot branch still cannot initiate either workflow under this allow-list.

No code under `src/` is touched. Workflow-only patch. Same comment block style as #348 so the rationale is co-located with the change.

### Related Issues

- Closes #350

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A`

### Documentation Updates

- [x] **Requirements:** N/A (Reason: workflow-only patch; no requirement surface affected.)
- [x] **Architecture:** N/A (Reason: ADR-317-DEV already governs the automation pipeline; this PR is a faithful implementation of its bot-allowlist policy across the third and fourth Claude-action invocations, not a new architectural decision.)
- [x] **Risk Management:** N/A (Reason: no new hazards; this *reduces* the operational risk of stuck ready-gates by removing a known failure mode.)
- [x] **Journeys:** N/A (Reason: not a pilot-facing change.)
- [x] **Code Docs:** N/A (Reason: rationale is documented inline at each patched step.)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules — no `src/` code touched).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** N/A (Reason: workflow YAML has no unit-test surface; covered by the live re-run of the workflow on this very PR — the next iteration / overnight push that triggers `pr-review-bot.yml` will validate the allowlist is in effect.)
- [x] **Integration Tests:** N/A (Reason: same — the workflow is its own integration surface.)
- [x] **Manual Testing:** N/A (Reason: pre-merge automation runs unattended; the empirical evidence that the fix is needed is PR #353 today, and the empirical evidence that the same pattern works is `pr-iteration.yml` since #348.)
- [x] **DoD:** All Definition of Done items from #350 met:
    - [x] `allowed_bots: 'claude'` added to `pr-review-bot.yml` under the `anthropics/claude-code-action@v1` step
    - [x] Inline comment explains why `'claude'` rather than `'*'`
    - [x] Same fix applied preventively to `overnight-implementation.yml` for parity
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** N/A (Reason: ADR-317-DEV already covers the automation pipeline; no architectural surface changed.)
