### PR TITLE
feat: [Feat]: POH-based take-off & landing distance calculation (TOR/TOD/LR/LD) (#298)

### DIFF
--- a/docs/architecture/performance-bilinear-interpolation-contract.md
+++ b/docs/architecture/performance-bilinear-interpolation-contract.md
@@ -259,3 +259,84 @@ distance  = lerp(367.5, 440.0, 0.5) = 403.75 m
   responsibility and must happen before calling this function.
 - This function is **pure** and **deterministic**: identical inputs always
   produce identical outputs. It has no side effects.
+
+---
+
+## 9. 3-Axis Extension — Mass × Pressure Altitude × Temperature
+
+REQ-PF-002 specifies interpolation over **three** continuous variables
+(mass, pressure altitude, temperature). Section 5 documents the 2-axis
+building block; this section documents the 3-axis facade that composes it.
+
+### 9.1 `PerformanceCube3D`
+
+| Field | Type | Constraint |
+| :---- | :--- | :--------- |
+| `massAxis` | `number[]` | ≥ 1 entry; strictly ascending; unit: **kg** |
+| `altitudeAxis` | `number[]` | ≥ 1 entry; strictly ascending; unit: **ft** |
+| `temperatureAxis` | `number[]` | ≥ 1 entry; strictly ascending; unit: **°C** |
+| `values` | `number[][][]` | `values[t][a][m]` — distance in metres |
+
+A degenerate axis (length 1) is supported: interpolation along that axis
+collapses to a constant, which models legacy POH tables that publish only
+one temperature column.
+
+### 9.2 `trilinearInterpolate(input)`
+
+Algorithm (composition over the 2-D engine):
+
+1. Validate cube shape (axis lengths and value dimensions).
+2. Clamp `mass`, `pressureAltitude`, `temperature` independently to their
+   axis bounds; flag any clamping.
+3. Locate the lo/hi temperature slice indices and the fraction `t_temp`.
+4. Run `bilinearInterpolate` on each slice for `(mass, pressureAltitude)`.
+5. Linearly interpolate the two resulting distances along the temperature
+   axis: `distance = lerp(dLo, dHi, t_temp)`.
+
+Returned `{ distance, massClamped, altitudeClamped, temperatureClamped }`
+mirror the 2-D contract.
+
+### 9.3 `pivotDataPointsToCube(dataPoints)`
+
+Aircraft profiles store performance data as a sparse
+`PerformanceDataPoint[]` (REQ-AD-008, REQ-AD-009). The facade pivots this
+list into a dense `PerformanceCube3D` before trilinear lookup. Constraints
+(all enforced via `[PF-PIVOT]` errors):
+
+- At least one data point.
+- Every numeric field finite (NaN / ±Infinity rejected).
+- Every `(mass, PA, temperature)` triple unique (no duplicates).
+- Points form a *regular* grid:
+  `|points| = |unique mass| × |unique PA| × |unique temp|`.
+  Irregular layouts are rejected in v1; a follow-up will define a
+  documented strategy for sparse POH data.
+
+### 9.4 `computePohDistances(profile, conditions)` — Verified-only facade
+
+Single entry point for the four certified distances (REQ-PF-001). The
+function is **pure**, never throws on valid call sites, and surfaces every
+non-success path as a typed `failure` so callers can render it without
+exception handling.
+
+| Failure reason | Trigger |
+| :------------- | :------ |
+| `profile_unverified` | `profile.status !== 'verified'` (architecture constraint — H-004 / H-011 mitigation) |
+| `profile_incomplete` | Any of the four phases missing or empty |
+| `invalid_input` | `mass`, `pressureAltitude`, or `temperature` not finite |
+| `invalid_grid` | Pivot fails (irregular grid, duplicates, non-finite cell) |
+
+On success the function returns `{ takeoffRoll, takeoffDistance50ft,
+landingRoll, landingDistance50ft }` plus a per-phase clamping flag block.
+Each `*Clamped` flag must be surfaced to the pilot UI — extrapolation
+cap + 20 % penalty + acknowledgement (REQ-PF-010 / REQ-PF-012) are applied
+by a sibling module that composes this facade.
+
+### 9.5 Safety Considerations (extension)
+
+- The Verified-status gate is the *only* mechanism that prevents Draft
+  profile data from feeding the math core. There is no alternate code path
+  that skips the gate.
+- The facade never returns `NaN` / `Infinity` for any input that passes
+  validation; structurally invalid cubes are surfaced as `invalid_grid`.
+- Implementation tags: `IMP-PF-CORE-002` … `IMP-PF-CORE-005` in
+  `frontend/src/core/logic/performance.poh-distance.ts`.

--- a/docs/requirements/performance.md
+++ b/docs/requirements/performance.md
@@ -12,7 +12,7 @@ This document defines the performance behavior using the **EARS** (Easy Approach
 **Requirement:** The system shall calculate four distinct performance variables for every flight: Takeoff Run (TOR), Takeoff Distance to 50ft (TOD), Landing Roll (LR), and Landing Distance from 50ft (LD).
 **Rationale:** Complete performance picture required for phase-specific corrections.
 **Priority:** P1
-**Status:** Approved
+**Status:** Implemented
 **Design Reference:** n/a
 
 <!-- @REQ-PF-002@ (FROM: @H-004@) -->
@@ -21,7 +21,7 @@ This document defines the performance behavior using the **EARS** (Easy Approach
 **Requirement:** The system shall determine base performance values via bilinear interpolation of the aircraft's POH tables, utilizing Mass, Pressure Altitude, and Temperature.
 **Rationale:** Core engine for certified baseline data.
 **Priority:** P1
-**Status:** Approved
+**Status:** Implemented
 **Design Reference:** n/a
 
 <!-- @REQ-PF-003@ -->

--- a/frontend/src/core/logic/__tests__/performance.poh-distance.int.spec.ts
+++ b/frontend/src/core/logic/__tests__/performance.poh-distance.int.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests for the POH distance facade — exercises the full path
+ * through the Zod-validated AircraftProfile aggregate, the schemaVersion
+ * migration walker, and the trilinear interpolation engine.
+ *
+ * The unit specs live next to the source; this file proves the **flow**:
+ *   raw IndexedDB document → migrateProfileDocument → computePohDistances
+ *
+ * The integration boundary is intentionally inside the P1 core (no Vue/Pinia
+ * imports — the boundary is P1 modules talking to each other, not P1↔P2).
+ *
+ * @see ../performance.poh-distance.ts
+ */
+
+// @IT-PF-CORE-001@ (FROM: @IMP-PF-CORE-005@, @IMP-AC-CORE-003@)
+
+import { describe, it, expect } from 'vitest'
+import {
+  migrateProfileDocument,
+  type ProfileMigrationOutcome,
+} from '../profile-migrations'
+import {
+  computePohDistances,
+  type PohDistanceConditions,
+} from '../performance.poh-distance'
+import type { PerformanceDataPoint } from '../../domain/aircraft.types'
+
+const conditions = (
+  mass: number,
+  pa: number,
+  temperature: number,
+): PohDistanceConditions => ({ mass, pressureAltitude: pa, temperature })
+
+function phaseDataPoints(base: number): PerformanceDataPoint[] {
+  const out: PerformanceDataPoint[] = []
+  for (const t of [0, 20]) {
+    for (const a of [0, 2000]) {
+      for (const m of [850, 1000]) {
+        out.push({
+          mass: m,
+          pressureAltitude: a,
+          temperature: t,
+          distance: base * (m / 850) * (1 + a / 10000) * (1 + t / 200),
+        })
+      }
+    }
+  }
+  return out
+}
+
+function rawDocument(status: 'draft' | 'verified'): Record<string, unknown> {
+  return {
+    id: '00000000-0000-4000-a000-000000000200',
+    ownerId: 'pilot-int-test',
+    registration: 'D-EAEX',
+    manufacturer: 'Test',
+    model: 'PF Integration',
+    icaoTypeDesignator: 'C172',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Datum',
+    referenceDatumLocation: 'Station 0',
+    shareCode: null,
+    status,
+    schemaVersion: 1,
+    powertrain: 'combustion',
+    passengerProfiles: [],
+    weighingReports: [
+      { bem: 700, emptyCg: 1.5, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+    ],
+    loadPoints: [
+      {
+        name: 'Pilot',
+        arm: 1.8,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 1157,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.4, mass: 600 },
+          { armOrMoment: 1.4, mass: 1157 },
+          { armOrMoment: 2.0, mass: 1157 },
+          { armOrMoment: 2.0, mass: 600 },
+        ],
+      },
+    ],
+    performanceProfiles: [
+      { flightPhase: 'TakeoffRoll', dataPoints: phaseDataPoints(210) },
+      { flightPhase: 'TakeoffDistance50ft', dataPoints: phaseDataPoints(340) },
+      { flightPhase: 'LandingRoll', dataPoints: phaseDataPoints(185) },
+      { flightPhase: 'LandingDistance50ft', dataPoints: phaseDataPoints(315) },
+    ],
+  }
+}
+
+function expectMigrated(outcome: ProfileMigrationOutcome) {
+  expect(outcome.kind).toBe('migrated')
+  if (outcome.kind !== 'migrated') {
+    throw new Error('migration did not yield a profile')
+  }
+  return outcome
+}
+
+describe('integration: raw doc → migration → POH distance computation', () => {
+  it('a Verified profile produces all four distances at an exact grid point', () => {
+    const out = expectMigrated(migrateProfileDocument(rawDocument('verified')))
+    const result = computePohDistances(out.profile, conditions(850, 0, 0))
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') return
+    expect(result.distances.takeoffRoll).toBeCloseTo(210, 5)
+    expect(result.distances.takeoffDistance50ft).toBeCloseTo(340, 5)
+    expect(result.distances.landingRoll).toBeCloseTo(185, 5)
+    expect(result.distances.landingDistance50ft).toBeCloseTo(315, 5)
+  })
+
+  it('a Draft profile is blocked from performance computation', () => {
+    const out = expectMigrated(migrateProfileDocument(rawDocument('draft')))
+    expect(out.profile.status).toBe('draft')
+    const result = computePohDistances(out.profile, conditions(900, 1000, 15))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('profile_unverified')
+    expect(result.message).toContain('Verified')
+  })
+
+  it('a legacy v0 document is upgraded then computation respects its status', () => {
+    const raw = rawDocument('verified')
+    delete (raw as { schemaVersion?: number }).schemaVersion
+    const out = expectMigrated(migrateProfileDocument(raw))
+    expect(out.profile.schemaVersion).toBe(1)
+    const result = computePohDistances(out.profile, conditions(925, 1000, 10))
+    expect(result.status).toBe('success')
+  })
+})

--- a/frontend/src/core/logic/performance.poh-distance.spec.ts
+++ b/frontend/src/core/logic/performance.poh-distance.spec.ts
@@ -1,0 +1,601 @@
+/**
+ * Unit tests for the POH distance facade — trilinear interpolation, sparse
+ * data-point → cube pivot, and the Verified-status gate.
+ *
+ * @see performance.poh-distance.ts
+ */
+
+// @UT-PF-CORE-041@ (FROM: @IMP-PF-CORE-002@, @IMP-PF-CORE-003@, @IMP-PF-CORE-004@, @IMP-PF-CORE-005@)
+
+import { describe, it, expect } from 'vitest'
+import { AircraftProfileSchema, type AircraftProfile } from '../adapters/aircraft.schema'
+import {
+  computePohDistances,
+  pivotDataPointsToCube,
+  trilinearInterpolate,
+  type PerformanceCube3D,
+  type PohDistanceConditions,
+} from './performance.poh-distance'
+import type { PerformanceDataPoint } from '../domain/aircraft.types'
+
+// ── Trilinear engine fixtures ────────────────────────────────────────────────
+
+const MASS_AXIS = [850, 1000, 1157]
+const ALT_AXIS = [0, 2000, 4000, 6000]
+const TEMP_AXIS = [-20, 0, 20, 40]
+
+/**
+ * Canonical TOR (Takeoff Roll) 3-D cube — temperature dimension extends the
+ * v0.3.0 2-D table with a documented ISA-style scale factor:
+ *   slice(-20 °C) = 0.85 × slice(0 °C)
+ *   slice(  0 °C) = baseline v0.3.0 TOR table
+ *   slice( 20 °C) = 1.15 × slice(0 °C)
+ *   slice( 40 °C) = 1.30 × slice(0 °C)
+ * Values are aviation-realistic and self-consistent so manual hand-checks
+ * cross-validate the trilinear math.
+ */
+const TOR_CUBE: PerformanceCube3D = {
+  massAxis: MASS_AXIS,
+  altitudeAxis: ALT_AXIS,
+  temperatureAxis: TEMP_AXIS,
+  values: [
+    // T = -20 °C
+    [
+      [178.5, 229.5, 289.0],
+      [216.75, 276.25, 348.5],
+      [259.25, 331.5, 416.5],
+      [310.25, 395.25, 497.25],
+    ],
+    // T = 0 °C — baseline
+    [
+      [210, 270, 340],
+      [255, 325, 410],
+      [305, 390, 490],
+      [365, 465, 585],
+    ],
+    // T = 20 °C
+    [
+      [241.5, 310.5, 391.0],
+      [293.25, 373.75, 471.5],
+      [350.75, 448.5, 563.5],
+      [419.75, 534.75, 672.75],
+    ],
+    // T = 40 °C
+    [
+      [273, 351, 442],
+      [331.5, 422.5, 533],
+      [396.5, 507, 637],
+      [474.5, 604.5, 760.5],
+    ],
+  ],
+}
+
+const conditions = (
+  mass: number,
+  pa: number,
+  temperature: number,
+): PohDistanceConditions => ({ mass, pressureAltitude: pa, temperature })
+
+// ── trilinearInterpolate ─────────────────────────────────────────────────────
+
+describe('trilinearInterpolate — temperature axis', () => {
+  it('VEC-TRI-001: exact grid point in all 3 axes (850 kg, 0 ft, 0 °C) → 210 m', () => {
+    const r = trilinearInterpolate({
+      mass: 850,
+      pressureAltitude: 0,
+      temperature: 0,
+      cube: TOR_CUBE,
+    })
+    expect(r.distance).toBeCloseTo(210, 5)
+    expect(r.massClamped).toBe(false)
+    expect(r.altitudeClamped).toBe(false)
+    expect(r.temperatureClamped).toBe(false)
+  })
+
+  it('VEC-TRI-002: exact grid in mass/PA, temperature midpoint 0–20 °C at (850 kg, 0 ft, 10 °C)', () => {
+    // slice(0): 210; slice(20): 241.5 → lerp(210, 241.5, 0.5) = 225.75
+    const r = trilinearInterpolate({
+      mass: 850,
+      pressureAltitude: 0,
+      temperature: 10,
+      cube: TOR_CUBE,
+    })
+    expect(r.distance).toBeCloseTo(225.75, 5)
+    expect(r.temperatureClamped).toBe(false)
+  })
+
+  it('VEC-TRI-003: full trilinear at (925 kg, 1000 ft, 10 °C)', () => {
+    // slice(0)  bilinear(925,1000) = 265
+    // slice(20) bilinear(925,1000) = 304.75
+    // lerp(265, 304.75, 0.5) = 284.875
+    const r = trilinearInterpolate({
+      mass: 925,
+      pressureAltitude: 1000,
+      temperature: 10,
+      cube: TOR_CUBE,
+    })
+    expect(r.distance).toBeCloseTo(284.875, 5)
+    expect(r.massClamped).toBe(false)
+    expect(r.altitudeClamped).toBe(false)
+    expect(r.temperatureClamped).toBe(false)
+  })
+
+  it('VEC-TRI-004: temperature above max (1000 kg, 2000 ft, 50 °C) clamps to slice(40 °C)', () => {
+    // slice(40) bilinear(1000, 2000) = exact grid 422.5
+    const r = trilinearInterpolate({
+      mass: 1000,
+      pressureAltitude: 2000,
+      temperature: 50,
+      cube: TOR_CUBE,
+    })
+    expect(r.distance).toBeCloseTo(422.5, 5)
+    expect(r.temperatureClamped).toBe(true)
+    expect(r.massClamped).toBe(false)
+    expect(r.altitudeClamped).toBe(false)
+  })
+
+  it('VEC-TRI-005: temperature below min (1000 kg, 2000 ft, -30 °C) clamps to slice(-20 °C)', () => {
+    const r = trilinearInterpolate({
+      mass: 1000,
+      pressureAltitude: 2000,
+      temperature: -30,
+      cube: TOR_CUBE,
+    })
+    expect(r.distance).toBeCloseTo(276.25, 5)
+    expect(r.temperatureClamped).toBe(true)
+  })
+
+  it('VEC-TRI-006: all three axes clamped (1300 kg, 9000 ft, 100 °C) → upper-corner value', () => {
+    // upper-corner = values[3][3][2] = 760.5
+    const r = trilinearInterpolate({
+      mass: 1300,
+      pressureAltitude: 9000,
+      temperature: 100,
+      cube: TOR_CUBE,
+    })
+    expect(r.distance).toBeCloseTo(760.5, 5)
+    expect(r.massClamped).toBe(true)
+    expect(r.altitudeClamped).toBe(true)
+    expect(r.temperatureClamped).toBe(true)
+  })
+
+  it('VEC-TRI-007: degenerate temperature axis (single slice) — behaves like 2-D bilinear', () => {
+    const cube: PerformanceCube3D = {
+      massAxis: MASS_AXIS,
+      altitudeAxis: ALT_AXIS,
+      temperatureAxis: [15],
+      values: [
+        [
+          [210, 270, 340],
+          [255, 325, 410],
+          [305, 390, 490],
+          [365, 465, 585],
+        ],
+      ],
+    }
+    const r = trilinearInterpolate({
+      mass: 925,
+      pressureAltitude: 1000,
+      temperature: 999, // any temperature: degenerate axis ignores it after clamp
+      cube,
+    })
+    expect(r.distance).toBeCloseTo(265, 5)
+    expect(r.temperatureClamped).toBe(true)
+  })
+
+  it('VEC-TRI-008: rejects non-finite inputs', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: Number.NaN,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: TOR_CUBE,
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: Number.POSITIVE_INFINITY,
+        temperature: 0,
+        cube: TOR_CUBE,
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: Number.NaN,
+        cube: TOR_CUBE,
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+
+  it('VEC-TRI-009: rejects malformed cube — empty mass axis', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: { massAxis: [], altitudeAxis: [0], temperatureAxis: [0], values: [[[]]] },
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+
+  it('VEC-TRI-010: rejects malformed cube — empty altitude axis', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: { massAxis: [1000], altitudeAxis: [], temperatureAxis: [0], values: [[]] },
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+
+  it('VEC-TRI-011: rejects malformed cube — empty temperature axis', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: { massAxis: [1000], altitudeAxis: [0], temperatureAxis: [], values: [] },
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+
+  it('VEC-TRI-012: rejects malformed cube — wrong temperature dimension count', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: {
+          massAxis: [1000],
+          altitudeAxis: [0],
+          temperatureAxis: [0, 20],
+          values: [[[300]]], // only 1 slice but 2 temperatures
+        },
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+
+  it('VEC-TRI-013: rejects malformed cube — wrong altitude dimension per slice', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: {
+          massAxis: [1000],
+          altitudeAxis: [0, 2000],
+          temperatureAxis: [0],
+          values: [[[300]]], // 1 alt row but axis declares 2
+        },
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+
+  it('VEC-TRI-014: rejects malformed cube — wrong mass dimension per row', () => {
+    expect(() =>
+      trilinearInterpolate({
+        mass: 1000,
+        pressureAltitude: 0,
+        temperature: 0,
+        cube: {
+          massAxis: [850, 1157],
+          altitudeAxis: [0],
+          temperatureAxis: [0],
+          values: [[[300]]], // 1 col but axis declares 2
+        },
+      }),
+    ).toThrow('[PF-TRILINEAR]')
+  })
+})
+
+// ── pivotDataPointsToCube ────────────────────────────────────────────────────
+
+describe('pivotDataPointsToCube', () => {
+  function makeRegularGrid(): PerformanceDataPoint[] {
+    const out: PerformanceDataPoint[] = []
+    const masses = [850, 1000]
+    const alts = [0, 2000]
+    const temps = [0, 20]
+    let i = 0
+    for (const t of temps) {
+      for (const a of alts) {
+        for (const m of masses) {
+          out.push({ mass: m, pressureAltitude: a, temperature: t, distance: 100 + i })
+          i++
+        }
+      }
+    }
+    return out
+  }
+
+  it('pivots a regular 2×2×2 grid in any order', () => {
+    const points = makeRegularGrid()
+    // Shuffle deterministically
+    const shuffled = [
+      points[7]!,
+      points[2]!,
+      points[5]!,
+      points[0]!,
+      points[6]!,
+      points[1]!,
+      points[4]!,
+      points[3]!,
+    ]
+    const cube = pivotDataPointsToCube(shuffled)
+    expect(cube.massAxis).toEqual([850, 1000])
+    expect(cube.altitudeAxis).toEqual([0, 2000])
+    expect(cube.temperatureAxis).toEqual([0, 20])
+    // values[t][a][m] — original index = t*4 + a*2 + m
+    expect(cube.values[0]![0]![0]).toBe(100)
+    expect(cube.values[0]![0]![1]).toBe(101)
+    expect(cube.values[0]![1]![0]).toBe(102)
+    expect(cube.values[0]![1]![1]).toBe(103)
+    expect(cube.values[1]![0]![0]).toBe(104)
+    expect(cube.values[1]![0]![1]).toBe(105)
+    expect(cube.values[1]![1]![0]).toBe(106)
+    expect(cube.values[1]![1]![1]).toBe(107)
+  })
+
+  it('rejects an empty data-point list', () => {
+    expect(() => pivotDataPointsToCube([])).toThrow('[PF-PIVOT]')
+  })
+
+  it('rejects a data point with a non-finite numeric field', () => {
+    const points: PerformanceDataPoint[] = [
+      { mass: 850, pressureAltitude: 0, temperature: 0, distance: Number.NaN },
+    ]
+    expect(() => pivotDataPointsToCube(points)).toThrow('[PF-PIVOT]')
+  })
+
+  it('rejects an irregular grid (missing one combination)', () => {
+    const points = makeRegularGrid().slice(0, -1) // 7/8 points
+    expect(() => pivotDataPointsToCube(points)).toThrow('[PF-PIVOT]')
+  })
+
+  it('rejects an irregular grid that has the right count but wrong shape', () => {
+    // 2×2 mass + 2 alt + 2 temp would be 8 — substitute one (mass, alt, temp)
+    // with a brand-new mass value, producing 9 unique masses÷but only 8 points.
+    const points = makeRegularGrid()
+    points[0] = { ...points[0]!, mass: 999 } // introduces a 3rd mass; total points still 8
+    expect(() => pivotDataPointsToCube(points)).toThrow('[PF-PIVOT]')
+  })
+
+  it('rejects duplicate (mass, PA, temperature) entries', () => {
+    const points = makeRegularGrid()
+    points[7] = { ...points[0]! } // duplicate the first point
+    expect(() => pivotDataPointsToCube(points)).toThrow('[PF-PIVOT]')
+  })
+
+  it('accepts a 1×1×1 degenerate grid', () => {
+    const points: PerformanceDataPoint[] = [
+      { mass: 1000, pressureAltitude: 0, temperature: 15, distance: 300 },
+    ]
+    const cube = pivotDataPointsToCube(points)
+    expect(cube.values).toEqual([[[300]]])
+  })
+
+  it('round-trips through trilinearInterpolate at an exact grid point', () => {
+    const points = makeRegularGrid()
+    const cube = pivotDataPointsToCube(points)
+    const r = trilinearInterpolate({
+      mass: 1000,
+      pressureAltitude: 2000,
+      temperature: 20,
+      cube,
+    })
+    expect(r.distance).toBe(107)
+  })
+})
+
+// ── computePohDistances (Verified gate + facade) ─────────────────────────────
+
+/** Synthesize a 2×2×2 cube for one phase by scaling a base value. */
+function phaseDataPoints(base: number): PerformanceDataPoint[] {
+  const out: PerformanceDataPoint[] = []
+  const masses = [850, 1000]
+  const alts = [0, 2000]
+  const temps = [0, 20]
+  for (const t of temps) {
+    for (const a of alts) {
+      for (const m of masses) {
+        // Distance grows with mass, altitude, and temperature in a
+        // deterministic, monotone way — produces a unique value per cell.
+        const d = base * (m / 850) * (1 + a / 10000) * (1 + t / 200)
+        out.push({ mass: m, pressureAltitude: a, temperature: t, distance: d })
+      }
+    }
+  }
+  return out
+}
+
+function buildVerifiedProfile(): AircraftProfile {
+  const raw = {
+    id: '00000000-0000-4000-a000-000000000099',
+    ownerId: 'user-perf',
+    registration: 'D-TEST',
+    manufacturer: 'Test',
+    model: 'PF Trainer',
+    icaoTypeDesignator: 'C172',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Datum',
+    referenceDatumLocation: 'Station 0',
+    shareCode: null,
+    status: 'verified',
+    schemaVersion: 1,
+    powertrain: 'combustion',
+    passengerProfiles: [],
+    weighingReports: [
+      { bem: 700, emptyCg: 1.5, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+    ],
+    loadPoints: [
+      {
+        name: 'Pilot',
+        arm: 1.8,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 1157,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.4, mass: 600 },
+          { armOrMoment: 1.4, mass: 1157 },
+          { armOrMoment: 2.0, mass: 1157 },
+          { armOrMoment: 2.0, mass: 600 },
+        ],
+      },
+    ],
+    performanceProfiles: [
+      { flightPhase: 'TakeoffRoll', dataPoints: phaseDataPoints(210) },
+      { flightPhase: 'TakeoffDistance50ft', dataPoints: phaseDataPoints(340) },
+      { flightPhase: 'LandingRoll', dataPoints: phaseDataPoints(185) },
+      { flightPhase: 'LandingDistance50ft', dataPoints: phaseDataPoints(315) },
+    ],
+  }
+  return AircraftProfileSchema.parse(raw)
+}
+
+describe('computePohDistances — Verified-status gate', () => {
+  it('rejects a Draft profile with reason "profile_unverified"', () => {
+    const verified = buildVerifiedProfile()
+    const draft: AircraftProfile = { ...verified, status: 'draft' }
+    const result = computePohDistances(draft, conditions(925, 1000, 10))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('profile_unverified')
+    expect(result.message).toContain('Verified')
+  })
+
+  it('accepts a Verified profile and returns all four distances', () => {
+    const profile = buildVerifiedProfile()
+    const result = computePohDistances(profile, conditions(850, 0, 0))
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') return
+    expect(result.distances.takeoffRoll).toBeCloseTo(210, 5)
+    expect(result.distances.takeoffDistance50ft).toBeCloseTo(340, 5)
+    expect(result.distances.landingRoll).toBeCloseTo(185, 5)
+    expect(result.distances.landingDistance50ft).toBeCloseTo(315, 5)
+  })
+
+  it('returns per-phase clamping flags when inputs are outside the cube', () => {
+    const profile = buildVerifiedProfile()
+    const result = computePohDistances(profile, conditions(2000, 12000, 80))
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') return
+    for (const phase of [
+      'takeoffRoll',
+      'takeoffDistance50ft',
+      'landingRoll',
+      'landingDistance50ft',
+    ] as const) {
+      expect(result.clamping[phase].massClamped).toBe(true)
+      expect(result.clamping[phase].altitudeClamped).toBe(true)
+      expect(result.clamping[phase].temperatureClamped).toBe(true)
+    }
+  })
+
+  it('does not flag clamping when inputs fall inside every cube axis', () => {
+    const profile = buildVerifiedProfile()
+    const result = computePohDistances(profile, conditions(900, 500, 5))
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') return
+    expect(result.clamping.takeoffRoll.massClamped).toBe(false)
+    expect(result.clamping.takeoffRoll.altitudeClamped).toBe(false)
+    expect(result.clamping.takeoffRoll.temperatureClamped).toBe(false)
+  })
+})
+
+describe('computePohDistances — profile_incomplete', () => {
+  it('returns "profile_incomplete" when performanceProfiles is undefined', () => {
+    const profile = buildVerifiedProfile()
+    const incomplete: AircraftProfile = { ...profile, performanceProfiles: undefined }
+    const result = computePohDistances(incomplete, conditions(900, 0, 15))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('profile_incomplete')
+  })
+
+  it('returns "profile_incomplete" when a phase is missing', () => {
+    const profile = buildVerifiedProfile()
+    const incomplete: AircraftProfile = {
+      ...profile,
+      performanceProfiles: profile.performanceProfiles!.filter(
+        (p) => p.flightPhase !== 'LandingRoll',
+      ),
+    }
+    const result = computePohDistances(incomplete, conditions(900, 0, 15))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('profile_incomplete')
+    expect(result.message).toContain('LandingRoll')
+  })
+
+  it('returns "profile_incomplete" when a phase has zero data points', () => {
+    const profile = buildVerifiedProfile()
+    const incomplete: AircraftProfile = {
+      ...profile,
+      performanceProfiles: profile.performanceProfiles!.map((p) =>
+        p.flightPhase === 'TakeoffRoll' ? { ...p, dataPoints: [] } : p,
+      ),
+    }
+    const result = computePohDistances(incomplete, conditions(900, 0, 15))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('profile_incomplete')
+    expect(result.message).toContain('TakeoffRoll')
+  })
+})
+
+describe('computePohDistances — invalid input + grid', () => {
+  it('returns "invalid_input" for NaN mass', () => {
+    const result = computePohDistances(buildVerifiedProfile(), conditions(Number.NaN, 0, 0))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('invalid_input')
+  })
+
+  it('returns "invalid_input" for Infinity pressureAltitude', () => {
+    const result = computePohDistances(
+      buildVerifiedProfile(),
+      conditions(900, Number.POSITIVE_INFINITY, 0),
+    )
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('invalid_input')
+  })
+
+  it('returns "invalid_input" for NaN temperature', () => {
+    const result = computePohDistances(buildVerifiedProfile(), conditions(900, 0, Number.NaN))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('invalid_input')
+  })
+
+  it('returns "invalid_grid" when a phase has an irregular data-point set', () => {
+    const profile = buildVerifiedProfile()
+    const broken: AircraftProfile = {
+      ...profile,
+      performanceProfiles: profile.performanceProfiles!.map((p) =>
+        p.flightPhase === 'TakeoffRoll'
+          ? { ...p, dataPoints: p.dataPoints.slice(0, -1) } // drop one cell
+          : p,
+      ),
+    }
+    const result = computePohDistances(broken, conditions(900, 0, 10))
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') return
+    expect(result.reason).toBe('invalid_grid')
+  })
+})

--- a/frontend/src/core/logic/performance.poh-distance.ts
+++ b/frontend/src/core/logic/performance.poh-distance.ts
@@ -1,0 +1,517 @@
+/**
+ * POH-based take-off & landing distance computation.
+ * P1 Safety Core — pure TypeScript, no framework dependencies.
+ *
+ * Implements REQ-PF-001 (Distinct Performance Variables — TOR / TOD / LR / LD)
+ * and REQ-PF-002 (3-axis linear interpolation over Mass, Pressure Altitude,
+ * Temperature) of the aircraft's POH performance tables. Acts as the
+ * high-level facade for the v0.4.0 Performance Math Core: callers pass in an
+ * `AircraftProfile` plus environmental conditions, and receive either the
+ * four interpolated distances or a typed failure indicating *why* no result
+ * was produced.
+ *
+ * Architecture constraint (milestone v0.4.0):
+ *   "Performance interpolation must operate solely on pre-validated aircraft
+ *    profile data; profile must be in Verified status before performance
+ *    computation proceeds."
+ *
+ * This module is the single enforcement point of that contract — non-Verified
+ * profiles are rejected before any math runs. Extrapolation cap, safety-
+ * factor application, CAA SSL 07 estimation, and pilot-acknowledgement
+ * handling are explicitly OUT of scope here and are implemented in sibling
+ * modules so this facade can be composed with them.
+ *
+ * @see docs/architecture/performance-bilinear-interpolation-contract.md
+ */
+
+import { bilinearInterpolate, type PerformanceTable } from './performance.bilinear-interpolation'
+import type {
+  FlightPhase,
+  PerformanceDataPoint,
+  PerformanceProfile,
+} from '../domain/aircraft.types'
+import type { AircraftProfile } from '../adapters/aircraft.schema'
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-002@ (FROM: @REQ-PF-002@, @REQ-AD-008@, @REQ-AD-009@)
+/**
+ * A 3-D performance cube spanning (mass × pressure altitude × temperature).
+ *
+ * Axis ordering requirement (strictly ascending, no duplicates):
+ *   - massAxis        — kg
+ *   - altitudeAxis    — ft pressure altitude
+ *   - temperatureAxis — °C
+ *
+ * Value layout:
+ *   values[tempIdx][altIdx][massIdx] = distance (m)
+ *
+ * Each axis must contain at least one entry. A "degenerate" axis with a single
+ * entry is supported and reduces interpolation along that axis to a constant
+ * — useful for legacy POH tables that publish only one temperature column.
+ */
+export interface PerformanceCube3D {
+  /** Aircraft mass break-points, ascending, in kg. */
+  massAxis: number[]
+  /** Pressure altitude break-points, ascending, in ft. */
+  altitudeAxis: number[]
+  /** Temperature break-points, ascending, in °C. */
+  temperatureAxis: number[]
+  /**
+   * Distance values (m). Indexed as values[tempIdx][altIdx][massIdx].
+   * Dimensions: temperatureAxis.length × altitudeAxis.length × massAxis.length.
+   */
+  values: number[][][]
+}
+
+/** Input to {@link trilinearInterpolate}. */
+export interface TrilinearLookupInput {
+  /** Aircraft gross mass (kg). */
+  mass: number
+  /** Pressure altitude (ft). */
+  pressureAltitude: number
+  /** Outside air temperature (°C). */
+  temperature: number
+  /** The 3-D cube to interpolate over. */
+  cube: PerformanceCube3D
+}
+
+/** Result of {@link trilinearInterpolate}. */
+export interface TrilinearLookupResult {
+  /** Interpolated distance (m). */
+  distance: number
+  /** True when the requested mass was outside the cube range and was clamped. */
+  massClamped: boolean
+  /** True when the requested pressure altitude was outside the cube range and was clamped. */
+  altitudeClamped: boolean
+  /** True when the requested temperature was outside the cube range and was clamped. */
+  temperatureClamped: boolean
+}
+
+/** Environmental conditions at the interpolation point. */
+export interface PohDistanceConditions {
+  /** Aircraft gross mass (kg). */
+  mass: number
+  /** Pressure altitude (ft). */
+  pressureAltitude: number
+  /** Outside air temperature (°C). */
+  temperature: number
+}
+
+/** Per-phase clamping flags. */
+export interface PohDistanceClampingFlags {
+  massClamped: boolean
+  altitudeClamped: boolean
+  temperatureClamped: boolean
+}
+
+/** The four certified distances returned by {@link computePohDistances}. */
+export interface PohDistances {
+  /** Takeoff Roll (m). */
+  takeoffRoll: number
+  /** Takeoff Distance to 50 ft obstacle (m). */
+  takeoffDistance50ft: number
+  /** Landing Roll (m). */
+  landingRoll: number
+  /** Landing Distance from 50 ft obstacle (m). */
+  landingDistance50ft: number
+}
+
+/** Successful result of {@link computePohDistances}. */
+export interface PohDistanceSuccess {
+  status: 'success'
+  distances: PohDistances
+  /** Per-phase clamping flags — caller must surface any `true` flag to the pilot. */
+  clamping: {
+    takeoffRoll: PohDistanceClampingFlags
+    takeoffDistance50ft: PohDistanceClampingFlags
+    landingRoll: PohDistanceClampingFlags
+    landingDistance50ft: PohDistanceClampingFlags
+  }
+}
+
+/** Why no result was produced. Caller-visible — never escapes as an exception. */
+export type PohDistanceFailureReason =
+  | 'profile_unverified'
+  | 'profile_incomplete'
+  | 'invalid_grid'
+  | 'invalid_input'
+
+/** Typed failure surface — pure data, no exceptions. */
+export interface PohDistanceFailure {
+  status: 'failure'
+  reason: PohDistanceFailureReason
+  /** Free-text diagnostic for the pilot UI / logs. Never includes raw user data. */
+  message: string
+}
+
+export type PohDistanceResult = PohDistanceSuccess | PohDistanceFailure
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/** Linear interpolation between two scalars. */
+function lerp(a: number, b: number, t: number): number {
+  return a + t * (b - a)
+}
+
+/** Clamp `value` to the closed interval [min, max]. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Locate the surrounding lo/hi indices and interpolation fraction for `value`
+ * within a strictly-ascending `axis`. `value` MUST already be clamped to
+ * `[axis[0], axis[last]]`. Mirrors {@link findBounds} in the 2-D engine.
+ */
+function findBounds(axis: number[], value: number): { lo: number; hi: number; t: number } {
+  if (axis.length === 1) return { lo: 0, hi: 0, t: 0 }
+  for (let i = 0; i < axis.length - 1; i++) {
+    const lo = axis[i]!
+    const hi = axis[i + 1]!
+    if (value <= hi) {
+      const span = hi - lo
+      const t = span === 0 ? 0 : (value - lo) / span
+      return { lo: i, hi: i + 1, t }
+    }
+  }
+  const last = axis.length - 1
+  return { lo: last - 1, hi: last, t: 1 }
+}
+
+// ── Trilinear interpolation ──────────────────────────────────────────────────
+
+// @IMP-PF-CORE-003@ (FROM: @REQ-PF-002@)
+/**
+ * Trilinear interpolation over a 3-D performance cube — composes the existing
+ * 2-D {@link bilinearInterpolate} engine across the temperature axis.
+ *
+ * Boundary behaviour: each axis is clamped independently to its [min, max].
+ * The clamping flags allow the caller to surface "outside the certified
+ * envelope" notifications to the pilot per the milestone's H-007/H-012
+ * mitigation track (REQ-PF-010, REQ-PF-012 — handled by sibling modules).
+ *
+ * Algorithm:
+ *   1. Validate cube structure (axis lengths, value-array shape).
+ *   2. Clamp inputs to cube bounds; flag any clamping.
+ *   3. Resolve the temperature lo/hi slice indices and the t_temp fraction.
+ *   4. Run `bilinearInterpolate` on each slice (lo, hi).
+ *   5. Lerp the two resulting distances along the temperature axis.
+ */
+export function trilinearInterpolate(input: TrilinearLookupInput): TrilinearLookupResult {
+  const { mass, pressureAltitude, temperature, cube } = input
+
+  if (!Number.isFinite(mass) || !Number.isFinite(pressureAltitude) || !Number.isFinite(temperature)) {
+    throw new Error('[PF-TRILINEAR] mass, pressureAltitude, and temperature must be finite numbers.')
+  }
+
+  const { massAxis, altitudeAxis, temperatureAxis, values } = cube
+
+  if (massAxis.length < 1) {
+    throw new Error('[PF-TRILINEAR] massAxis must have at least 1 entry.')
+  }
+  if (altitudeAxis.length < 1) {
+    throw new Error('[PF-TRILINEAR] altitudeAxis must have at least 1 entry.')
+  }
+  if (temperatureAxis.length < 1) {
+    throw new Error('[PF-TRILINEAR] temperatureAxis must have at least 1 entry.')
+  }
+  if (values.length !== temperatureAxis.length) {
+    throw new Error(
+      `[PF-TRILINEAR] values temperature dimension (${values.length}) must match temperatureAxis length (${temperatureAxis.length}).`,
+    )
+  }
+  for (let t = 0; t < values.length; t++) {
+    const slice = values[t]!
+    if (slice.length !== altitudeAxis.length) {
+      throw new Error(
+        `[PF-TRILINEAR] values[${t}] altitude dimension (${slice.length}) must match altitudeAxis length (${altitudeAxis.length}).`,
+      )
+    }
+    for (let a = 0; a < slice.length; a++) {
+      if (slice[a]!.length !== massAxis.length) {
+        throw new Error(
+          `[PF-TRILINEAR] values[${t}][${a}] mass dimension (${slice[a]!.length}) must match massAxis length (${massAxis.length}).`,
+        )
+      }
+    }
+  }
+
+  const minTemp = temperatureAxis[0]!
+  const maxTemp = temperatureAxis[temperatureAxis.length - 1]!
+  const minMass = massAxis[0]!
+  const maxMass = massAxis[massAxis.length - 1]!
+  const minAlt = altitudeAxis[0]!
+  const maxAlt = altitudeAxis[altitudeAxis.length - 1]!
+
+  const massClamped = mass < minMass || mass > maxMass
+  const altitudeClamped = pressureAltitude < minAlt || pressureAltitude > maxAlt
+  const temperatureClamped = temperature < minTemp || temperature > maxTemp
+
+  const clampedMass = clamp(mass, minMass, maxMass)
+  const clampedAlt = clamp(pressureAltitude, minAlt, maxAlt)
+  const clampedTemp = clamp(temperature, minTemp, maxTemp)
+
+  const { lo: tLoIdx, hi: tHiIdx, t: tTemp } = findBounds(temperatureAxis, clampedTemp)
+
+  // Re-use the 2-D bilinear engine per temperature slice.
+  const tableLo: PerformanceTable = {
+    massAxis,
+    altitudeAxis,
+    values: values[tLoIdx]!,
+  }
+  const tableHi: PerformanceTable = {
+    massAxis,
+    altitudeAxis,
+    values: values[tHiIdx]!,
+  }
+
+  const dLo = bilinearInterpolate({
+    mass: clampedMass,
+    pressureAltitude: clampedAlt,
+    table: tableLo,
+  }).distance
+  const dHi = bilinearInterpolate({
+    mass: clampedMass,
+    pressureAltitude: clampedAlt,
+    table: tableHi,
+  }).distance
+
+  const distance = lerp(dLo, dHi, tTemp)
+
+  return { distance, massClamped, altitudeClamped, temperatureClamped }
+}
+
+// ── Data-point → cube pivot ──────────────────────────────────────────────────
+
+// @IMP-PF-CORE-004@ (FROM: @REQ-AD-009@, @REQ-PF-002@)
+/**
+ * Pivot a sparse list of {@link PerformanceDataPoint}s (the storage shape on
+ * `AircraftProfile`) into a dense {@link PerformanceCube3D} suitable for
+ * trilinear interpolation.
+ *
+ * Constraints (enforced via thrown `[PF-PIVOT]` errors — caller should catch
+ * via the {@link computePohDistances} facade which converts them to typed
+ * `failure` results):
+ *  - At least one data point per phase.
+ *  - All numeric fields finite (NaN/Infinity rejected).
+ *  - Every (mass, PA, temp) combination appears at most once (no duplicates).
+ *  - The data must form a *regular* 3-D grid: |dataPoints| ===
+ *    |unique mass| × |unique PA| × |unique temp|. Irregular layouts are
+ *    rejected here in v1 (a follow-up will lift this restriction with a
+ *    documented strategy for sparse POH data).
+ */
+export function pivotDataPointsToCube(dataPoints: readonly PerformanceDataPoint[]): PerformanceCube3D {
+  if (dataPoints.length === 0) {
+    throw new Error('[PF-PIVOT] dataPoints must contain at least one entry.')
+  }
+
+  for (let i = 0; i < dataPoints.length; i++) {
+    const dp = dataPoints[i]!
+    if (
+      !Number.isFinite(dp.distance) ||
+      !Number.isFinite(dp.mass) ||
+      !Number.isFinite(dp.pressureAltitude) ||
+      !Number.isFinite(dp.temperature)
+    ) {
+      throw new Error(`[PF-PIVOT] dataPoints[${i}] contains a non-finite numeric field.`)
+    }
+  }
+
+  const massSet = new Set<number>()
+  const altSet = new Set<number>()
+  const tempSet = new Set<number>()
+  for (const dp of dataPoints) {
+    massSet.add(dp.mass)
+    altSet.add(dp.pressureAltitude)
+    tempSet.add(dp.temperature)
+  }
+
+  const massAxis = [...massSet].sort((a, b) => a - b)
+  const altitudeAxis = [...altSet].sort((a, b) => a - b)
+  const temperatureAxis = [...tempSet].sort((a, b) => a - b)
+
+  const expectedCount = massAxis.length * altitudeAxis.length * temperatureAxis.length
+  if (dataPoints.length !== expectedCount) {
+    throw new Error(
+      `[PF-PIVOT] data points do not form a regular grid: expected ${expectedCount} (${temperatureAxis.length}×${altitudeAxis.length}×${massAxis.length}) but found ${dataPoints.length}.`,
+    )
+  }
+
+  const massIdx = new Map(massAxis.map((v, i) => [v, i]))
+  const altIdx = new Map(altitudeAxis.map((v, i) => [v, i]))
+  const tempIdx = new Map(temperatureAxis.map((v, i) => [v, i]))
+
+  // values[t][a][m] — NaN-fill so any missing cell is detectable after pivot.
+  const values: number[][][] = Array.from({ length: temperatureAxis.length }, () =>
+    Array.from({ length: altitudeAxis.length }, () =>
+      Array.from({ length: massAxis.length }, () => Number.NaN),
+    ),
+  )
+
+  for (const dp of dataPoints) {
+    const t = tempIdx.get(dp.temperature)!
+    const a = altIdx.get(dp.pressureAltitude)!
+    const m = massIdx.get(dp.mass)!
+    if (!Number.isNaN(values[t]![a]![m])) {
+      throw new Error(
+        `[PF-PIVOT] duplicate data point at (mass=${dp.mass}, pressureAltitude=${dp.pressureAltitude}, temperature=${dp.temperature}).`,
+      )
+    }
+    values[t]![a]![m] = dp.distance
+  }
+
+  // Defensive — a regular-count grid with no duplicates should be fully filled,
+  // but explicitly catch malformed sets where pivot somehow left holes.
+  for (let t = 0; t < values.length; t++) {
+    for (let a = 0; a < values[t]!.length; a++) {
+      for (let m = 0; m < values[t]![a]!.length; m++) {
+        if (Number.isNaN(values[t]![a]![m]!)) {
+          throw new Error(
+            `[PF-PIVOT] missing data point at (mass=${massAxis[m]}, pressureAltitude=${altitudeAxis[a]}, temperature=${temperatureAxis[t]}).`,
+          )
+        }
+      }
+    }
+  }
+
+  return { massAxis, altitudeAxis, temperatureAxis, values }
+}
+
+// ── High-level facade (Verified-only) ────────────────────────────────────────
+
+// @IMP-PF-CORE-005@ (FROM: @REQ-PF-001@, @REQ-PF-002@, @REQ-AC-005@)
+/**
+ * Compute the four certified POH distances (TOR, TOD, LR, LD) for the
+ * requested operating point.
+ *
+ * Preconditions enforced here (each yields a typed `failure`, never throws):
+ *  - `profile.status === 'verified'` — Draft profiles are rejected with
+ *    `profile_unverified`. This is the single architectural enforcement
+ *    point of the milestone constraint and the H-004 / H-011 mitigation
+ *    boundary.
+ *  - All four `performanceProfiles` entries (`TakeoffRoll`,
+ *    `TakeoffDistance50ft`, `LandingRoll`, `LandingDistance50ft`) must be
+ *    present with at least one data point each. Missing phases yield
+ *    `profile_incomplete` — CAA SSL 07 estimation (REQ-PF-005) covers the
+ *    "missing TOR↔TOD or LR↔LD" case in a sibling module and is composed by
+ *    P2 before invoking this facade.
+ *  - `conditions.{mass, pressureAltitude, temperature}` must all be finite —
+ *    a non-finite value yields `invalid_input`.
+ *  - Each phase's data points must form a regular 3-D grid (see
+ *    {@link pivotDataPointsToCube}). Anything else yields `invalid_grid`.
+ *
+ * The function is pure: identical inputs always produce identical outputs.
+ * It performs no I/O, never throws on valid call sites, and never returns
+ * NaN/Infinity distances for any input that survives validation.
+ */
+export function computePohDistances(
+  profile: AircraftProfile,
+  conditions: PohDistanceConditions,
+): PohDistanceResult {
+  if (profile.status !== 'verified') {
+    return {
+      status: 'failure',
+      reason: 'profile_unverified',
+      message:
+        'Performance computation requires a Verified aircraft profile (current status: ' +
+        profile.status +
+        ').',
+    }
+  }
+
+  if (
+    !Number.isFinite(conditions.mass) ||
+    !Number.isFinite(conditions.pressureAltitude) ||
+    !Number.isFinite(conditions.temperature)
+  ) {
+    return {
+      status: 'failure',
+      reason: 'invalid_input',
+      message: 'mass, pressureAltitude, and temperature must all be finite numbers.',
+    }
+  }
+
+  const profiles = profile.performanceProfiles ?? []
+  const byPhase = new Map<FlightPhase, PerformanceProfile>()
+  for (const pp of profiles) {
+    byPhase.set(pp.flightPhase, pp)
+  }
+
+  const requiredPhases: FlightPhase[] = [
+    'TakeoffRoll',
+    'TakeoffDistance50ft',
+    'LandingRoll',
+    'LandingDistance50ft',
+  ]
+  for (const phase of requiredPhases) {
+    const pp = byPhase.get(phase)
+    if (!pp || pp.dataPoints.length === 0) {
+      return {
+        status: 'failure',
+        reason: 'profile_incomplete',
+        message: `Performance profile for phase "${phase}" is missing or empty.`,
+      }
+    }
+  }
+
+  try {
+    const phaseResults: Record<FlightPhase, TrilinearLookupResult> = {
+      TakeoffRoll: trilinearInterpolate({
+        mass: conditions.mass,
+        pressureAltitude: conditions.pressureAltitude,
+        temperature: conditions.temperature,
+        cube: pivotDataPointsToCube(byPhase.get('TakeoffRoll')!.dataPoints),
+      }),
+      TakeoffDistance50ft: trilinearInterpolate({
+        mass: conditions.mass,
+        pressureAltitude: conditions.pressureAltitude,
+        temperature: conditions.temperature,
+        cube: pivotDataPointsToCube(byPhase.get('TakeoffDistance50ft')!.dataPoints),
+      }),
+      LandingRoll: trilinearInterpolate({
+        mass: conditions.mass,
+        pressureAltitude: conditions.pressureAltitude,
+        temperature: conditions.temperature,
+        cube: pivotDataPointsToCube(byPhase.get('LandingRoll')!.dataPoints),
+      }),
+      LandingDistance50ft: trilinearInterpolate({
+        mass: conditions.mass,
+        pressureAltitude: conditions.pressureAltitude,
+        temperature: conditions.temperature,
+        cube: pivotDataPointsToCube(byPhase.get('LandingDistance50ft')!.dataPoints),
+      }),
+    }
+
+    return {
+      status: 'success',
+      distances: {
+        takeoffRoll: phaseResults.TakeoffRoll.distance,
+        takeoffDistance50ft: phaseResults.TakeoffDistance50ft.distance,
+        landingRoll: phaseResults.LandingRoll.distance,
+        landingDistance50ft: phaseResults.LandingDistance50ft.distance,
+      },
+      clamping: {
+        takeoffRoll: extractClamping(phaseResults.TakeoffRoll),
+        takeoffDistance50ft: extractClamping(phaseResults.TakeoffDistance50ft),
+        landingRoll: extractClamping(phaseResults.LandingRoll),
+        landingDistance50ft: extractClamping(phaseResults.LandingDistance50ft),
+      },
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      status: 'failure',
+      reason: 'invalid_grid',
+      message,
+    }
+  }
+}
+
+function extractClamping(r: TrilinearLookupResult): PohDistanceClampingFlags {
+  return {
+    massClamped: r.massClamped,
+    altitudeClamped: r.altitudeClamped,
+    temperatureClamped: r.temperatureClamped,
+  }
+}

--- a/frontend/src/core/logic/profile-migrations.spec.ts
+++ b/frontend/src/core/logic/profile-migrations.spec.ts
@@ -318,3 +318,81 @@ describe('migrateProfileDocument — purity and determinism', () => {
     expect(p.registration).toBe('D-EBPN')
   })
 })
+
+// ─── M4 round-trip: performance + surface + OSF + wind limits ────────────────
+
+describe('migrateProfileDocument — M4 round-trip (REQ-AD-008/009/015/016/017)', () => {
+  // @UT-AC-CORE-103@ (FROM: @IMP-AC-CORE-003@)
+  // The performance-profile / surface-condition / OSF / wind-limit fields
+  // shipped together in the v0.4.0 (M4) schema bump. Each is optional on the
+  // Zod schema and therefore must survive the migration walker unchanged on
+  // both the "current pass-through" path and the "legacy v0 stamping" path —
+  // i.e. the walker treats them as opaque payload, never coerces them, never
+  // drops them.
+  const M4_FIELDS = {
+    performanceProfiles: [
+      {
+        flightPhase: 'TakeoffRoll' as const,
+        dataPoints: [
+          { distance: 210, mass: 850, pressureAltitude: 0, temperature: 15 },
+          { distance: 340, mass: 1157, pressureAltitude: 0, temperature: 15 },
+        ],
+      },
+      {
+        flightPhase: 'TakeoffDistance50ft' as const,
+        dataPoints: [
+          { distance: 340, mass: 850, pressureAltitude: 0, temperature: 15 },
+          { distance: 545, mass: 1157, pressureAltitude: 0, temperature: 15 },
+        ],
+      },
+    ],
+    surfaceConditions: [
+      { name: 'Dry Paved', takeoffFactor: 1.0, landingFactor: 1.0 },
+      { name: 'Wet Grass', takeoffFactor: 1.3, landingFactor: 1.4 },
+    ],
+    safetyFactors: { takeoff: 1.25, landing: 1.43 },
+    windLimits: [
+      { component: 'MaxCrosswind' as const, value: 15, classification: 'Demonstrated' as const },
+      { component: 'MaxTailwind' as const, value: 10, classification: 'Limit' as const },
+    ],
+  }
+
+  it('preserves performance/surface/OSF/wind-limit payloads on a current-version document', () => {
+    const result = migrateProfileDocument(buildV1Document(M4_FIELDS))
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    const p: AircraftProfile = result.profile
+    expect(p.performanceProfiles).toEqual(M4_FIELDS.performanceProfiles)
+    expect(p.surfaceConditions).toEqual(M4_FIELDS.surfaceConditions)
+    expect(p.safetyFactors).toEqual(M4_FIELDS.safetyFactors)
+    expect(p.windLimits).toEqual(M4_FIELDS.windLimits)
+  })
+
+  it('preserves the same payloads when the document is stamped from v0 to v1', () => {
+    const doc = buildV1Document(M4_FIELDS)
+    delete (doc as { schemaVersion?: number }).schemaVersion
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('migrated')
+    if (result.kind !== 'migrated') return
+    const p: AircraftProfile = result.profile
+    expect(p.schemaVersion).toBe(1)
+    expect(p.performanceProfiles).toEqual(M4_FIELDS.performanceProfiles)
+    expect(p.surfaceConditions).toEqual(M4_FIELDS.surfaceConditions)
+    expect(p.safetyFactors).toEqual(M4_FIELDS.safetyFactors)
+    expect(p.windLimits).toEqual(M4_FIELDS.windLimits)
+  })
+
+  it('rejects an M4 document that exceeds the 1000 data-point cap (REQ-AD-009)', () => {
+    const dataPoints = Array.from({ length: 1001 }, (_, i) => ({
+      distance: 100 + i,
+      mass: 850,
+      pressureAltitude: i,
+      temperature: 15,
+    }))
+    const doc = buildV1Document({
+      performanceProfiles: [{ flightPhase: 'TakeoffRoll', dataPoints }],
+    })
+    const result = migrateProfileDocument(doc)
+    expect(result.kind).toBe('corrupt')
+  })
+})

--- a/trace/implementation/pf.yaml
+++ b/trace/implementation/pf.yaml
@@ -7,3 +7,37 @@ PF Core — Bilinear Interpolation
       - DES-ARCH-006
     files:
       - frontend/src/core/logic/performance.bilinear-interpolation.ts
+
+PF Core — POH Distance (3-D Trilinear) Facade
+  IMP-PF-CORE-002
+    title: PerformanceCube3D — 3-D (mass × PA × temperature) POH cube type
+    req:
+      - REQ-PF-002
+      - REQ-AD-008
+      - REQ-AD-009
+    files:
+      - frontend/src/core/logic/performance.poh-distance.ts
+
+  IMP-PF-CORE-003
+    title: trilinearInterpolate — 3-axis linear interpolation over the POH cube
+    req:
+      - REQ-PF-002
+    files:
+      - frontend/src/core/logic/performance.poh-distance.ts
+
+  IMP-PF-CORE-004
+    title: pivotDataPointsToCube — sparse data-points → regular 3-D cube
+    req:
+      - REQ-AD-009
+      - REQ-PF-002
+    files:
+      - frontend/src/core/logic/performance.poh-distance.ts
+
+  IMP-PF-CORE-005
+    title: computePohDistances — Verified-only POH TOR/TOD/LR/LD facade
+    req:
+      - REQ-PF-001
+      - REQ-PF-002
+      - REQ-AC-005
+    files:
+      - frontend/src/core/logic/performance.poh-distance.ts

--- a/trace/integration_test/pf.yaml
+++ b/trace/integration_test/pf.yaml
@@ -1,0 +1,8 @@
+PF Core — POH Distance Facade (Integration)
+  IT-PF-CORE-001
+    title: raw doc → migrateProfileDocument → computePohDistances — Verified passes, Draft is blocked, legacy v0 is upgraded
+    impl:
+      - IMP-PF-CORE-005
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/core/logic/__tests__/performance.poh-distance.int.spec.ts

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -69,6 +69,13 @@ AC Core — Aircraft Schema M3 fields (Unit)
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
 
+  UT-AC-CORE-103
+    title: M4 round-trip — performanceProfiles/surfaceConditions/safetyFactors/windLimits survive migration walker
+    impl:
+      - IMP-AC-CORE-003
+    files:
+      - frontend/src/core/logic/profile-migrations.spec.ts
+
 AC Store — ICAO Registration Validator (Unit)
   UT-AC-STORE-001
     title: validates D-EBPN as valid ICAO registration

--- a/trace/unit_test/pf.yaml
+++ b/trace/unit_test/pf.yaml
@@ -278,3 +278,14 @@ PF Core — Bilinear Interpolation (Unit)
       - IMP-PF-CORE-001
     files:
       - frontend/src/core/logic/performance.bilinear-interpolation.spec.ts
+
+PF Core — POH Distance (Trilinear / Pivot / Verified Gate) (Unit)
+  UT-PF-CORE-041
+    title: trilinear + pivot + computePohDistances facade — full unit suite (verified gate, profile_incomplete, invalid_grid, invalid_input, clamping)
+    impl:
+      - IMP-PF-CORE-002
+      - IMP-PF-CORE-003
+      - IMP-PF-CORE-004
+      - IMP-PF-CORE-005
+    files:
+      - frontend/src/core/logic/performance.poh-distance.spec.ts


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Delivers the v0.4.0 Performance Math Core: POH-based TOR / TOD / LR / LD distance
computation over the three certified axes (mass × pressure altitude × temperature),
gated on a Verified aircraft profile.

- New P1 module `frontend/src/core/logic/performance.poh-distance.ts` composes
  the existing v0.3.0 2-D bilinear engine across a temperature axis (trilinear
  interpolation), pivots sparse `PerformanceDataPoint[]` into a regular 3-D cube,
  and exposes the high-level `computePohDistances(profile, conditions)` facade.
- The facade is the **single architectural enforcement point** of the milestone
  constraint "performance computation requires Verified profile data" — Draft
  profiles are rejected with a typed `profile_unverified` failure **before any
  math runs** (H-004 / H-011 mitigation). Every non-success path is returned as
  pure data; the function never throws on valid call sites.
- The schema work for performance profiles (up to 1000 data points), surface
  conditions, operational safety factors, and wind limits was already in place;
  this PR adds the M4 round-trip migration tests required by #307's DoD.
- Trace registry entries `IMP-PF-CORE-002..005`, `UT-PF-CORE-041`,
  `UT-AC-CORE-103`, `IT-PF-CORE-001` added in the same commit.
- Contract doc extended with §9 (3-axis extension + Verified-only facade).
- REQ-PF-001 and REQ-PF-002 marked **Implemented** in `docs/requirements/performance.md`.

### Related Issues

Closes #298 (Feature: POH-based take-off & landing distance calculation)
Closes #306 (Task: Bilinear interpolation core (P1) for TOR/TOD/LR/LD)
Closes #307 (Task: Performance-profile schema (Zod) + migration — points, surface factors, OSF, wind limits)
Closes #314 (Task: Verified-profile precondition guard for performance computation)

### Issue State Management (Post-Merge)

- [x] Merging to `develop`: every linked issue auto-closes via `Closes #`. Labels transition to `fixed` and the project column moves to *Done*. Verified DoD attestation for all four issues — every checkbox ticked, every `N/A` reasoned.

### Affected Items

- **Requirements Implemented/Affected:** `REQ-PF-001` (Distinct Performance Variables → Implemented), `REQ-PF-002` (Bilinear Interpolation over Mass/PA/Temperature → Implemented). Touches `REQ-AC-005` (Verified-status gate) and `REQ-AD-008/009/015/016/017` (round-trip preserved by the migration walker).

### Documentation Updates

- [x] **Requirements:** Updated ID(s): `REQ-PF-001`, `REQ-PF-002` in `docs/requirements/performance.md` (status `Approved` → `Implemented`).
- [x] **Architecture:** Updated ID(s): `DES-ARCH-006` in `docs/architecture/performance-bilinear-interpolation-contract.md` (new §9 — 3-axis extension, pivot contract, Verified-only facade, failure-reason surface).
- [x] **Risk Management:** `N/A` (Reason: this PR implements the H-004 mitigation that REQ-PF-002 already targets; no hazard register entry is added or revised).
- [x] **Journeys:** `N/A` (Reason: REQ-PF-002 is an internal-algorithm requirement — per `docs/testing/TESTING.md` §"Algorithm Exception" it is unit-test-only and does not require a UJ tag; user-observable behaviour is verified end-to-end via the sibling tickets that consume this facade — UI #311, extrapolation #299/308, safety factors #300/309).
- [x] **Code Docs:** API docs inside `performance.poh-distance.ts` (JSDoc on every exported symbol). `CHANGELOG.md` not touched (release-process owned, per CONTRIBUTING and the implement-issue skill).

### Safety Considerations

- [x] Checked Safety Traceability Matrix — H-004 → REQ-PF-002 → IMP-PF-CORE-001..005 → UT-PF-CORE-001..041 chain is intact; H-011 (verified-profile precondition) → REQ-AC-005 → IMP-PF-CORE-005 (gate) → UT-PF-CORE-041 + IT-PF-CORE-001.
- [x] No new hazards introduced — the trilinear engine is a strict superset of the certified 2-D bilinear engine; the Verified gate strictly narrows what reaches the math.
- [x] Existing mitigations preserved — the 40 canonical v0.3.0 bilinear test vectors continue to pass unchanged; `bilinearInterpolate` is reused without modification.
- [x] P1 isolation maintained — no `vue`, `pinia`, or `vue-router` imports in modified files; `pnpm --filter frontend test:p1` passes in pure-Node env (459 tests / 17 files); ESLint with the `[P1-ISOLATION]` rule passes; only allowed P1 deps (`zod`, other `src/core/`) are imported.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (feature branch `feature/issue-298`).
- [x] **Unit Tests:** Added/updated and passing locally — 33 new POH-distance unit cases + 3 M4 migration round-trip cases; full unit suite green (`pnpm test:unit` → 1175 tests / 61 files).
- [x] **Integration Tests:** Passing — 3 new POH-distance integration cases (raw doc → migrate → compute, draft blocked, legacy v0 upgrade); full integration suite green (`pnpm test:integration` → 43 tests / 5 files).
- [x] **Manual Testing:** `N/A (Reason: pure P1 math core with no UI surface in this PR — UI rendering of distances + clamping flags is owned by #311 (Performance module UI). The facade is verified by an integration test that exercises the same code path a UI consumer will use.)`
- [x] **DoD:** All Definition of Done items from the linked Feature #298 and Tasks #306, #307, #314 are met. Per-issue attestation:
  - **#298:** all 5 boxes ticked — engine returns all four distances ✓ • canonical v0.3.0 vectors still pass 100% ✓ • Verified-only gate enforced ✓ • trace registry entries added same commit ✓ • P1 coverage 99.06% lines / 97.39% branches / 100% functions (≥90%) ✓
  - **#306:** all 5 boxes ticked — implementation complete ✓ • canonical v0.3.0 vectors pass 100% ✓ • P1 coverage ≥ 90% ✓ • lint/oxlint/markdownlint pass ✓ • side effects checked (full unit + integration + p1 + build all green) ✓
  - **#307:** all 5 boxes ticked — schema fields (`performanceProfiles`, `surfaceConditions`, `safetyFactors`, `windLimits`) already in `AircraftProfileSchema` and exercised by `aircraft.schema.spec.ts` ✓ • 1000-point cap accepts 1000 / rejects 1001 ✓ • migration round-trip test added (`migrateProfileDocument — M4 round-trip` describe block in `profile-migrations.spec.ts`) ✓ • lint passes ✓ • side effects checked ✓
  - **#314:** all 5 boxes ticked — Verified gate implemented in `computePohDistances` ✓ • unit test rejects Draft profile (`profile_unverified`) ✓ • integration test blocks Draft profile through the full migrate→compute path ✓ • lint passes ✓ • side effects checked ✓
- [x] **Review:** Self-review performed — typed failure surface (no exceptions escape on valid call sites), clamping flags returned per phase, pure deterministic math, exhaustive edge-case coverage (degenerate axes, malformed cubes, NaN/Infinity inputs, duplicate / irregular grid).
- [x] **ADR:** No new ADR required. The trilinear extension is a pure composition of the existing bilinear engine documented in `performance-bilinear-interpolation-contract.md`; this PR extends that contract with §9 rather than introducing a new architectural decision. The P1 isolation contract (ADR-314) is honoured unchanged.
