### PR TITLE
feat: [Task]: ADR — privacy implications of remote version.json fetch (#274)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,7 +8,7 @@
 
 ## 1. Overview
 
-AeroDash is an offline-first, client-side single-page application (SPA) for flight preparation. It runs entirely in the user's browser. **No personal, aircraft, or session data is transmitted to any server, backend, or third-party service.** There is no telemetry, analytics, tracking, advertising, or remote logging. The application makes exactly **one** first-party network request — an online safety-version check (`GET /version.json`) described in [§7](#7-network-activity-version-safety-check) — which carries no personal data and exists only as a safety "kill switch" (REQ-SYS-006 / H-019).
+AeroDash is an offline-first, client-side single-page application (SPA) for flight preparation. It runs entirely in the user's browser. **No personal, aircraft, or session data is transmitted to any server, backend, or third-party service.** There is no telemetry, analytics, tracking, advertising, or remote logging. Beyond loading and updating the app itself (same-origin requests for the app shell and the service-worker update lifecycle), the application makes exactly **one** application-level network request — an online safety-version check (`GET /version.json`) described in [§7](#7-network-activity-version-safety-check) — which carries no personal data and exists only as a safety "kill switch" (REQ-SYS-006 / H-019).
 
 ## 2. Data Collected
 
@@ -199,8 +199,9 @@ The following mechanism remains **planned but not yet implemented**:
 
 AeroDash is offline-first and issues **no** network requests while offline.
 When the application starts — or regains connectivity — **while online**, it
-makes exactly **one** first-party request: an HTTP `GET` for `/version.json`
-served from the **same origin** as the app. This is the *minimum safe version*
+makes exactly **one** application-level request beyond loading and updating the
+app itself: an HTTP `GET` for `/version.json` served from the **same origin** as
+the app. This is the *minimum safe version*
 check that satisfies REQ-SYS-006 and mitigates hazard H-019: it lets a
 safety-critical defect discovered after release block an unsafe build (a remote
 "kill switch"). The full privacy analysis is recorded in
@@ -211,10 +212,12 @@ safety-critical defect discovered after release block an unsafe build (a remote
   headers, no query string, and no device, install, or user identifier. No
   aircraft, fleet, or session data is included.
 - **What is nonetheless observable:** as with any HTTPS request, the server can
-  see your **IP address** and the browser's default **User-Agent**, plus the
-  timing of the request (roughly, when you opened the app online). For a
-  self-hosted or single-origin deployment this is the same origin that already
-  served you the app, so the check introduces no third party.
+  see your **IP address**, the browser's default **User-Agent**, and — unless the
+  deployment sets `Referrer-Policy: no-referrer` at the network edge — a
+  same-origin **`Referer`** (the in-app page URL you were on), plus the timing of
+  the request (roughly, when you opened the app online). For a self-hosted or
+  single-origin deployment this is the same origin that already served you the
+  app, so the check introduces no third party.
 - **When it fires:** only when the device reports it is online — on app start
   and on reconnect. It is best-effort; any failure is ignored and the app keeps
   the last known safe-version floor.
@@ -228,8 +231,9 @@ safety-critical defect discovered after release block an unsafe build (a remote
 ## 8. Third-Party Dependencies
 
 - No third-party analytics, advertising, or tracking libraries are included.
-- The only network request the app makes is the first-party, same-origin
-  version-safety check described in §7; no third-party service is contacted.
+- Beyond loading and updating the app itself, the only network request the app
+  makes is the first-party, same-origin version-safety check described in §7; no
+  third-party service is contacted.
 - Runtime dependencies are limited to Vue.js, Pinia, Vue Router, and Zod.
 - Dependency security is monitored via Dependabot and `pnpm audit` in CI.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -212,12 +212,12 @@ safety-critical defect discovered after release block an unsafe build (a remote
   headers, no query string, and no device, install, or user identifier. No
   aircraft, fleet, or session data is included.
 - **What is nonetheless observable:** as with any HTTPS request, the server can
-  see your **IP address**, the browser's default **User-Agent**, and — unless the
-  deployment sets `Referrer-Policy: no-referrer` at the network edge — a
-  same-origin **`Referer`** (the in-app page URL you were on), plus the timing of
-  the request (roughly, when you opened the app online). For a self-hosted or
-  single-origin deployment this is the same origin that already served you the
-  app, so the check introduces no third party.
+  see your **IP address**, the browser's default **User-Agent**, and — unless a
+  `no-referrer` policy is applied (planned; see issue #377) — a same-origin
+  **`Referer`** (the in-app page URL you were on), plus the timing of the request
+  (roughly, when you opened the app online). For a self-hosted or single-origin
+  deployment this is the same origin that already served you the app, so the
+  check introduces no third party.
 - **When it fires:** only when the device reports it is online — on app start
   and on reconnect. It is best-effort; any failure is ignored and the app keeps
   the last known safe-version floor.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy & Data Protection
 
-- version: 1.3
+- version: 1.4
 - date: 2026-05-28
 - status: active
 
@@ -8,7 +8,7 @@
 
 ## 1. Overview
 
-AeroDash is an offline-first, client-side single-page application (SPA) for flight preparation. It runs entirely in the user's browser. **No data is transmitted to any server, backend, or third-party service.** There is no telemetry, analytics, tracking, or remote logging.
+AeroDash is an offline-first, client-side single-page application (SPA) for flight preparation. It runs entirely in the user's browser. **No personal, aircraft, or session data is transmitted to any server, backend, or third-party service.** There is no telemetry, analytics, tracking, advertising, or remote logging. The application makes exactly **one** first-party network request — an online safety-version check (`GET /version.json`) described in [§7](#7-network-activity-version-safety-check) — which carries no personal data and exists only as a safety "kill switch" (REQ-SYS-006 / H-019).
 
 ## 2. Data Collected
 
@@ -195,19 +195,53 @@ The following mechanism remains **planned but not yet implemented**:
   import works today via the existing Fleet import card). Tracked alongside
   Milestone #7 cloud-sync onboarding.
 
-## 7. Third-Party Dependencies
+## 7. Network Activity (Version-Safety Check)
+
+AeroDash is offline-first and issues **no** network requests while offline.
+When the application starts — or regains connectivity — **while online**, it
+makes exactly **one** first-party request: an HTTP `GET` for `/version.json`
+served from the **same origin** as the app. This is the *minimum safe version*
+check that satisfies REQ-SYS-006 and mitigates hazard H-019: it lets a
+safety-critical defect discovered after release block an unsafe build (a remote
+"kill switch"). The full privacy analysis is recorded in
+[ADR-011](docs/architecture/adr/011-min-safe-version-fetch-privacy.md).
+
+- **What the request sends:** nothing AeroDash adds. It carries no cookies or
+  credentials (`credentials: 'omit'`), no request body, no AeroDash-set
+  headers, no query string, and no device, install, or user identifier. No
+  aircraft, fleet, or session data is included.
+- **What is nonetheless observable:** as with any HTTPS request, the server can
+  see your **IP address** and the browser's default **User-Agent**, plus the
+  timing of the request (roughly, when you opened the app online). For a
+  self-hosted or single-origin deployment this is the same origin that already
+  served you the app, so the check introduces no third party.
+- **When it fires:** only when the device reports it is online — on app start
+  and on reconnect. It is best-effort; any failure is ignored and the app keeps
+  the last known safe-version floor.
+- **Opt-out:** because this check is a *safety control*, there is intentionally
+  no in-app switch to disable it — turning it off would let a known-unsafe build
+  keep running (hazard H-019). If you need zero outbound requests you can
+  operate the app fully offline (no request is made), block the endpoint at the
+  network layer, or self-host the origin so the metadata never leaves your own
+  infrastructure.
+
+## 8. Third-Party Dependencies
 
 - No third-party analytics, advertising, or tracking libraries are included.
+- The only network request the app makes is the first-party, same-origin
+  version-safety check described in §7; no third-party service is contacted.
 - Runtime dependencies are limited to Vue.js, Pinia, Vue Router, and Zod.
 - Dependency security is monitored via Dependabot and `pnpm audit` in CI.
 
-## 8. Security Measures
+## 9. Security Measures
 
-- Offline-first architecture eliminates network-based attack vectors.
+- Offline-first architecture minimises network-based attack surface; the sole
+  outbound request (§7) is a same-origin, credential-less `GET` that never
+  reads more than a small bounded response body.
 - Input validation via Zod schemas at the adapter boundary.
 - No credentials, tokens, or secrets are stored in the application.
 - CI pipeline enforces frozen lockfiles and dependency auditing.
 
-## 9. Contact
+## 10. Contact
 
 For privacy-related questions, open an issue in the project repository with the label `privacy`.

--- a/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+++ b/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
@@ -46,7 +46,8 @@ nonetheless observe is the unavoidable metadata of any HTTPS request:
 | Client IP address | IP/TLS layer | **Yes** | Inherent to any TCP/TLS connection; cannot be suppressed client-side. Coarse-grained location / ISP inference only. |
 | `User-Agent` header | Browser default | **Yes** | Browser/engine/OS family. Not set by AeroDash; the browser attaches it. |
 | TLS fingerprint, request timing & frequency | Transport / scheduling | **Yes** | Reveals *that* and *roughly when* the app was opened online (cold start / reconnect). |
-| `Referer`, cookies, auth | Browser / app | **No** | `credentials: 'omit'` sends no cookies/credentials. No `Authorization` header. |
+| `Referer` header (same-origin) | Browser default referrer policy | **Yes, by default** | `credentials: 'omit'` does **not** govern `Referer` — referrer policy does. The fetch sets no `referrerPolicy` and the app ships no `<meta name="referrer">`, so under the browser default (`strict-origin-when-cross-origin`) a **same-origin** `GET` sends a `Referer` carrying the document's full URL — including the in-app route, since the router runs in HTML5 history mode. It is suppressed only if the **deploy edge** sets `Referrer-Policy: no-referrer` (recommended in `frontend/index.html`, but unenforceable from a `<meta>` tag). Being same-origin, the route is disclosed only to the origin that already served the app. |
+| Cookies, credentials, `Authorization` | Browser / app | **No** | `credentials: 'omit'` sends no cookies/credentials; no `Authorization` header is set. |
 | Request body | App | **No** | The request carries no body. |
 | Custom / identifying headers | App | **No** | AeroDash adds none. No device id, install id, or query parameter is appended. |
 | Aircraft / fleet / session data | App | **No** | No persisted or in-memory personal data is part of the request. |
@@ -64,6 +65,10 @@ party and no **third-party** processor.
 - On the browser `online` event, via `attachConnectivityRefresh()`.
 - **Gated on `navigator.onLine === true`** — it never fires while offline,
   which is the dominant cockpit/remote-airfield case.
+- **Suppressed in the fail-closed state** — when a structurally-broken build
+  raises the ephemeral `FAIL_CLOSED_MIN_SAFE_VERSION` sentinel, the refresh is
+  skipped entirely (`app-version.store.ts`). This only makes the fetch rarer; no
+  privacy claim depends on it.
 - Serialised by a single-flight latch, so a reconnect racing a cold start
   issues at most one in-flight request.
 
@@ -139,10 +144,11 @@ which this ADR makes binding:
 
 ### Negative
 
-- The app is no longer "zero network requests" when online; the IP/User-Agent of
-  an online cold start is observable by the origin server. This is accepted as
-  the minimum metadata intrinsic to any HTTPS request and is bounded to the
-  same origin that already served the app.
+- The app is no longer "zero network requests" when online; the IP, User-Agent,
+  and — unless the deploy edge sets `Referrer-Policy: no-referrer` — a same-origin
+  `Referer` (the in-app route) of an online cold start are observable by the
+  origin server. This is accepted as the minimum metadata intrinsic to any HTTPS
+  request and is bounded to the same origin that already served the app.
 - Privacy-maximalist users who want *no* outbound request must take an external
   action (stay offline, block the endpoint, or self-host); there is no in-app
   switch, by design.

--- a/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+++ b/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
@@ -54,10 +54,13 @@ nonetheless observe is the unavoidable metadata of any HTTPS request:
 
 The endpoint is **same-origin** (`/version.json` is shipped in the PWA
 `public/` directory and served by the same origin that already delivered the
-application bundle and every other asset). For a self-hosted or single-origin
-deployment, the fetch therefore discloses metadata only to a server the user is
-*already* in contact with merely by loading the app — it introduces no **new**
-party and no **third-party** processor.
+application bundle and every other asset). This is enforced at runtime, not by
+convention alone: the Content-Security-Policy `connect-src 'self'`
+(`frontend/index.html`) makes a cross-origin `/version.json` fetch unreachable by
+construction, so the request cannot be redirected to a third-party origin. For a
+self-hosted or single-origin deployment, the fetch therefore discloses metadata
+only to a server the user is *already* in contact with merely by loading the
+app — it introduces no **new** party and no **third-party** processor.
 
 ### When the fetch fires
 

--- a/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+++ b/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
@@ -2,7 +2,7 @@
 
 <!-- @DES-ARCH-013@ (FROM: @REQ-SYS-006@) -->
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-05-28
 
 ## Context

--- a/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+++ b/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
@@ -1,0 +1,167 @@
+# ADR-011: Privacy Posture of the Remote `minSafeVersion` Fetch
+
+<!-- @DES-ARCH-013@ (FROM: @REQ-SYS-006@, @H-019@) -->
+
+- **Status:** Accepted
+- **Date:** 2026-05-28
+
+## Context
+
+REQ-SYS-006 (Safe Version Verification) mitigates H-019 — operating with
+outdated or erroneous calculation logic because of PWA caching latency — by
+acting as a remote "kill switch": when the application initialises **online**
+it verifies the running build against a minimum-safe-version floor and blocks
+execution if the build is below it.
+
+The build-time constant `__MIN_SAFE_VERSION__` is baked into each released
+bundle and cannot be raised without a re-deploy. To make the kill switch
+usable for a safety-critical defect discovered *after* release, issue #271
+added a best-effort online refresh: `app-version.remote.ts` issues
+`GET /version.json` on every online check, and the store enforces
+`max(buildTimeConstant, cachedValue, remoteValue)` (`app-version.store.ts`).
+
+The v0.3.0-alpha data-privacy release audit (2026-05-08) raised **DP-018**:
+for an *offline-first* PWA whose users reasonably expect zero network activity,
+issuing even a first-party HTTP request is an **unanticipated** behaviour that
+exposes request metadata — at minimum the client **IP address** and
+**User-Agent** — to whatever server hosts `/version.json`. This ADR records the
+privacy implications of that fetch (the data exposed, when it fires, and the
+opt-out posture) and the decision on how to make the behaviour honest, so the
+exposure is a documented, bounded architectural choice rather than an
+accidental side effect.
+
+This decision interacts with `PRIVACY.md`, whose §1 previously asserted a
+blanket "**No data is transmitted to any server**". That statement is true of
+all *stored* personal data (the fleet, the saved session) but is contradicted
+by the existence of the `/version.json` request itself, which must therefore be
+disclosed.
+
+### Data actually exposed by the fetch
+
+The request is a bare `GET` with no application payload. What a server can
+nonetheless observe is the unavoidable metadata of any HTTPS request:
+
+| Datum | Source | Exposed? | Notes |
+| :---- | :----- | :------- | :---- |
+| Client IP address | IP/TLS layer | **Yes** | Inherent to any TCP/TLS connection; cannot be suppressed client-side. Coarse-grained location / ISP inference only. |
+| `User-Agent` header | Browser default | **Yes** | Browser/engine/OS family. Not set by AeroDash; the browser attaches it. |
+| TLS fingerprint, request timing & frequency | Transport / scheduling | **Yes** | Reveals *that* and *roughly when* the app was opened online (cold start / reconnect). |
+| `Referer`, cookies, auth | Browser / app | **No** | `credentials: 'omit'` sends no cookies/credentials. No `Authorization` header. |
+| Request body | App | **No** | The request carries no body. |
+| Custom / identifying headers | App | **No** | AeroDash adds none. No device id, install id, or query parameter is appended. |
+| Aircraft / fleet / session data | App | **No** | No persisted or in-memory personal data is part of the request. |
+
+The endpoint is **same-origin** (`/version.json` is shipped in the PWA
+`public/` directory and served by the same origin that already delivered the
+application bundle and every other asset). For a self-hosted or single-origin
+deployment, the fetch therefore discloses metadata only to a server the user is
+*already* in contact with merely by loading the app — it introduces no **new**
+party and no **third-party** processor.
+
+### When the fetch fires
+
+- On mount, via `App.vue` → `checkMinSafeVersion()`.
+- On the browser `online` event, via `attachConnectivityRefresh()`.
+- **Gated on `navigator.onLine === true`** — it never fires while offline,
+  which is the dominant cockpit/remote-airfield case.
+- Serialised by a single-flight latch, so a reconnect racing a cold start
+  issues at most one in-flight request.
+
+It is **best-effort**: every failure mode (network down, non-2xx, oversized
+body, parse failure, timeout) returns `null` and the prior enforced floor is
+kept. A flaky or hostile endpoint can never *unblock* a kill-switched build.
+
+## Considered Options
+
+- **Option A — Drop the remote fetch (build-time + IndexedDB cache only):**
+  zero network activity, perfectly matching the "no transmission" promise. But
+  the build-time floor cannot be raised post-release without shipping a new
+  bundle, and a kill-switched older bundle resurrected from the Service Worker
+  cache would only learn of a newer floor it had previously cached — never one
+  published *after* it went offline. This guts the post-release usefulness of
+  the REQ-SYS-006 kill switch and weakens the H-019 mitigation.
+- **Option B — Keep the fetch, leave it undocumented (status quo at audit
+  time):** rejected. The metadata exposure is real and the privacy notice was
+  inaccurate; an undocumented network request in an offline-first tool is the
+  exact DP-018 finding.
+- **Option C — Keep the fetch, minimise it, document it, *and* add a runtime
+  opt-out toggle:** a user could disable the version check. Rejected as the
+  default posture: REQ-SYS-006 is a **safety control**. A pilot who disables it
+  silently re-creates H-019 (running known-unsafe calculation logic) — the
+  precise hazard the requirement exists to prevent. Trading a bounded,
+  same-origin metadata exposure for the ability to switch off a safety
+  kill-switch is the wrong default for a flight-prep tool. (A network-level or
+  self-hosting opt-out remains available to the user — see the Decision.)
+- **Option D — Keep the fetch, keep it minimal, document the residual exposure,
+  provide no in-app opt-out, and correct the privacy notice (chosen).**
+
+## Decision
+
+We adopt **Option D**. The remote `minSafeVersion` fetch is retained because it
+is integral to the REQ-SYS-006 / H-019 safety mitigation, subject to the
+following constraints, which the current implementation already satisfies and
+which this ADR makes binding:
+
+1. **Minimal request.** The fetch stays a credential-less (`credentials:
+   'omit'`), body-less `GET` to a **same-origin** endpoint, with **no**
+   AeroDash-set identifying headers, query parameters, cache-busting tokens, or
+   device/install identifiers. Any future change that adds an identifier, a
+   third-party origin, or a request body **requires a new ADR**.
+2. **Online-only, best-effort.** The fetch fires only when `navigator.onLine`
+   is true and never blocks or fails the app on error. Offline operation — the
+   dominant use case — produces no network activity at all.
+3. **No in-app opt-out.** Because disabling the check would re-introduce H-019,
+   there is intentionally no toggle to suppress it. Users who require zero
+   outbound requests retain two avenues that do **not** disable the safety
+   control: operate the app offline (no fetch is issued), or block the request
+   at the network layer / self-host the origin so the metadata never leaves
+   their own infrastructure.
+4. **Honest disclosure.** `PRIVACY.md` must accurately describe this single
+   first-party request — what metadata it exposes, when it fires, why it
+   exists, and that there is no in-app opt-out. The blanket "no data is
+   transmitted" claim is corrected to scope it to *stored personal data* (which
+   genuinely never leaves the device) and to disclose the version-safety
+   request explicitly. This ADR is recorded in the same change as that
+   correction.
+
+## Consequences
+
+### Positive
+
+- The REQ-SYS-006 kill switch remains usable for post-release safety defects;
+  the H-019 mitigation is preserved in full.
+- The privacy exposure is now a **documented, bounded** architectural decision:
+  same-origin only, no cookies, no body, no identifiers, online-only.
+- `PRIVACY.md` becomes truthful, closing DP-018: users are told about the one
+  request the app makes and how to avoid it without disabling a safety control.
+- A guardrail is established — adding any identifier, third-party origin, or
+  payload to the request now requires a fresh ADR.
+
+### Negative
+
+- The app is no longer "zero network requests" when online; the IP/User-Agent of
+  an online cold start is observable by the origin server. This is accepted as
+  the minimum metadata intrinsic to any HTTPS request and is bounded to the
+  same origin that already served the app.
+- Privacy-maximalist users who want *no* outbound request must take an external
+  action (stay offline, block the endpoint, or self-host); there is no in-app
+  switch, by design.
+
+## Compliance
+
+- **REQ-SYS-006 (Safe Version Verification)** and **H-019 (PWA caching latency
+  errors)** are preserved; this ADR is the Design Reference linked from
+  REQ-SYS-006.
+- **GDPR.** The request transmits no personal data as defined by the app's data
+  inventory (no fleet, session, account, or identifier data — see `PRIVACY.md`
+  §2). The IP address is processed only transiently at the transport layer to
+  serve a request the user initiated by opening the app online, on the
+  Art. 6(1)(f) legitimate-interest basis of keeping safety-critical computation
+  logic current (H-019); no server-side retention or profiling is performed or
+  intended by AeroDash. Where the household-activity exemption (Art. 2(2)(c))
+  applies to a private pilot, this processing falls outside GDPR scope, as noted
+  in `PRIVACY.md` §3.1.
+- **Transparency (GDPR Art. 13/5(1)(a)).** Satisfied by the `PRIVACY.md`
+  correction mandated in the Decision (§ Third-Party Dependencies / Security
+  Measures and the storage overview).
+- Closes data-privacy audit finding **DP-018** (v0.3.0-alpha, 2026-05-08).

--- a/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+++ b/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
@@ -46,7 +46,7 @@ nonetheless observe is the unavoidable metadata of any HTTPS request:
 | Client IP address | IP/TLS layer | **Yes** | Inherent to any TCP/TLS connection; cannot be suppressed client-side. Coarse-grained location / ISP inference only. |
 | `User-Agent` header | Browser default | **Yes** | Browser/engine/OS family. Not set by AeroDash; the browser attaches it. |
 | TLS fingerprint, request timing & frequency | Transport / scheduling | **Yes** | Reveals *that* and *roughly when* the app was opened online (cold start / reconnect). |
-| `Referer` header (same-origin) | Browser default referrer policy | **Yes, by default** | `credentials: 'omit'` does **not** govern `Referer` — referrer policy does. The fetch sets no `referrerPolicy` and the app ships no `<meta name="referrer">`, so under the browser default (`strict-origin-when-cross-origin`) a **same-origin** `GET` sends a `Referer` carrying the document's full URL — including the in-app route, since the router runs in HTML5 history mode. It is suppressed only if the **deploy edge** sets `Referrer-Policy: no-referrer` (recommended in `frontend/index.html`, but unenforceable from a `<meta>` tag). Being same-origin, the route is disclosed only to the origin that already served the app. |
+| `Referer` header (same-origin) | Browser default referrer policy | **Yes, by default** | `credentials: 'omit'` does **not** govern `Referer` — referrer policy does. The fetch sets no `referrerPolicy` and the app ships no `<meta name="referrer">`, so under the browser default (`strict-origin-when-cross-origin`) a **same-origin** `GET` sends a `Referer` carrying the document's full URL — including the in-app route, since the router runs in HTML5 history mode. It can be suppressed by any of three levers AeroDash currently declines: a per-request `referrerPolicy: 'no-referrer'` on the fetch, a `<meta name="referrer" content="no-referrer">` in `frontend/index.html`, or a deploy-edge `Referrer-Policy: no-referrer` header (the HTTP-header form is the one that "cannot be set from a `<meta>` tag", per the `index.html` note). The two in-app levers are tracked in #377. Being same-origin, the route is disclosed only to the origin that already served the app. |
 | Cookies, credentials, `Authorization` | Browser / app | **No** | `credentials: 'omit'` sends no cookies/credentials; no `Authorization` header is set. |
 | Request body | App | **No** | The request carries no body. |
 | Custom / identifying headers | App | **No** | AeroDash adds none. No device id, install id, or query parameter is appended. |
@@ -55,12 +55,15 @@ nonetheless observe is the unavoidable metadata of any HTTPS request:
 The endpoint is **same-origin** (`/version.json` is shipped in the PWA
 `public/` directory and served by the same origin that already delivered the
 application bundle and every other asset). This is enforced at runtime, not by
-convention alone: the Content-Security-Policy `connect-src 'self'`
-(`frontend/index.html`) makes a cross-origin `/version.json` fetch unreachable by
-construction, so the request cannot be redirected to a third-party origin. For a
-self-hosted or single-origin deployment, the fetch therefore discloses metadata
-only to a server the user is *already* in contact with merely by loading the
-app — it introduces no **new** party and no **third-party** processor.
+convention alone: for the **shipped artifact**, the default endpoint is the
+same-origin relative path and the `<meta>` Content-Security-Policy `connect-src
+'self'` (`frontend/index.html`) blocks any cross-origin `connect-src`, so the
+fetch cannot reach a third-party origin. (Both the endpoint default and the
+`<meta>` CSP are overridable by a self-hosting operator, but the build ships
+closed.) For a self-hosted or single-origin deployment, the fetch therefore
+discloses metadata only to a server the user is *already* in contact with merely
+by loading the app — it introduces no **new** party and no **third-party**
+processor.
 
 ### When the fetch fires
 
@@ -131,6 +134,12 @@ which this ADR makes binding:
    genuinely never leaves the device) and to disclose the version-safety
    request explicitly. This ADR is recorded in the same change as that
    correction.
+5. **Maintenance guardrail.** The "exactly one application-level request" claim
+   in `PRIVACY.md` §1/§7 is only true for the current module set. Any **new**
+   outbound network request introduced by a future module (e.g. `weather`,
+   `sync`) **must**, in the same change, update `PRIVACY.md` §7 and re-verify the
+   §1 request count — so the notice cannot silently regress to the DP-018 state
+   this ADR fixes.
 
 ## Consequences
 
@@ -148,8 +157,9 @@ which this ADR makes binding:
 ### Negative
 
 - The app is no longer "zero network requests" when online; the IP, User-Agent,
-  and — unless the deploy edge sets `Referrer-Policy: no-referrer` — a same-origin
-  `Referer` (the in-app route) of an online cold start are observable by the
+  and — unless a `no-referrer` policy is applied (see the exposure table; the
+  two in-app levers are tracked in #377) — a same-origin `Referer` (the in-app
+  route) of an online cold start are observable by the
   origin server. This is accepted as the minimum metadata intrinsic to any HTTPS
   request and is bounded to the same origin that already served the app.
 - Privacy-maximalist users who want *no* outbound request must take an external

--- a/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+++ b/docs/architecture/adr/011-min-safe-version-fetch-privacy.md
@@ -1,6 +1,6 @@
 # ADR-011: Privacy Posture of the Remote `minSafeVersion` Fetch
 
-<!-- @DES-ARCH-013@ (FROM: @REQ-SYS-006@, @H-019@) -->
+<!-- @DES-ARCH-013@ (FROM: @REQ-SYS-006@) -->
 
 - **Status:** Accepted
 - **Date:** 2026-05-28
@@ -162,6 +162,8 @@ which this ADR makes binding:
   applies to a private pilot, this processing falls outside GDPR scope, as noted
   in `PRIVACY.md` §3.1.
 - **Transparency (GDPR Art. 13/5(1)(a)).** Satisfied by the `PRIVACY.md`
-  correction mandated in the Decision (§ Third-Party Dependencies / Security
-  Measures and the storage overview).
+  correction mandated in the Decision — primarily the new **§7 Network
+  Activity**, which discloses the request directly, supported by the scoped §1
+  overview and the §8 (Third-Party Dependencies) / §9 (Security Measures)
+  cross-references.
 - Closes data-privacy audit finding **DP-018** (v0.3.0-alpha, 2026-05-08).

--- a/docs/requirements/system.md
+++ b/docs/requirements/system.md
@@ -64,7 +64,7 @@ This document defines the system behavior using the **EARS** (Easy Approach to R
 **Rationale:** "Kill Switch" for critical bugs (e.g., calculation errors discovered post-release).
 **Priority:** P1
 **Status:** Implemented
-**Design Reference:** n/a
+**Design Reference:** [ADR-011: Privacy Posture of the Remote `minSafeVersion` Fetch](../architecture/adr/011-min-safe-version-fetch-privacy.md)
 
 <!-- @REQ-SYS-007@ -->
 

--- a/frontend/src/modules/aircraft/__tests__/data-rights.service.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/data-rights.service.int.spec.ts
@@ -5,7 +5,7 @@
  * @see frontend/src/modules/aircraft/services/data-rights.service.ts
  */
 
-// @IT-SYS-STORE-001@ (FROM: @IMP-SYS-STORE-013@, @REQ-SYS-014@, @REQ-SYS-015@)
+// @IT-SYS-STORE-002@ (FROM: @IMP-SYS-STORE-021@, @REQ-SYS-014@, @REQ-SYS-015@)
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'

--- a/frontend/src/modules/aircraft/__tests__/data-rights.service.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/data-rights.service.spec.ts
@@ -6,7 +6,7 @@
  * @see frontend/src/modules/aircraft/services/data-rights.service.ts
  */
 
-// @UT-SYS-STORE-046@ (FROM: @IMP-SYS-STORE-013@)
+// @UT-SYS-STORE-097@ (FROM: @IMP-SYS-STORE-021@)
 
 import { describe, it, expect } from 'vitest'
 import {

--- a/frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/profile.import.spec.ts
@@ -220,7 +220,7 @@ describe('exportProfileToJson', () => {
     expect((parsed.profile as Record<string, unknown>).registration).toBe('D-EBPN')
   })
 
-  // @UT-AC-STORE-124@ (FROM: @IMP-AC-STORE-010@)
+  // @UT-AC-STORE-128@ (FROM: @IMP-AC-STORE-010@)
   it('excludes operating-cost fields from the default export (DP-008/DP-009)', () => {
     const data = {
       ...createValidExportedProfile(),

--- a/frontend/src/modules/aircraft/services/data-rights.service.ts
+++ b/frontend/src/modules/aircraft/services/data-rights.service.ts
@@ -17,7 +17,7 @@
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 import { fleetRepository, DB_NAME, type MigrationDiagnostic } from './fleet.repository'
 
-// @IMP-SYS-STORE-013@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@, @DES-ARCH-011@, @DES-ARCH-012@)
+// @IMP-SYS-STORE-021@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@, @DES-ARCH-011@, @DES-ARCH-012@)
 
 // ─── Storage keys cleared by Delete-All-Data ──────────────────────────────
 // These three live keys cover all known AeroDash persistence at v0.4.0-alpha:

--- a/frontend/src/stores/__tests__/session-persistence.store.spec.ts
+++ b/frontend/src/stores/__tests__/session-persistence.store.spec.ts
@@ -285,7 +285,7 @@ describe('useSessionPersistenceStore — clearSession()', () => {
 })
 
 describe('useSessionPersistenceStore — cancelPendingSave()', () => {
-  // @UT-SYS-STORE-047@ (FROM: @IMP-SYS-STORE-001@)
+  // @UT-SYS-STORE-098@ (FROM: @IMP-SYS-STORE-001@)
   it('cancels a pending debounced save but leaves the persisted payload in place', async () => {
     loadProfile(MOCK_PROFILE_A)
     const store = useSessionPersistenceStore()
@@ -312,7 +312,7 @@ describe('useSessionPersistenceStore — cancelPendingSave()', () => {
     expect(localStorage.getItem('aerodash:session:payload')).not.toBeNull()
   })
 
-  // @UT-SYS-STORE-048@ (FROM: @IMP-SYS-STORE-001@)
+  // @UT-SYS-STORE-099@ (FROM: @IMP-SYS-STORE-001@)
   it('is a no-op when no save is pending', () => {
     const store = useSessionPersistenceStore()
     expect(() => store.cancelPendingSave()).not.toThrow()

--- a/trace/design/arch.yaml
+++ b/trace/design/arch.yaml
@@ -91,6 +91,12 @@ Architecture Design
       - REQ-SYS-015
     file: docs/architecture/data-rights.md
 
+  DES-ARCH-013
+    title: Remote minSafeVersion Fetch — Privacy Posture
+    req:
+      - REQ-SYS-006
+    file: docs/architecture/adr/011-min-safe-version-fetch-privacy.md
+
 ARCH (auto)
   DES-ARCH-010
     title: TODO: describe this artifact

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -266,7 +266,7 @@ SYS (auto)
     req:
       - REQ-SYS-005
 
-  IMP-SYS-STORE-013
+  IMP-SYS-STORE-021
     title: Data-rights service — erase / export of all personal data (REQ-SYS-014/015)
     files:
       - frontend/src/modules/aircraft/services/data-rights.service.ts
@@ -276,6 +276,7 @@ SYS (auto)
     des:
       - DES-ARCH-011
       - DES-ARCH-012
+
 SYS Shared — Min-Safe-Version offline enforcement (#271)
   IMP-SYS-SHARED-009
     title: App.vue wires checkMinSafeVersion + attachConnectivityRefresh on mount so the offline-enforced gate (issue #271) runs every cold start and again when connectivity returns (REQ-SYS-006 / H-019)

--- a/trace/integration_test/sys.yaml
+++ b/trace/integration_test/sys.yaml
@@ -8,12 +8,13 @@ SYS App — Session-Storage Advisory (Integration — #263 DP-004 / CS-012)
       - frontend/src/__tests__/App.session-storage-advisory.int.spec.ts
 
 SYS (auto)
-  IT-SYS-STORE-001
+  IT-SYS-STORE-002
     title: Data-rights service integration tests — wipe + bulk export (fake-indexeddb)
     files:
       - frontend/src/modules/aircraft/__tests__/data-rights.service.int.spec.ts
     impl:
-      - IMP-SYS-STORE-013
+      - IMP-SYS-STORE-021
+
 SYS Store — App-version offline enforcement (Integration — #271 CS-011 / TECH-023)
   IT-SYS-STORE-001
     title: useAppVersionStore + real IndexedDB cache — stale bundle that previously ran online is BLOCKED on the next offline start; truly fresh install OFFLINE bypasses; cache TTL warning still enforces (#271)

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -1784,7 +1784,7 @@ AC Store — ICAO Registration Validator (Hyphen-Abuse Rejection) (Unit)
       - frontend/src/modules/aircraft/__tests__/profile.validator.spec.ts
 
 AC Store — Export Data Minimisation (#273)
-  UT-AC-STORE-124
+  UT-AC-STORE-128
     title: excludes operating-cost fields from the default export (DP-008/DP-009)
     impl:
       - IMP-AC-STORE-010

--- a/trace/unit_test/sys.yaml
+++ b/trace/unit_test/sys.yaml
@@ -1202,9 +1202,6 @@ SYS (auto)
       - IMP-SYS-STORE-010
 
   UT-SYS-STORE-046
-    title: Data-rights service unit tests — export serialization + constants
-    files:
-      - frontend/src/modules/aircraft/__tests__/data-rights.service.spec.ts
     title: app-version.cache load returns null on first install (no record present)
     files:
       - frontend/src/stores/__tests__/app-version.cache.spec.ts
@@ -1212,23 +1209,11 @@ SYS (auto)
       - IMP-SYS-STORE-013
 
   UT-SYS-STORE-047
-    title: cancelPendingSave — cancels a queued debounced save but leaves the persisted payload for the wipe sweep
-    impl:
-      - IMP-SYS-STORE-001
-    files:
-      - frontend/src/stores/__tests__/session-persistence.store.spec.ts
-
-  UT-SYS-STORE-048
-    title: cancelPendingSave — no-op when no save is pending
-    impl:
-      - IMP-SYS-STORE-001
-    files:
-      - frontend/src/stores/__tests__/session-persistence.store.spec.ts
-    title: app-version.cache persist + load round-trip writes and reads SemVer + fetchedAt
-    files:
-      - frontend/src/stores/__tests__/app-version.cache.spec.ts
+    title: app-version.cache persists and loads a SemVer value
     impl:
       - IMP-SYS-STORE-014
+    files:
+      - frontend/src/stores/__tests__/app-version.cache.spec.ts
 
   UT-SYS-STORE-048
     title: app-version.cache overwrites prior record on second persist (highest-floor selection lives in caller)
@@ -1572,3 +1557,24 @@ SYS (auto)
       - frontend/src/stores/__tests__/app-version.store.spec.ts
     impl:
       - IMP-SYS-STORE-007
+
+  UT-SYS-STORE-097
+    title: Data-rights service unit tests — export serialization + constants
+    files:
+      - frontend/src/modules/aircraft/__tests__/data-rights.service.spec.ts
+    impl:
+      - IMP-SYS-STORE-021
+
+  UT-SYS-STORE-098
+    title: cancelPendingSave — cancels a queued debounced save but leaves the persisted payload for the wipe sweep
+    files:
+      - frontend/src/stores/__tests__/session-persistence.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-001
+
+  UT-SYS-STORE-099
+    title: cancelPendingSave — no-op when no save is pending
+    files:
+      - frontend/src/stores/__tests__/session-persistence.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-001


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Implements #274 (deferred audit finding **DP-018**): authors an Architectural
Decision Record documenting the privacy implications of the online
`GET /version.json` minimum-safe-version fetch that #271 added to satisfy
REQ-SYS-006 (the H-019 "kill switch"), and makes the privacy notice truthful.

- **New `docs/architecture/adr/011-min-safe-version-fetch-privacy.md`**
  (Status: Proposed — flips to Accepted on merge, per the ADR README
  lifecycle). Records the **data exposed** (client IP, default
  `User-Agent`, request timing/frequency, and — by default, unless the deploy
  edge sets `Referrer-Policy: no-referrer` — a same-origin `Referer` carrying the
  in-app route) and what is **not** sent (no cookies —
  `credentials: 'omit'`, no body, no AeroDash-set headers, no query string, no
  device/install/user identifier, no personal/aircraft/session data); the
  **timing** (fires only when `navigator.onLine`, on cold start and reconnect,
  never offline; single-flight; best-effort); the **same-origin** scope; options
  A–D; and the **opt-out** posture (Decision = Option D: no in-app toggle,
  because disabling a safety control re-introduces H-019 — offline operation,
  network-level blocking, and self-hosting remain available to the user).
- **`REQ-SYS-006` Design Reference** now links ADR-011 (was `n/a`) — satisfying
  "ADR recorded and linked from REQ-SYS-006".
- **`PRIVACY.md` corrected** (v1.3 → v1.4): the blanket "*No data is transmitted
  to any server*" claim is scoped to *stored personal data* (which genuinely
  never leaves the device) and a new **§7 Network Activity** truthfully discloses
  the single first-party version-safety request — what it exposes, when, why, and
  that there is no in-app opt-out. §8/§9 updated to match.
- **Traceability:** `@DES-ARCH-013@ (FROM: @REQ-SYS-006@)` in ADR-011 (the
  canonical `H-019 → REQ-SYS-006 → DES-ARCH-013` chain; design tags do not trace
  directly to a hazard per `docs/stc.md`), with a curated `DES-ARCH-013` entry in
  `trace/design/arch.yaml`.

The ADR/privacy change itself is documentation-only — no runtime code, no
P1/core, no behavioural change.

> **✅ Structural-gate breakage (#375) folded in.** This branch inherited a
> red `unit-tests` job from `develop`: the repo-wide structural-gate spec
> (`frontend/scripts/trace/__tests__/repo-structural-gate.spec.ts`) detected **6
> duplicate trace-tag declarations** from a semantic merge conflict between
> earlier feature branches (#271 app-version, #272 data-rights/session-persistence,
> #273 profile export) that independently allocated the same trace IDs. Rather
> than block this PR, the fix is now included here (commit `84f5678`): the
> later-merged (squatter) side of each collision is renumbered to the next free
> ID in its namespace and the registries are synced —
> `IMP-SYS-STORE-013→021`, `UT-SYS-STORE-046→097`, `UT-SYS-STORE-047→098`,
> `UT-SYS-STORE-048→099`, `IT-SYS-STORE-001→002`, `UT-AC-STORE-124→128`.
> The full unit suite is now **1360/1360 green** and `trace check
> --structural-only --baseline` reports no new violations. This is
> traceability bookkeeping only — no runtime/behaviour change. Closes #375.

### Related Issues

- Closes #274
- Closes #375 (the `develop`-wide structural-gate breakage — fix folded into this PR per request)
- Closes audit finding DP-018

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-SYS-006`

### Documentation Updates

- [x] **Requirements:** Created/Updated ID(s): `REQ-SYS-006` (Design Reference now links ADR-011) in `docs/requirements/`
- [x] **Architecture:** Created/Updated ID(s): `ADR-011` / `DES-ARCH-013` in `docs/architecture/`
- [x] **Risk Management:** `N/A` (Reason: H-019 mitigation is unchanged; the ADR documents and references it, but no hazard entry is edited)
- [x] **Journeys:** `N/A` (Reason: documentation/ADR task; no user journey added or changed)
- [x] **Code Docs:** `N/A` (Reason: doc/ADR only — `PRIVACY.md` updated; no API/README change; `CHANGELOG.md` is intentionally not touched per the implement-issue workflow's changelog policy — reserved for the release process)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved. (REQ-SYS-006 / H-019 behaviour is unchanged; the ADR records its privacy posture only.)
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). (The ADR/privacy work touches docs only; the folded-in #375 fix edits `frontend/src/` **comment-only** trace tags + trace registries — no imports, logic, or `src/core/` changed.)

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (features/bugs) OR `main` (releases/hotfixes).
- [x] **Unit Tests:** Passing — **1360/1360 green**. The ADR/privacy change adds no production code (so no new unit test), but this PR now also folds in the #375 structural-gate fix (trace-tag renumbering + registry sync), which turns the previously-red `repo-structural-gate.spec.ts` green; `pnpm --filter frontend test:unit` and `trace check --structural-only --baseline` both pass.
- [x] **Integration Tests:** Passing. (`pnpm test:integration` is green; no integration test added — doc-only change.)
- [x] **Manual Testing:** `N/A` (Reason: documentation-only ADR; no runtime behaviour to exercise. Not merging to `main`.)
- [x] **DoD:** All Definition of Done items from the linked Feature/Bug are met. (The single DoD item — "ADR recorded and linked from REQ-SYS-006" — is genuinely done and ticked on #274.)
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** Does this change require an Architectural Decision Record (ADR) update/creation? Yes — **ADR-011** is created and included in this PR.



