### PR TITLE
feat: [Feat]: Wire .claude/skills to the shared concision directive (#379)

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -25,7 +25,7 @@ This skill bundles four E2E operations + two embedded rule sets. Load only the o
 
 - criticality: safety-critical aviation
 - mode: strict correctness
-- verbosity: no explanation unless asked
+- verbosity: per `CLAUDE.md § Concision`
 - clarity > DRY; explicitness > cleverness
 - forbid: invented behavior; gherkin-only output; mocking in business E2E; live external API hits
 

--- a/.claude/skills/e2e/create-business.md
+++ b/.claude/skills/e2e/create-business.md
@@ -47,7 +47,7 @@
 - path: `trace/e2e/{phase-slug}.yaml`
 - entry: `E2E-{PHASE}-{NNN}` + `title` + feature file path
 
-## Output (no preamble; no commentary)
+## Output
 
 1. feature path + full content
 2. steps path + full content

--- a/.claude/skills/e2e/create-technical.md
+++ b/.claude/skills/e2e/create-technical.md
@@ -56,7 +56,7 @@
 - path: `trace/e2e/smoke.yaml` | `trace/e2e/technical.yaml`
 - entry: `E2E-{DOMAIN}-{NNN}` + `title` + feature file path
 
-## Output (no preamble; no commentary)
+## Output
 
 1. classification
 2. feature path + full content

--- a/.claude/skills/e2e/implementation-rules.md
+++ b/.claude/skills/e2e/implementation-rules.md
@@ -4,7 +4,7 @@ Source-of-truth rules for `frontend/tests/e2e/steps/**/*.ts` step definitions. I
 
 - criticality: safety-critical aviation
 - mode: strict correctness
-- verbosity: no explanation unless asked
+- verbosity: per `CLAUDE.md § Concision`
 
 ## Paths
 

--- a/.claude/skills/e2e/refactor.md
+++ b/.claude/skills/e2e/refactor.md
@@ -70,4 +70,4 @@ Items:
 
 If clean: `No improvements were necessary. The test slice is already compliant.` + `Run /e2e.validate to confirm.`
 
-`output.style`: no preamble; no commentary
+`output.style`: per `CLAUDE.md § Concision`

--- a/.claude/skills/e2e/validate.md
+++ b/.claude/skills/e2e/validate.md
@@ -64,4 +64,4 @@ Footer: `Total: {n}  (CRITICAL: {c}  WARNING: {w}  INFO: {i})` + `Status: PASS |
 
 Clean output: `✓ No violations found. The test slice is compliant.` + `Status: PASS`
 
-`output.style`: no preamble; collect all findings before report
+`output.style`: collect all findings before report; verbosity per `CLAUDE.md § Concision`

--- a/.claude/skills/gherkin/SKILL.md
+++ b/.claude/skills/gherkin/SKILL.md
@@ -5,7 +5,7 @@ description: Use when authoring or editing Gherkin .feature files (Playwright BD
 
 # Gherkin authoring rules
 
-- authority: safety-critical BDD; clarity > DRY; explicitness > cleverness; no explanation unless asked
+- authority: safety-critical BDD; clarity > DRY; explicitness > cleverness; verbosity per `CLAUDE.md § Concision`
 - scope-: unimplemented features; future behavior
 - scope+: incomplete feature | scenario => `@wip`
 - trace: defer to `e2e/traceability-rules.md` if writing/refactoring trace-bearing files

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -38,7 +38,7 @@ If user intent is ambiguous (e.g. "look at milestone 0.7.0"), ask which of the f
 
 ## Shared output style
 
-- bullet points | compressed wording | no full sentences | no repetition | no explanation | no justification | no extra text
+- per `CLAUDE.md § Concision`; milestone reports use telegraphic bullets (no full sentences)
 - each sub-file declares its exact section structure — follow it precisely
 
 ## Procedure

--- a/.claude/skills/milestone/check.md
+++ b/.claude/skills/milestone/check.md
@@ -92,4 +92,4 @@ Rules: classes only: `implementation` | `validation` | `docs` | `traceability` |
 
 - `- P<1|2|3> | <short action> | <issue/artifact refs>`
 
-Rules: blocker-removal actions only; smallest closure step first; no explanations.
+Rules: blocker-removal actions only; smallest closure step first.

--- a/.claude/skills/milestone/create.md
+++ b/.claude/skills/milestone/create.md
@@ -41,10 +41,10 @@
   - if name|focus absent -> derive from Purpose + Key Capabilities; no scope change
   - no new capabilities
   - every deliverable | exit criterion -> observable | testable | reviewable
-  - concise | operational wording
+  - operational wording
   - audience: engineers | validators | product owners
 
-## Output (filled template below; no preamble | notes | explanations | extra sections)
+## Output (filled template below; no extra sections)
 
 ### Title
 
@@ -52,7 +52,7 @@
 
 ### Objective
 
-`2-4` concise sentences; usable value | safety-critical behavior/workflow advanced | roadmap significance.
+`2-4` sentences; usable value | safety-critical behavior/workflow advanced | roadmap significance.
 
 ### Scope
 

--- a/.claude/skills/milestone/plan.md
+++ b/.claude/skills/milestone/plan.md
@@ -77,7 +77,7 @@ ordered milestones `start_version -> target_version`; per item:
   - `<capability 2>`
   - `<capability 3>`
 
-Rules: concise | testable language; externally meaningful capabilities; not component-only work; newly introduced prerequisite milestone -> say so in `Purpose`.
+Rules: testable language; externally meaningful capabilities; not component-only work; newly introduced prerequisite milestone -> say so in `Purpose`.
 
 ### 2. Coverage Mapping
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Wires `.claude/skills/**` to the single shared concision directive at `CLAUDE.md § Concision` (added by #378), removing per-skill duplication of brevity / word-economy guidance so the rule stays DRY. Documentation/tooling only — no `src/core/`, product, or runtime change.

Changes (11 files, 13 single-line edits):

- **References added** to `CLAUDE.md § Concision` where a skill's primary brevity declaration lived:
  - `e2e/SKILL.md`, `e2e/implementation-rules.md` — `verbosity:` line now `per CLAUDE.md § Concision`.
  - `e2e/refactor.md`, `e2e/validate.md` — `output.style:` now references the directive (validate keeps its functional "collect all findings before report").
  - `gherkin/SKILL.md` — authority line's "no explanation unless asked" clause replaced by a reference.
  - `milestone/SKILL.md` — shared output style references the directive **and** retains the milestone-specific telegraphic format ("no full sentences").
- **Redundant brevity modifiers dropped** where brevity was a secondary modifier on a functional line (concision now governed by the always-loaded directive + the skill's referenced shared style):
  - `milestone/create.md` — dropped "concise" from `operational wording`, the Objective `2-4 sentences` spec, and the Output guardrail (kept functional `filled template below; no extra sections`).
  - `milestone/plan.md` — dropped "concise" from the `testable language` rule.
  - `milestone/check.md` — dropped "no explanations" (kept functional `blocker-removal actions only; smallest closure step first`).
  - `e2e/create-business.md`, `e2e/create-technical.md` — `## Output` headings de-parenthesised (numbered output structure unchanged).

All functional output-shape constraints (templates, section counts, numbered output, granularity, ordering, telegraphic "no full sentences", content-quality words like operational/testable) and every safety/traceability instruction in the skills were preserved unchanged.

### Related Issues

- Closes #379

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A` — meta/tooling change to `.claude/skills/**`; no product requirement implemented or affected.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: no requirement created/changed; skill-doc dedup only)
- [x] **Architecture:** `N/A` (Reason: no architecture/ADR change; references an existing directive)
- [x] **Risk Management:** `N/A` (Reason: no hazard introduced or affected; no `src/core/` change)
- [x] **Journeys:** `N/A` (Reason: no user journey created/changed)
- [x] **Code Docs:** `N/A` (Reason: `CHANGELOG.md` is reserved for the release process per `implement-issue`; skill files are agent-workflow docs, not user-facing API/README)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. `N/A` — no traced source artifact added/changed; no trace registry touched.
- [x] No new hazards introduced. Documentation-only change; no runtime/`src/core/` impact.
- [x] Existing mitigations preserved. No safety/traceability instruction removed from any skill (verified by diff + grep).
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). `N/A` — no `frontend/src/**` code changed.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (features/bugs) OR `main` (releases/hotfixes).
- [x] **Unit Tests:** `N/A` (Reason: docs/tooling-only change to `.claude/skills/**`; no source under test changed). Full suite still run green: 1360/1360 unit tests pass.
- [x] **Integration Tests:** Passing — 64/64 integration tests pass (no change expected; verified).
- [x] **Manual Testing:** `N/A` (Reason: no UI/runtime behaviour changed; not a `main`-targeting PR).
- [x] **DoD:** All Definition of Done items from the linked Feature are met and ticked on #379.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` — no architectural/developer-workflow change; references the existing `CLAUDE.md § Concision` anchor, no ADR needed.

### Verification

Local pipeline green prior to push:

- `pnpm install --frozen-lockfile` — up to date
- `pnpm lint` — oxlint + eslint + trace structural + markdownlint (92 files, 0 errors)
- `pnpm --filter frontend type-check` — pass
- `pnpm test:unit` — 1360 passed
- `pnpm test:integration` — 64 passed
- `pnpm build` — pass

Note: `.claude/**` is excluded from the repo markdownlint globs (`.markdownlint-cli2.jsonc`), so `pnpm lint` does not scan these files; they were additionally linted directly under the repo rule set (`.markdownlint.json`) — HEAD vs edited diff: **0 markdownlint violations** introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
