### PR TITLE
feat: [Feat]: Wire PR/issue & doc templates to the shared concision directive + verify (#381)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,8 @@ body:
       value: |
         **Important:** As this is a safety-critical application for aviation, please provide precise details regarding reproduction and potential hazards.
 
+        Keep entries word-efficient per `CLAUDE.md § Concision` — bullets over prose. Per its safety carve-out, never omit a required safety or traceability detail for brevity.
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Thank you for your idea! Please help us understand how this fits into the General Aviation context.
 
+        Keep entries word-efficient per `CLAUDE.md § Concision` — bullets over prose. Per its safety carve-out, never omit a required safety or traceability detail for brevity.
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable-file MD041 -->
+<!-- Authoring: keep this description word-efficient per CLAUDE.md § Concision (bullets over prose, no padding). Per its safety carve-out, never drop a required safety or traceability field below for brevity. -->
 ### Summary
 <!-- Briefly describe the code and documentation changes made in this PR. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ A "Good PR" is small, focused, and easy to review.
 * If your changes affect Requirements, Architecture, or Risk Mitigation, you must update the corresponding `docs/` files in the same PR.
 * **Traceability Tags:** You must include traceability inline code tags (e.g., `// @IMP-SYS-001@ (FROM: @REQ-SYS-001@)`) inside your new source files linking your implementation to the upstream Master Traceability Matrix requirements. Use the local **trace CLI** to generate the next free id and insert the comment — never hand-write the integer suffix. See [§ 5.1 Trace authoring CLI](#51-trace-authoring-cli) below.
 * **Journey Coverage:** If your PR adds or modifies a P1 requirement, verify that the requirement is tagged in at least one UJ in `docs/journeys/`. If not, extend an existing journey or propose a new one. Check with: `grep -r "@REQ-XX-YYY@" docs/journeys/`
-* **Changelog:** Add your changes under `## [Unreleased]` in `CHANGELOG.md`. Use `### Added`, `### Changed`, `### Fixed`, or `### Engineering` (for non-user-facing work). Entries are moved to the release version during the release branch.
+* **Changelog:** Add your changes under `## [Unreleased]` in `CHANGELOG.md`. Use `### Added`, `### Changed`, `### Fixed`, or `### Engineering` (for non-user-facing work). Entries are moved to the release version during the release branch. Write each entry per [`CLAUDE.md § Concision`](CLAUDE.md#concision) — one bullet per change, no narrative paragraphs; per its safety carve-out, never drop a required `H-` / `REQ-` / `IMP-` trace reference for brevity.
 
 ## 7. 🏗️ P1 Constraints (The Safety Core)
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -5,6 +5,8 @@ The requirements are structured by functional area (modules) to allow modular de
 
 AeroDash follows a strict requirements engineering process to ensure safety and certification readiness (Project Level: Experimental / EAB, but following DO-178C principles where applicable).
 
+> **Authoring concision:** Write each requirement as a single declarative EARS sentence and keep the Rationale terse — follow [`CLAUDE.md § Concision`](../../CLAUDE.md#concision). Per its safety carve-out, never drop a `Mitigation Hazard ID` or trace link for brevity.
+
 ## Requirement Syntax (EARS)
 
 All requirements must be written using the **EARS** (Easy Approach to Requirements Syntax) patterns:


### PR DESCRIPTION
### Summary

- Point the PR template, issue templates (bug + feature), the `CONTRIBUTING.md` §6 changelog convention, and the `docs/requirements/README.md` authoring guidance at `CLAUDE.md § Concision` instead of restating brevity rules.
- Every pointer cites the directive's safety carve-out; no required safety/traceability field removed.
- Completes #374's final verification step (sibling of #383, which already wired `.claude/skills`).

### Related Issues

Closes #381

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `N/A` (meta/tooling; no REQ implemented or modified)

### Documentation Updates

- [x] **Requirements:** Updated `docs/requirements/README.md` authoring-concision note (no REQ ID — meta-guidance, not a requirement change)
- [x] **Architecture:** `N/A` (Reason: no architectural change)
- [x] **Risk Management:** `N/A` (Reason: no hazard change; safety carve-out preserved in every pointer)
- [x] **Journeys:** `N/A` (Reason: no user-journey change)
- [x] **Code Docs:** Updated `CONTRIBUTING.md` §6 changelog convention + PR/issue templates; `CHANGELOG.md` intentionally not edited (reserved for the release process per implement-issue policy)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. (No trace change; `trace check --structural-only` passed — no new violations.)
- [x] No new hazards introduced.
- [x] Existing mitigations preserved. (Each pointer cites the concision safety carve-out: never drop `H-`/`REQ-`/`IMP-` references for brevity.)
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). — no `src/core/` change in this PR.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop` (features/bugs) OR `main` (releases/hotfixes). — targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: docs/templates only — no product code; full unit suite still run green: 1360 passed).
- [x] **Integration Tests:** `N/A` (Reason: docs/templates only; suite still run green: 64 passed).
- [x] **Manual Testing:** `N/A` (Reason: docs/templates only, not a `main` release; verified via `pnpm lint` markdownlint, YAML parse of issue forms, and rendered-markdown check).
- [x] **DoD:** All Definition of Done items from #381 are met and ticked `[x]`.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` (Reason: no architectural decision — meta/tooling wording change).

---

**Verification (DoD item 3):** sample artifacts authored under the now-wired rule are concise — bullets-first, no padding, trace refs retained:

- Sample changelog entry — `- PR/issue & doc templates now reference \`CLAUDE.md § Concision\` instead of restating brevity rules (refs #381)` (one bullet, one change).
- This PR description (filled template) is the live concise sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
