### PR TITLE
feat: [Task]: Data-constants registry (fuel densities, standard passenger weights) with source + effective date (#275)

### DIFF
--- a/docs/data_constants/README.md
+++ b/docs/data_constants/README.md
@@ -1,0 +1,97 @@
+# Data-Constants Registry
+
+Source-cited provenance for safety-relevant **hardcoded data constants** whose
+silent revision could distort a Go/No-Go advisory — fuel densities and occupant
+masses. Closes the PR-014 process gap (v0.3.0-alpha audit): hardcoded fuel
+densities and standard occupant masses previously had no source citation,
+effective-date tracking, or drift detection, so an upstream standard revision
+would be silently ignored (issue #275).
+
+The runtime values live in code (P1 `core/`, P2 `modules/`). This registry does
+**not** redefine them — it records, per value, **where it came from** and **when
+it must be re-verified**, and a CI gate fails the build if code and registry
+diverge or an entry goes stale.
+
+## Files
+
+| File | Role |
+| :--- | :--- |
+| [`registry.json`](registry.json) | **Single source of truth** (machine-readable). Each constant: value, unit, source, effective date, review-by date, requirement, hazard, code reference. |
+| `README.md` (this file) | Human-readable schema, policy, and update procedure. `registry.json` is authoritative on conflict. |
+
+## Registered constants
+
+| ID | Value | Unit | Source (abridged) | Effective | Review by | REQ / H |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `fuel-density-avgas-mogas` | `0.72` | kg/L | ASTM D910 AvGas 100LL ≈ 0.72 kg/L @ 15 °C | 2026-05-28 | 2028-05-28 | REQ-FE-001 / H-002 |
+| `fuel-density-jet-diesel` | `0.84` | kg/L | ASTM D1655 / DEF STAN 91-091 Jet A-1 conservative upper bound | 2026-05-28 | 2028-05-28 | REQ-FE-001 / H-002 |
+| `fuel-density-fallback` | `0.84` | kg/L | Conservative fallback = heaviest catalogued density (fail-closed) | 2026-05-28 | 2028-05-28 | REQ-FE-001 / H-002 |
+| `occupant-preset-masses-kg` | `[55, 70, 85]` | kg | Representative adult masses for one-tap entry (not regulatory) | 2026-05-28 | 2028-05-28 | REQ-UQ-001 / H-011 |
+| `occupant-preset-masses-lb` | `[120, 160, 200]` | lb | Representative adult masses for one-tap entry (not regulatory) | 2026-05-28 | 2028-05-28 | REQ-UQ-001 / H-011 |
+
+> Occupant presets are **convenience shortcuts**, not authoritative masses. The
+> pilot always enters the actual or applicable standard mass. EASA standard-mass
+> reference for context: AMC1 CAT.POL.MAB.105 / CS-23.
+
+## Entry schema (`registry.json`)
+
+Each object in `constants[]` carries:
+
+- `id` — unique kebab-case key.
+- `category` — grouping (`fuel-density`, `occupant-mass`).
+- `description` — what the value is and where it is used.
+- `value` — the value, mirrored from code (number or array). The gate fails if it drifts from code.
+- `unit` — physical unit.
+- `source` — non-empty citation (standard, requirement, or documented engineering rationale). An empty/missing source fails the gate (**uncited**).
+- `effectiveDate` — ISO `YYYY-MM-DD` the value was last verified against its source.
+- `reviewBy` — ISO `YYYY-MM-DD` by which the source must be re-checked. Once in the past the entry is **stale** and the gate fails.
+- `requirement` — upstream `REQ-…` id.
+- `hazard` — related `H-…` id (when applicable).
+- `code.file` / `code.symbol` — where the value is defined in source.
+
+## Staleness policy
+
+Default review cadence is **24 months** (`reviewPolicy.defaultIntervalMonths`).
+The gate compares each `reviewBy` against the current date: an entry whose
+`reviewBy` has passed fails CI. This is deliberate — a time-based safety prompt
+(like a certificate-expiry check) that forces periodic re-verification of every
+cited source rather than letting an upstream revision pass silently.
+
+## The CI gate
+
+`frontend/scripts/data-constants/` validates this registry. It runs as a Vitest
+spec wired into `pnpm test:unit` (and therefore CI) — **no GitHub Actions
+workflow change is required**:
+
+- **Uncited** — an entry with an empty/missing `source` fails.
+- **Stale** — an entry whose `reviewBy` is in the past fails.
+- **Schema** — missing/ill-formed required fields (`id`, `unit`, dates,
+  `requirement`, `code.*`) fail.
+- **Drift** — the spec imports the real code constants and asserts each `value`
+  matches; a code change without a registry update fails.
+
+Run locally:
+
+```bash
+# Citation + staleness + schema (pure-node CLI; non-zero exit on violation)
+pnpm --filter frontend check:data-constants
+
+# Full gate incl. code-vs-registry drift (the CI surface)
+pnpm test:unit
+```
+
+## Updating an entry
+
+1. Re-verify the value against its cited `source`.
+2. Update `value` in code **and** `registry.json` together.
+3. Bump `effectiveDate` to today and `reviewBy` forward (default +24 months).
+4. Run `pnpm --filter frontend check:data-constants` and `pnpm test:unit`.
+
+## Adding a constant
+
+1. Add the runtime value in code with an inline comment referencing
+   `docs/data_constants/registry.json#<id>`.
+2. Add a `constants[]` entry with every schema field populated.
+3. Add a drift assertion in
+   `frontend/scripts/data-constants/__tests__/registry-gate.spec.ts`.
+4. Run the gate commands above.

--- a/docs/data_constants/registry.json
+++ b/docs/data_constants/registry.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "description": "Source-cited registry of safety-relevant hardcoded data constants. Single source of truth for the value-provenance metadata of constants whose silent revision could distort a Go/No-Go advisory (fuel densities, occupant masses). The runtime values themselves live in code (see each entry's `code` block); this registry records WHERE each value came from and WHEN it must be re-verified. Enforced by the data-constants gate (frontend/scripts/data-constants) — see README.md.",
+  "reviewPolicy": {
+    "defaultIntervalMonths": 24,
+    "note": "`reviewBy` is the date by which the cited source MUST be re-checked against the live value. Once `reviewBy` is in the past the entry is STALE and the gate fails CI, forcing a human to re-verify the source and bump `effectiveDate`/`reviewBy`."
+  },
+  "constants": [
+    {
+      "id": "fuel-density-avgas-mogas",
+      "category": "fuel-density",
+      "description": "Density of AvGas (100LL, UL91) and MoGas used for fuel volume-to-mass conversion.",
+      "value": 0.72,
+      "unit": "kg/L",
+      "source": "ASTM D910 AvGas 100LL nominal density approx. 0.72 kg/L at 15 degrees C; adopted by AeroDash REQ-FE-001.",
+      "effectiveDate": "2026-05-28",
+      "reviewBy": "2028-05-28",
+      "requirement": "REQ-FE-001",
+      "hazard": "H-002",
+      "code": {
+        "file": "frontend/src/core/logic/fuel-density.ts",
+        "symbol": "FUEL_DENSITY_KG_PER_L['AvGas 100LL'] / ['AvGas UL91'] / ['MoGas']"
+      }
+    },
+    {
+      "id": "fuel-density-jet-diesel",
+      "category": "fuel-density",
+      "description": "Density of Jet A-1 and Diesel used for fuel volume-to-mass conversion.",
+      "value": 0.84,
+      "unit": "kg/L",
+      "source": "ASTM D1655 / DEF STAN 91-091 Jet A-1 density range 0.775-0.840 kg/L at 15 degrees C; conservative upper bound 0.84 adopted by AeroDash REQ-FE-001.",
+      "effectiveDate": "2026-05-28",
+      "reviewBy": "2028-05-28",
+      "requirement": "REQ-FE-001",
+      "hazard": "H-002",
+      "code": {
+        "file": "frontend/src/core/logic/fuel-density.ts",
+        "symbol": "FUEL_DENSITY_KG_PER_L['Jet A-1'] / ['Diesel']"
+      }
+    },
+    {
+      "id": "fuel-density-fallback",
+      "category": "fuel-density",
+      "description": "Conservative fallback density applied when a fuel type is unrecognised. Uses the heaviest catalogued density so an unknown type can never under-state fuel mass.",
+      "value": 0.84,
+      "unit": "kg/L",
+      "source": "Conservative engineering choice: heaviest catalogued density (Jet A-1, 0.84 kg/L). Fail-closed behaviour for H-002 fuel confusion; callers MUST gate on isKnownFuelType. AeroDash REQ-FE-001.",
+      "effectiveDate": "2026-05-28",
+      "reviewBy": "2028-05-28",
+      "requirement": "REQ-FE-001",
+      "hazard": "H-002",
+      "code": {
+        "file": "frontend/src/core/logic/fuel-density.ts",
+        "symbol": "FALLBACK_DENSITY_KG_PER_L (via getFuelDensityKgPerL on an unknown type)"
+      }
+    },
+    {
+      "id": "occupant-preset-masses-kg",
+      "category": "occupant-mass",
+      "description": "One-tap occupant-mass preset chips (light / medium / heavy adult) for metric (kg) mass-station entry. Convenience shortcuts only; the pilot enters the actual or applicable standard mass.",
+      "value": [55, 70, 85],
+      "unit": "kg",
+      "source": "Representative adult occupant masses for turbulence-tolerant one-tap entry (AeroDash REQ-UQ-001). NOT a regulatory standard mass. EASA standard-mass reference for context: AMC1 CAT.POL.MAB.105 / CS-23.",
+      "effectiveDate": "2026-05-28",
+      "reviewBy": "2028-05-28",
+      "requirement": "REQ-UQ-001",
+      "hazard": "H-011",
+      "code": {
+        "file": "frontend/src/modules/mass-balance/data/occupant-presets.ts",
+        "symbol": "OCCUPANT_PRESET_MASSES_KG"
+      }
+    },
+    {
+      "id": "occupant-preset-masses-lb",
+      "category": "occupant-mass",
+      "description": "One-tap occupant-mass preset chips (light / medium / heavy adult) for imperial (lb) mass-station entry. Convenience shortcuts only; the pilot enters the actual or applicable standard mass.",
+      "value": [120, 160, 200],
+      "unit": "lb",
+      "source": "Representative adult occupant masses for turbulence-tolerant one-tap entry (AeroDash REQ-UQ-001). NOT a regulatory standard mass. EASA standard-mass reference for context: AMC1 CAT.POL.MAB.105 / CS-23.",
+      "effectiveDate": "2026-05-28",
+      "reviewBy": "2028-05-28",
+      "requirement": "REQ-UQ-001",
+      "hazard": "H-011",
+      "code": {
+        "file": "frontend/src/modules/mass-balance/data/occupant-presets.ts",
+        "symbol": "OCCUPANT_PRESET_MASSES_LB"
+      }
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "trace:check:structural": "node scripts/trace/index.mjs check --structural-only --baseline",
     "trace:sync": "node scripts/trace/index.mjs sync",
     "trace:sync:apply": "node scripts/trace/index.mjs sync --apply",
+    "check:data-constants": "node scripts/data-constants/index.mjs",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
     "lint": "run-s lint:*",

--- a/frontend/scripts/data-constants/__tests__/registry-gate.spec.ts
+++ b/frontend/scripts/data-constants/__tests__/registry-gate.spec.ts
@@ -1,0 +1,103 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { FUEL_DENSITY_KG_PER_L, getFuelDensityKgPerL } from '@/core/logic/fuel-density'
+import {
+  OCCUPANT_PRESET_MASSES_KG,
+  OCCUPANT_PRESET_MASSES_LB,
+} from '@/modules/mass-balance/data/occupant-presets'
+
+import { loadRegistry, validateRegistry } from '../lib/registry.mjs'
+
+// This spec is the CI surface for the data-constants gate (issue #275). It runs
+// in `pnpm test:unit` (vitest.config.ts includes `scripts/**/*.spec.ts`), so the
+// gate is enforced WITHOUT any GitHub Actions workflow change. It asserts:
+//   - the registry is schema-complete, source-cited, and not stale, AND
+//   - each registry value still matches the real code constant (drift).
+// File lives at frontend/scripts/data-constants/__tests__/… → repo root is 4 up.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+
+interface RegistryEntry {
+  id: string
+  value: unknown
+  source: string
+  effectiveDate: string
+  reviewBy: string
+  requirement: string
+}
+
+interface Registry {
+  constants: RegistryEntry[]
+}
+
+let registry: Registry
+
+beforeAll(async () => {
+  registry = (await loadRegistry(REPO_ROOT)) as Registry
+})
+
+const entry = (id: string): RegistryEntry => {
+  const found = registry.constants.find((c) => c.id === id)
+  if (!found) throw new Error(`registry entry not found: ${id}`)
+  return found
+}
+
+describe('data-constants registry gate (#275 / PR-014)', () => {
+  it('is schema-complete, source-cited, and current (no stale entries)', () => {
+    const report = validateRegistry(registry, new Date())
+    expect(report.schemaErrors, 'schema errors').toEqual([])
+    expect(report.uncited, 'entries with empty/missing source').toEqual([])
+    expect(report.stale, 'entries whose reviewBy date has passed').toEqual([])
+    expect(report.ok).toBe(true)
+  })
+
+  it('contains the expected safety-relevant constants', () => {
+    expect(registry.constants.length).toBeGreaterThanOrEqual(5)
+  })
+})
+
+describe('data-constants drift — registry value matches code', () => {
+  // Every registry id MUST appear here so a newly-added constant cannot ship
+  // without a drift assertion (see "every constant is drift-checked" below).
+  const DRIFT_CHECKED_IDS = new Set<string>([
+    'fuel-density-avgas-mogas',
+    'fuel-density-jet-diesel',
+    'fuel-density-fallback',
+    'occupant-preset-masses-kg',
+    'occupant-preset-masses-lb',
+  ])
+
+  it('fuel-density-avgas-mogas matches FUEL_DENSITY_KG_PER_L (AvGas/MoGas)', () => {
+    const v = entry('fuel-density-avgas-mogas').value
+    expect(FUEL_DENSITY_KG_PER_L['AvGas 100LL']).toBe(v)
+    expect(FUEL_DENSITY_KG_PER_L['AvGas UL91']).toBe(v)
+    expect(FUEL_DENSITY_KG_PER_L['MoGas']).toBe(v)
+  })
+
+  it('fuel-density-jet-diesel matches FUEL_DENSITY_KG_PER_L (Jet A-1/Diesel)', () => {
+    const v = entry('fuel-density-jet-diesel').value
+    expect(FUEL_DENSITY_KG_PER_L['Jet A-1']).toBe(v)
+    expect(FUEL_DENSITY_KG_PER_L['Diesel']).toBe(v)
+  })
+
+  it('fuel-density-fallback matches the conservative unknown-type fallback', () => {
+    expect(getFuelDensityKgPerL('__unrecognised-fuel-type__')).toBe(
+      entry('fuel-density-fallback').value,
+    )
+  })
+
+  it('occupant-preset-masses-kg matches OCCUPANT_PRESET_MASSES_KG', () => {
+    expect(OCCUPANT_PRESET_MASSES_KG).toEqual(entry('occupant-preset-masses-kg').value)
+  })
+
+  it('occupant-preset-masses-lb matches OCCUPANT_PRESET_MASSES_LB', () => {
+    expect(OCCUPANT_PRESET_MASSES_LB).toEqual(entry('occupant-preset-masses-lb').value)
+  })
+
+  it('every registry constant is drift-checked', () => {
+    const unchecked = registry.constants.map((c) => c.id).filter((id) => !DRIFT_CHECKED_IDS.has(id))
+    expect(unchecked, 'registry ids without a drift assertion above').toEqual([])
+  })
+})

--- a/frontend/scripts/data-constants/index.mjs
+++ b/frontend/scripts/data-constants/index.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- CLI entry point: stdout/stderr is the interface (mirrors scripts/trace/index.mjs). */
+/**
+ * Data-constants gate CLI.
+ *
+ * Validates docs/data_constants/registry.json (schema, citation, staleness) and
+ * exits non-zero on any violation. Code-vs-registry drift is enforced by the
+ * Vitest spec (frontend/scripts/data-constants/__tests__/registry-gate.spec.ts)
+ * which runs in `pnpm test:unit` and therefore CI. See README.md (#275).
+ *
+ * Usage: node scripts/data-constants/index.mjs   (pnpm --filter frontend check:data-constants)
+ */
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { loadRegistry, validateRegistry } from './lib/registry.mjs'
+
+// index.mjs lives at frontend/scripts/data-constants/index.mjs → repo root is 3 up.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+async function main() {
+  const registry = await loadRegistry(REPO_ROOT)
+  const report = validateRegistry(registry, new Date())
+
+  if (report.ok) {
+    console.log(
+      `data-constants: OK — ${registry.constants.length} entries cited, in-schema, and current.`,
+    )
+    return
+  }
+
+  console.error('data-constants gate FAILED:')
+  for (const e of report.schemaErrors) console.error(`  schema:  ${e}`)
+  for (const id of report.uncited) console.error(`  uncited: ${id} (empty/missing source)`)
+  for (const id of report.stale) console.error(`  stale:   ${id} (reviewBy date has passed — re-verify source)`)
+  process.exitCode = 1
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/frontend/scripts/data-constants/lib/registry.mjs
+++ b/frontend/scripts/data-constants/lib/registry.mjs
@@ -1,0 +1,103 @@
+/**
+ * Data-constants registry loader + validator (pure Node, no framework deps).
+ *
+ * Validates docs/data_constants/registry.json for the data-constants gate:
+ * schema completeness, source citation, and staleness. Code-vs-registry DRIFT
+ * is asserted separately in the Vitest spec (it must import the real TS
+ * constants). Source-of-truth + policy: docs/data_constants/README.md (#275).
+ */
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const REGISTRY_REL = 'docs/data_constants/registry.json'
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+/** Absolute path to registry.json for a given repo root. */
+export function registryPath(repoRoot) {
+  return path.join(repoRoot, REGISTRY_REL)
+}
+
+/** Read + parse registry.json. */
+export async function loadRegistry(repoRoot) {
+  const raw = await readFile(registryPath(repoRoot), 'utf8')
+  return JSON.parse(raw)
+}
+
+/** Parse an ISO `YYYY-MM-DD` date to epoch ms, or null when malformed. */
+function parseIsoDate(value) {
+  if (typeof value !== 'string' || !ISO_DATE.test(value)) return null
+  const ms = Date.parse(`${value}T00:00:00Z`)
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Validate the registry.
+ *
+ * @param {unknown} registry parsed registry.json
+ * @param {Date} [now] reference date for the staleness check
+ * @returns {{ ok: boolean, schemaErrors: string[], uncited: string[], stale: string[] }}
+ */
+export function validateRegistry(registry, now = new Date()) {
+  const schemaErrors = []
+  const uncited = []
+  const stale = []
+  const nowMs = now.getTime()
+
+  if (!registry || typeof registry !== 'object' || !Array.isArray(registry.constants)) {
+    return { ok: false, schemaErrors: ['registry.constants must be an array'], uncited, stale }
+  }
+
+  const seenIds = new Set()
+  registry.constants.forEach((entry, i) => {
+    const where = entry && typeof entry.id === 'string' ? entry.id : `constants[${i}]`
+    if (!entry || typeof entry !== 'object') {
+      schemaErrors.push(`${where}: not an object`)
+      return
+    }
+
+    if (typeof entry.id !== 'string' || entry.id.trim() === '') {
+      schemaErrors.push(`${where}: missing id`)
+    } else if (seenIds.has(entry.id)) {
+      schemaErrors.push(`${where}: duplicate id`)
+    } else {
+      seenIds.add(entry.id)
+    }
+
+    if (typeof entry.unit !== 'string' || entry.unit.trim() === '') {
+      schemaErrors.push(`${where}: missing unit`)
+    }
+    if (entry.value === undefined || entry.value === null) {
+      schemaErrors.push(`${where}: missing value`)
+    }
+    if (typeof entry.requirement !== 'string' || !entry.requirement.startsWith('REQ-')) {
+      schemaErrors.push(`${where}: missing/invalid requirement (expected REQ-…)`)
+    }
+    if (
+      !entry.code ||
+      typeof entry.code !== 'object' ||
+      typeof entry.code.file !== 'string' ||
+      entry.code.file.trim() === '' ||
+      typeof entry.code.symbol !== 'string' ||
+      entry.code.symbol.trim() === ''
+    ) {
+      schemaErrors.push(`${where}: missing code.file/code.symbol`)
+    }
+
+    if (typeof entry.source !== 'string' || entry.source.trim() === '') {
+      uncited.push(where)
+    }
+
+    const eff = parseIsoDate(entry.effectiveDate)
+    const rev = parseIsoDate(entry.reviewBy)
+    if (eff === null) schemaErrors.push(`${where}: missing/invalid effectiveDate (YYYY-MM-DD)`)
+    if (rev === null) schemaErrors.push(`${where}: missing/invalid reviewBy (YYYY-MM-DD)`)
+    if (eff !== null && rev !== null && rev < eff) {
+      schemaErrors.push(`${where}: reviewBy precedes effectiveDate`)
+    }
+
+    if (rev !== null && rev < nowMs) stale.push(where)
+  })
+
+  const ok = schemaErrors.length === 0 && uncited.length === 0 && stale.length === 0
+  return { ok, schemaErrors, uncited, stale }
+}

--- a/frontend/src/core/logic/fuel-density.ts
+++ b/frontend/src/core/logic/fuel-density.ts
@@ -31,6 +31,13 @@ export type CanonicalFuelType = (typeof CANONICAL_FUEL_TYPES)[number]
  * AvGas (100LL, UL91, MoGas) = 0.72 kg/L
  * Jet A-1 / Diesel = 0.84 kg/L
  *
+ * Provenance + revision tracking for these densities (and the conservative
+ * fallback below) live in the data-constants registry:
+ *   docs/data_constants/registry.json
+ *     #fuel-density-avgas-mogas, #fuel-density-jet-diesel, #fuel-density-fallback
+ * The data-constants gate (frontend/scripts/data-constants) fails CI if these
+ * values drift from the registry or a cited source goes past its review date.
+ *
  * Legacy uppercase aliases (`AVGAS`, `MOGAS`) are retained ONLY so historical
  * fixtures / ad-hoc callers still resolve a correct density; they are NOT
  * canonical and `isKnownFuelType` deliberately rejects them so the catalogue

--- a/frontend/src/modules/mass-balance/data/occupant-presets.ts
+++ b/frontend/src/modules/mass-balance/data/occupant-presets.ts
@@ -1,0 +1,17 @@
+/**
+ * Occupant-mass preset chips for one-tap mass-station entry (UX-002).
+ *
+ * Provenance + revision tracking lives in the data-constants registry:
+ *   docs/data_constants/registry.json
+ *     #occupant-preset-masses-kg, #occupant-preset-masses-lb
+ *
+ * These are convenience shortcuts (light / medium / heavy adult), NOT
+ * authoritative or regulatory standard masses — the pilot always enters the
+ * actual or applicable standard mass. The data-constants gate fails CI if
+ * these arrays drift from the registry (see frontend/scripts/data-constants).
+ */
+
+// @IMP-MB-DATA-004@ (FROM: @REQ-UQ-001@)
+export const OCCUPANT_PRESET_MASSES_KG: readonly number[] = [55, 70, 85]
+
+export const OCCUPANT_PRESET_MASSES_LB: readonly number[] = [120, 160, 200]

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -3,6 +3,10 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMassBalanceStore } from '@/modules/mass-balance/stores/mass-balance.store'
 import { AircraftContextSchema } from '@/modules/mass-balance/data/aircraft-context.schema'
+import {
+  OCCUPANT_PRESET_MASSES_KG,
+  OCCUPANT_PRESET_MASSES_LB,
+} from '@/modules/mass-balance/data/occupant-presets'
 import { mapFleetProfileToContext } from '@/modules/mass-balance/services/fleet-profile.mapper'
 import { useFleetStore } from '@/modules/aircraft/stores/fleet.store'
 import { useActiveAircraftStore } from '@/modules/aircraft/stores/active-aircraft.store'
@@ -330,12 +334,13 @@ const lastResult = computed(() => store.lastResult)
 
 // UX-002: one-tap preset weights for occupant (non-fuel) stations. Fuel tanks
 // are scrubbed via their slider, so they get no presets. Presets are unit-aware
-// so an imperial profile sees pound figures.
+// so an imperial profile sees pound figures. The preset values are source-cited
+// in docs/data_constants/registry.json (occupant-preset-masses-*).
 function presetsForStation(stationIndex: number): readonly number[] {
   const lp = store.aircraft?.loadPoints[stationIndex]
   if (!lp || lp.fuelTank) return []
   const isImperial = lp.unit?.toLowerCase() === 'lb'
-  return isImperial ? [120, 160, 200] : [55, 70, 85]
+  return isImperial ? OCCUPANT_PRESET_MASSES_LB : OCCUPANT_PRESET_MASSES_KG
 }
 
 const aircraftLabel = computed(() => {

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -410,3 +410,10 @@ MB (auto)
       - frontend/src/modules/mass-balance/stores/mass-balance.store.ts
     req:
       - REQ-UQ-006
+
+  IMP-MB-DATA-004
+    title: Occupant-Mass Preset Constants (source-cited via data-constants registry)
+    files:
+      - frontend/src/modules/mass-balance/data/occupant-presets.ts
+    req:
+      - REQ-UQ-001


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Adds a source-cited **data-constants registry** with a staleness/drift **CI gate**, closing audit gap **PR-014** (v0.3.0-alpha): hardcoded fuel densities and occupant-mass presets previously had no source citation, effective-date tracking, or drift detection, so an upstream standard revision would be silently ignored.

- `docs/data_constants/` — `registry.json` (single source of truth: value, unit, `source`, `effectiveDate`, `reviewBy`, `requirement`, `hazard`, code ref) + `README.md` (schema, staleness policy, update procedure).
- Constants reference the registry: `fuel-density.ts` cross-reference comment (P1 — comment only, no math/interface change); occupant-mass presets extracted to traced `occupant-presets.ts` and imported by `MassBalanceView` (values unchanged).
- CI gate `frontend/scripts/data-constants/`: pure-node validator (schema / uncited / stale) + a Vitest spec wired into `pnpm test:unit` that also asserts code-vs-registry **drift** — enforced in CI with **no workflow change**. Local: `pnpm --filter frontend check:data-constants`.

### Related Issues

- Closes #275

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-UQ-001` (new trace `IMP-MB-DATA-004` for occupant-mass presets); registry also references `REQ-FE-001` (fuel densities). No requirement text changed.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: no requirement text changed; `IMP-MB-DATA-004` traces to the existing `REQ-UQ-001`, status unchanged)
- [x] **Architecture:** `N/A` (Reason: no architectural model change; new registry is documented under `docs/data_constants/`)
- [x] **Risk Management:** `N/A` (Reason: no hazard text changed; registry references existing `H-002` and `H-011`, mitigations preserved)
- [x] **Journeys:** `N/A` (Reason: no user-journey change; preset values and runtime behaviour are unchanged)
- [x] **Code Docs:** Added `docs/data_constants/README.md` + `registry.json` and in-code registry cross-references. `CHANGELOG.md` deferred to the release process per the implement-issue policy.

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved. (Fuel-density and occupant-preset values are unchanged; a drift spec now fails CI if any value silently diverges.)
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). The only `src/core/` change is a documentation comment; `lint:eslint` (P1-ISOLATION) and `test:p1` (459 ✓) pass.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added/updated and passing locally. (`test:unit` 1368 ✓, incl. 8 new data-constants gate tests.)
- [x] **Integration Tests:** Passing. (`test:integration` 64 ✓; no new integration tests required.)
- [x] **Manual Testing:** `N/A` (Reason: docs + tooling registry + CI gate; no runtime behaviour change — preset values are identical and verified by the automated drift spec. Not merging to `main`.)
- [x] **DoD:** All Definition of Done items from #275 are met and attested (every box ticked with evidence).
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` (Reason: no P1 interface or architectural change; comment-only P1 touch; the registry + gate approach is prescribed by the accepted issue #275).
