### PR TITLE
feat: [Feature]: Aircraft-profile verification provenance + draft-aware aircraft picker (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Aircraft-profile verification provenance & expiry: verifying a profile now requires a sign-off (date, initials, POH revision) bound to the source weighing report and shown as "Verified by … on … against POH …"; the sign-off expires after 90 days or when its source weighing report changes, the fleet badge flips to **Expired**, and an expired profile can be re-verified in place (REQ-AC-007, H-011, closes #276)
+- Draft-aware Mass & Balance aircraft picker: Verified / Draft / Last-used `<optgroup>`s, a destructive `[Draft]` marker, and an inline `WARN-AC-002` acknowledgement before a draft envelope is loaded for computation (REQ-AC-005/REQ-AC-007, H-011, closes #276)
+
 ### Fixed
 
 - Minimum-safe-version kill-switch now enforces **offline** (REQ-SYS-006 / H-019; fixes audit gap CS-011 / TECH-023). The gate previously returned early when offline, letting an explicitly kill-switched bundle keep running on an unreliable cockpit network. The store now caches the highest-seen `minSafeVersion` in IndexedDB and enforces `effectiveMin = max(build-time, cached, online /version.json)` even offline, refreshing on reconnect. SemVer comparison follows §11 (pre-release ordering, `+build` ignored); a structurally-invalid build-time floor fails closed without polluting the cache; and the shipped `/version.json` is validated against the app version so a deploy cannot self-brick. Privacy of the cold-start `/version.json` fetch is tracked in #274. (closes #271)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Aircraft-profile verification provenance & expiry: verifying a profile now requires a sign-off (date, initials, POH revision) bound to the source weighing report and shown as "Verified by … on … against POH …"; the sign-off expires after 90 days or when its source weighing report changes, the fleet badge flips to **Expired**, and an expired profile can be re-verified in place (REQ-AC-007, H-011, closes #276)
-- Draft-aware Mass & Balance aircraft picker: Verified / Draft / Last-used `<optgroup>`s, a destructive `[Draft]` marker, and an inline `WARN-AC-002` acknowledgement before a draft envelope is loaded for computation (REQ-AC-005/REQ-AC-007, H-011, closes #276)
+- Draft-aware Mass & Balance aircraft picker: Verified / Draft / Last-used `<optgroup>`s, a destructive `[Draft]` marker, and an inline `WARN-AC-002` acknowledgement before a draft envelope is loaded for computation; an expired/source-changed Verified profile is treated as unverified at this Go/No-Go entry point — marked `[Expired]` and gated behind the same acknowledgement (including the on-mount auto-load / session-restore path) so it can never load silently (REQ-AC-005/REQ-AC-007, H-011, closes #276)
 
 ### Fixed
 

--- a/docs/journeys/01_fleet_management.md
+++ b/docs/journeys/01_fleet_management.md
@@ -4,7 +4,7 @@ Focus: Creating, validating, and managing aircraft profiles.
 
 ---
 
-<!-- @UJ-A-001@ (FROM: @REQ-AC-001@, @REQ-AC-005@, @REQ-AD-005@, @REQ-AD-012@, @REQ-AD-014@, @REQ-UQ-005@) -->
+<!-- @UJ-A-001@ (FROM: @REQ-AC-001@, @REQ-AC-005@, @REQ-AC-007@, @REQ-AD-005@, @REQ-AD-012@, @REQ-AD-014@, @REQ-UQ-005@) -->
 
 ## <a name="UJ-A-001"></a>UJ-A-001: The "Fleet Admin" Workflow (Complex Profile)
 

--- a/docs/requirements/aircraft_management.md
+++ b/docs/requirements/aircraft_management.md
@@ -66,6 +66,16 @@ This document defines the aircraft management behavior using the **EARS** (Easy 
 **Status:** Implemented
 **Design Reference:** n/a
 
+<!-- @REQ-AC-007@ (FROM: @H-011@) -->
+
+### REQ-AC-007: Verification Provenance & Expiry
+
+**Requirement:** When the user verifies an aircraft profile, the system shall require and record a sign-off provenance (verification date, verifier initials, and the POH revision verified against) bound to the source weighing report, and shall treat the verification as expired — surfacing it as unverified for safety-critical use — once it is older than a fixed validity period or its source weighing report no longer matches the recorded provenance.
+**Rationale:** A single un-attributed "Verified" tap (REQ-AC-005) cannot evidence *who* checked the data, *against which POH revision*, or *whether the underlying weighing report has since changed*; provenance and expiry close the H-011 "Garbage-In" gap for stale or unattributable profile data.
+**Priority:** P1
+**Status:** Implemented
+**Design Reference:** [Notification Schema](../architecture/notification_schema.md)
+
 ---
 
 ## Design References

--- a/docs/risk_management/safety_hazards.md
+++ b/docs/risk_management/safety_hazards.md
@@ -57,7 +57,7 @@ gap that issue #267 closed.
 | H-008 | S2 | Mitigated | REQ-PF-015, REQ-PF-016 |
 | H-009 | S2 | Mitigated | REQ-AP-004, REQ-WX-004, REQ-WX-005 |
 | H-010 | S1 | Mitigated | REQ-FE-002, REQ-UQ-006 |
-| H-011 | S1 | Mitigated | REQ-AC-005, REQ-UI-023, REQ-UQ-006 |
+| H-011 | S1 | Mitigated | REQ-AC-005, REQ-AC-007, REQ-UI-023, REQ-UQ-006 |
 | H-012 | S1 | Mitigated | REQ-PF-010, REQ-PF-012 |
 | H-013 | S1 | Mitigated | REQ-PF-011 |
 | H-014 | S1 | Mitigated | REQ-WX-009, REQ-AD-017 |
@@ -166,7 +166,7 @@ gap that issue #267 closed.
 **Severity:** S1
 **Cause:** Garbage In, Garbage Out (e.g., wrong MTOM entered).
 **Status:** Mitigated
-**Mitigated By:** REQ-AC-005, REQ-UI-023, REQ-UQ-006
+**Mitigated By:** REQ-AC-005, REQ-AC-007, REQ-UI-023, REQ-UQ-006
 
 <!-- @H-012@ -->
 ### H-012: Performance data extrapolation errors

--- a/frontend/src/core/adapters/aircraft.schema.spec.ts
+++ b/frontend/src/core/adapters/aircraft.schema.spec.ts
@@ -1095,3 +1095,60 @@ describe('AircraftProfileSchema — finite + numeric range guards', () => {
     expect(result.success).toBe(true)
   })
 })
+
+// ─── Verification provenance (REQ-AC-007) ──────────────────────────────────────
+
+describe('AircraftProfileSchema — verification provenance', () => {
+  const validVerification = {
+    verifiedOn: '2026-01-10',
+    verifiedBy: 'JS',
+    pohRevision: 'Rev 7',
+    sourceWeighingDate: '2025-01-15',
+  }
+
+  // @UT-AC-CORE-116@ (FROM: @IMP-AC-CORE-004@)
+  it('accepts a Verified profile carrying a full verification block', () => {
+    const parsed = AircraftProfileSchema.parse(
+      cloneWith((p) => {
+        p.status = 'verified'
+        p.verification = { ...validVerification }
+      }),
+    )
+    expect(parsed.verification?.pohRevision).toBe('Rev 7')
+    expect(parsed.verification?.sourceWeighingDate).toBe('2025-01-15')
+  })
+
+  // @UT-AC-CORE-117@ (FROM: @IMP-AC-CORE-004@)
+  it('leaves verification undefined when omitted (optional for legacy records)', () => {
+    const parsed = AircraftProfileSchema.parse(createValidProfile())
+    expect(parsed.verification).toBeUndefined()
+  })
+
+  // @UT-AC-CORE-118@ (FROM: @IMP-AC-CORE-004@)
+  it('rejects a verifiedOn that is not a YYYY-MM-DD calendar date', () => {
+    const result = AircraftProfileSchema.safeParse(
+      cloneWith((p) => {
+        p.verification = { ...validVerification, verifiedOn: '10/01/2026' }
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  // @UT-AC-CORE-119@ (FROM: @IMP-AC-CORE-004@)
+  it('rejects empty verifiedBy / pohRevision and over-long values', () => {
+    expect(
+      AircraftProfileSchema.safeParse(
+        cloneWith((p) => {
+          p.verification = { ...validVerification, verifiedBy: '' }
+        }),
+      ).success,
+    ).toBe(false)
+    expect(
+      AircraftProfileSchema.safeParse(
+        cloneWith((p) => {
+          p.verification = { ...validVerification, pohRevision: 'x'.repeat(41) }
+        }),
+      ).success,
+    ).toBe(false)
+  })
+})

--- a/frontend/src/core/adapters/aircraft.schema.spec.ts
+++ b/frontend/src/core/adapters/aircraft.schema.spec.ts
@@ -1134,6 +1134,18 @@ describe('AircraftProfileSchema — verification provenance', () => {
     expect(result.success).toBe(false)
   })
 
+  // @UT-AC-CORE-120@ (FROM: @IMP-AC-CORE-004@)
+  it('rejects a verifiedOn that is well-formed but an impossible calendar date', () => {
+    for (const bad of ['2026-13-45', '2026-02-30', '2026-00-10', '2026-01-32']) {
+      const result = AircraftProfileSchema.safeParse(
+        cloneWith((p) => {
+          p.verification = { ...validVerification, verifiedOn: bad }
+        }),
+      )
+      expect(result.success, `expected ${bad} to be rejected`).toBe(false)
+    }
+  })
+
   // @UT-AC-CORE-119@ (FROM: @IMP-AC-CORE-004@)
   it('rejects empty verifiedBy / pohRevision and over-long values', () => {
     expect(

--- a/frontend/src/core/adapters/aircraft.schema.ts
+++ b/frontend/src/core/adapters/aircraft.schema.ts
@@ -171,6 +171,28 @@ const PerformanceProfileSchema = z.object({
   dataPoints: z.array(PerformanceDataPointSchema).max(1000),
 })
 
+// @IMP-AC-CORE-004@ (FROM: @REQ-AC-007@)
+// Verification provenance — the human sign-off recorded when a Draft profile is
+// promoted to Verified (REQ-AC-007, H-011). It binds the "Verified" status to
+// *who* attested the data, *which POH revision* they checked it against, and
+// *which weighing report* was the source of truth at sign-off. `sourceWeighingDate`
+// is the `validFrom` of the active (latest) weighing report at verification time;
+// if the profile's active weighing report later no longer matches it, the
+// verification is stale (the source was edited) — see
+// `core/logic/profile-verification.ts`. Dates are calendar dates ('YYYY-MM-DD'),
+// not timestamps: provenance is a human attestation, not a machine event.
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const VerificationProvenanceSchema = z.object({
+  /** Calendar date the pilot signed off the verification ('YYYY-MM-DD'). */
+  verifiedOn: z.string().regex(ISO_DATE_RE),
+  /** Verifier initials / short identifier (free text, e.g. "JS"). */
+  verifiedBy: z.string().min(1).max(10),
+  /** POH/AFM revision label the data was checked against (e.g. "Rev 7"). */
+  pohRevision: z.string().min(1).max(40),
+  /** `validFrom` of the weighing report that was the source of truth at sign-off. */
+  sourceWeighingDate: z.string().min(1),
+})
+
 // @IMP-AD-CORE-004@ (FROM: @REQ-AD-001@, @REQ-AD-002@, @REQ-AD-003@, @REQ-AD-005@, @REQ-AD-011@, @REQ-AD-012@, @REQ-AD-014@, @DES-ARCH-002@)
 // @IMP-AC-CORE-002@ (FROM: @REQ-AC-001@, @REQ-AC-005@, @REQ-AC-006@, @REQ-AD-006@, @REQ-AD-007@, @REQ-AD-010@)
 export const AircraftProfileSchema = z
@@ -198,6 +220,13 @@ export const AircraftProfileSchema = z
       .default('draft'),
     // M3: Schema version for structured migration safety (refs #154)
     schemaVersion: z.number().int().positive().finite().default(1),
+    // v0.4: Verification provenance (REQ-AC-007, H-011). Present only on a
+    // Verified snapshot recorded via the sign-off flow; legacy/imported Verified
+    // profiles and all Drafts omit it. Optional so pre-provenance Verified
+    // records remain valid at rest (treated as "verified, provenance unknown" by
+    // the freshness evaluator). The store strips it on any Verified → Draft
+    // transition so a Draft never carries a stale sign-off.
+    verification: VerificationProvenanceSchema.optional(),
     // M3: Passenger profiles with standard weights (REQ-AC-006)
     passengerProfiles: z.array(PassengerProfileSchema).default([]),
     weighingReports: z.array(WeighingReportSchema).min(1),
@@ -316,3 +345,5 @@ export type AircraftProfilePerformanceDataPoint = z.infer<typeof PerformanceData
 // M3.5 types — powertrain discriminator + battery pack
 export type AircraftProfilePowertrain = z.infer<typeof AircraftProfileSchema>['powertrain']
 export type AircraftProfileBatteryPack = z.infer<typeof BatteryPackSchema>
+// v0.4 type — verification provenance (REQ-AC-007)
+export type AircraftProfileVerification = z.infer<typeof VerificationProvenanceSchema>

--- a/frontend/src/core/adapters/aircraft.schema.ts
+++ b/frontend/src/core/adapters/aircraft.schema.ts
@@ -182,9 +182,23 @@ const PerformanceProfileSchema = z.object({
 // `core/logic/profile-verification.ts`. Dates are calendar dates ('YYYY-MM-DD'),
 // not timestamps: provenance is a human attestation, not a machine event.
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+/**
+ * True only for a real calendar date. The regex above admits structurally-valid
+ * but impossible dates (e.g. `2026-13-45`, `2026-02-30`); round-tripping the
+ * components through `Date.UTC` and comparing back rejects those at parse so a
+ * sign-off cannot persist a nonsensical date. Pure: no `Date.now()`.
+ */
+function isRealCalendarDate(iso: string): boolean {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(Date.UTC(y!, m! - 1, d!))
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m! - 1 && dt.getUTCDate() === d
+}
 const VerificationProvenanceSchema = z.object({
   /** Calendar date the pilot signed off the verification ('YYYY-MM-DD'). */
-  verifiedOn: z.string().regex(ISO_DATE_RE),
+  verifiedOn: z
+    .string()
+    .regex(ISO_DATE_RE)
+    .refine(isRealCalendarDate, { message: 'IMPOSSIBLE_CALENDAR_DATE' }),
   /** Verifier initials / short identifier (free text, e.g. "JS"). */
   verifiedBy: z.string().min(1).max(10),
   /** POH/AFM revision label the data was checked against (e.g. "Rev 7"). */

--- a/frontend/src/core/logic/profile-verification.spec.ts
+++ b/frontend/src/core/logic/profile-verification.spec.ts
@@ -160,14 +160,25 @@ describe('evaluateVerificationFreshness — source change', () => {
   })
 
   // @UT-AC-CORE-115@ (FROM: @IMP-AC-CORE-005@)
-  it('matches the LATEST weighing report by validFrom, not insertion order', () => {
-    // Sign-off bound to the newest report; an older sibling must not "win".
-    const result = evaluateVerificationFreshness(
+  it('matches the LATEST weighing report by validFrom, regardless of array order', () => {
+    // Sign-off (SOURCE_DATE) is bound to the newest report; an older sibling
+    // must not "win". Both orderings must resolve to the newest report — if the
+    // evaluator naively took the first element, the [older, newer] case below
+    // would pick 2020-01-01 ≠ SOURCE_DATE and report expired-source-changed.
+    const latestFirst = evaluateVerificationFreshness(
       profile({
-        weighingReports: [{ validFrom: '2026-01-10' }, { validFrom: '2020-01-01' }],
+        weighingReports: [{ validFrom: SOURCE_DATE }, { validFrom: '2020-01-01' }],
       }),
       daysAfterVerified(0),
     )
-    expect(result.state).toBe('fresh')
+    expect(latestFirst.state).toBe('fresh')
+
+    const olderFirst = evaluateVerificationFreshness(
+      profile({
+        weighingReports: [{ validFrom: '2020-01-01' }, { validFrom: SOURCE_DATE }],
+      }),
+      daysAfterVerified(0),
+    )
+    expect(olderFirst.state).toBe('fresh')
   })
 })

--- a/frontend/src/core/logic/profile-verification.spec.ts
+++ b/frontend/src/core/logic/profile-verification.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for profile-verification.ts (P1 Safety Core).
+ *
+ * @see frontend/src/core/logic/profile-verification.ts
+ */
+
+// @UT-AC-CORE-104@ (FROM: @IMP-AC-CORE-005@)
+
+import { describe, it, expect } from 'vitest'
+import {
+  VERIFICATION_VALIDITY_DAYS,
+  evaluateVerificationFreshness,
+  type VerifiableProfile,
+} from './profile-verification'
+import type { AircraftProfileVerification } from '../adapters/aircraft.schema'
+
+const SOURCE_DATE = '2026-01-10'
+
+function provenance(overrides: Partial<AircraftProfileVerification> = {}): AircraftProfileVerification {
+  return {
+    verifiedOn: '2026-01-10',
+    verifiedBy: 'JS',
+    pohRevision: 'Rev 7',
+    sourceWeighingDate: SOURCE_DATE,
+    ...overrides,
+  }
+}
+
+function profile(overrides: Partial<VerifiableProfile> = {}): VerifiableProfile {
+  return {
+    status: 'verified',
+    verification: provenance(),
+    weighingReports: [{ validFrom: SOURCE_DATE }],
+    ...overrides,
+  }
+}
+
+/** A fixed UTC instant N days after the verifiedOn date used by `provenance()`. */
+function daysAfterVerified(days: number): Date {
+  return new Date(Date.parse(`${SOURCE_DATE}T00:00:00.000Z`) + days * 86_400_000)
+}
+
+describe('VERIFICATION_VALIDITY_DAYS', () => {
+  it('is a fixed 90-day window', () => {
+    expect(VERIFICATION_VALIDITY_DAYS).toBe(90)
+  })
+})
+
+describe('evaluateVerificationFreshness — draft + unattributed', () => {
+  // @UT-AC-CORE-105@ (FROM: @IMP-AC-CORE-005@)
+  it('reports draft for a non-verified profile and never requires re-verification', () => {
+    const result = evaluateVerificationFreshness(
+      profile({ status: 'draft', verification: undefined }),
+      daysAfterVerified(0),
+    )
+    expect(result.state).toBe('draft')
+    expect(result.requiresReverification).toBe(false)
+    expect(result.provenance).toBeNull()
+    expect(result.expiresOn).toBeNull()
+    expect(result.daysUntilExpiry).toBeNull()
+  })
+
+  // @UT-AC-CORE-106@ (FROM: @IMP-AC-CORE-005@)
+  it('reports verified-unattributed for a legacy Verified profile without provenance', () => {
+    const result = evaluateVerificationFreshness(
+      profile({ verification: undefined }),
+      daysAfterVerified(0),
+    )
+    expect(result.state).toBe('verified-unattributed')
+    // Legacy verified records are not mass-invalidated.
+    expect(result.requiresReverification).toBe(false)
+    expect(result.provenance).toBeNull()
+  })
+})
+
+describe('evaluateVerificationFreshness — fresh window', () => {
+  // @UT-AC-CORE-107@ (FROM: @IMP-AC-CORE-005@)
+  it('is fresh on the verification day with the full window remaining', () => {
+    const result = evaluateVerificationFreshness(profile(), daysAfterVerified(0))
+    expect(result.state).toBe('fresh')
+    expect(result.requiresReverification).toBe(false)
+    expect(result.daysUntilExpiry).toBe(VERIFICATION_VALIDITY_DAYS)
+    expect(result.expiresOn).toBe('2026-04-10')
+    expect(result.provenance).toEqual(provenance())
+  })
+
+  // @UT-AC-CORE-108@ (FROM: @IMP-AC-CORE-005@)
+  it('is fresh one day before expiry', () => {
+    const result = evaluateVerificationFreshness(
+      profile(),
+      daysAfterVerified(VERIFICATION_VALIDITY_DAYS - 1),
+    )
+    expect(result.state).toBe('fresh')
+    expect(result.daysUntilExpiry).toBe(1)
+  })
+})
+
+describe('evaluateVerificationFreshness — aged expiry', () => {
+  // @UT-AC-CORE-109@ (FROM: @IMP-AC-CORE-005@)
+  it('is expired exactly on the expiry day (boundary)', () => {
+    const result = evaluateVerificationFreshness(
+      profile(),
+      daysAfterVerified(VERIFICATION_VALIDITY_DAYS),
+    )
+    expect(result.state).toBe('expired-aged')
+    expect(result.requiresReverification).toBe(true)
+    expect(result.daysUntilExpiry).toBe(0)
+    expect(result.expiresOn).toBe('2026-04-10')
+  })
+
+  // @UT-AC-CORE-110@ (FROM: @IMP-AC-CORE-005@)
+  it('is expired well past the window with a negative days-remaining', () => {
+    const result = evaluateVerificationFreshness(
+      profile(),
+      daysAfterVerified(VERIFICATION_VALIDITY_DAYS + 30),
+    )
+    expect(result.state).toBe('expired-aged')
+    expect(result.daysUntilExpiry).toBe(-30)
+  })
+
+  // @UT-AC-CORE-111@ (FROM: @IMP-AC-CORE-005@)
+  it('fails closed (expired) when verifiedOn is structurally unparseable', () => {
+    const result = evaluateVerificationFreshness(
+      profile({ verification: provenance({ verifiedOn: 'not-a-date' }) }),
+      daysAfterVerified(0),
+    )
+    expect(result.state).toBe('expired-aged')
+    expect(result.requiresReverification).toBe(true)
+    expect(result.expiresOn).toBeNull()
+    expect(result.daysUntilExpiry).toBeNull()
+  })
+})
+
+describe('evaluateVerificationFreshness — source change', () => {
+  // @UT-AC-CORE-112@ (FROM: @IMP-AC-CORE-005@)
+  it('is expired-source-changed when the active weighing report no longer matches the sign-off', () => {
+    const result = evaluateVerificationFreshness(
+      profile({ weighingReports: [{ validFrom: '2026-02-01' }] }),
+      daysAfterVerified(0),
+    )
+    expect(result.state).toBe('expired-source-changed')
+    expect(result.requiresReverification).toBe(true)
+    expect(result.expiresOn).toBeNull()
+  })
+
+  // @UT-AC-CORE-113@ (FROM: @IMP-AC-CORE-005@)
+  it('source-change takes precedence over an otherwise-fresh window', () => {
+    const result = evaluateVerificationFreshness(
+      profile({ weighingReports: [{ validFrom: '2030-01-01' }] }),
+      daysAfterVerified(1),
+    )
+    expect(result.state).toBe('expired-source-changed')
+  })
+
+  // @UT-AC-CORE-114@ (FROM: @IMP-AC-CORE-005@)
+  it('is expired-source-changed when the profile has no weighing report at all', () => {
+    const result = evaluateVerificationFreshness(profile({ weighingReports: [] }), daysAfterVerified(0))
+    expect(result.state).toBe('expired-source-changed')
+    expect(result.requiresReverification).toBe(true)
+  })
+
+  // @UT-AC-CORE-115@ (FROM: @IMP-AC-CORE-005@)
+  it('matches the LATEST weighing report by validFrom, not insertion order', () => {
+    // Sign-off bound to the newest report; an older sibling must not "win".
+    const result = evaluateVerificationFreshness(
+      profile({
+        weighingReports: [{ validFrom: '2026-01-10' }, { validFrom: '2020-01-01' }],
+      }),
+      daysAfterVerified(0),
+    )
+    expect(result.state).toBe('fresh')
+  })
+})

--- a/frontend/src/core/logic/profile-verification.ts
+++ b/frontend/src/core/logic/profile-verification.ts
@@ -1,0 +1,189 @@
+/**
+ * Profile verification freshness — P1 Safety Core.
+ *
+ * A "Verified" aircraft profile carries a human sign-off (REQ-AC-007): who
+ * attested it, against which POH revision, and which weighing report was the
+ * source of truth at the time. That attestation does not stay true forever:
+ *
+ *  - It **ages out.** A sign-off made long ago no longer evidences that the
+ *    data still matches the current POH/AFM. After a fixed validity window the
+ *    verification is treated as expired and the profile must be re-verified.
+ *  - It is **invalidated when its source changes.** If the profile's active
+ *    weighing report no longer matches the one the sign-off was bound to, the
+ *    attestation is about data that no longer exists. This is a defence-in-depth
+ *    check against an imported/tampered exchange file that claims `verified`
+ *    while carrying a mismatched weighing report — the in-app edit flow already
+ *    drops a Verified profile back to Draft, but an external document can pair
+ *    any status with any data.
+ *
+ * An expired or source-changed verification is a Garbage-In gate failure
+ * (H-011): the profile must not be trusted as a verified source for a Go/No-Go
+ * advisory until a fresh sign-off is recorded.
+ *
+ * Pure, deterministic, side-effect free. `now` is injected so the result is a
+ * function of its inputs only — callers pass `new Date()`, tests pass a fixed
+ * instant. Calendar arithmetic is performed in whole UTC days: provenance dates
+ * are calendar dates ('YYYY-MM-DD'), not timestamps.
+ *
+ * @see docs/requirements/aircraft_management.md REQ-AC-007
+ * @see docs/risk_management/safety_hazards.md H-011
+ */
+
+import type { AircraftProfileVerification } from '../adapters/aircraft.schema'
+
+// @IMP-AC-CORE-005@ (FROM: @REQ-AC-007@)
+
+/**
+ * Validity window for a verification sign-off, in days. Fixed constant — not
+ * user-configurable, so a pilot cannot extend the trust horizon of stale data.
+ * 90 days mirrors a common pre-season / quarterly POH-data review cadence.
+ */
+export const VERIFICATION_VALIDITY_DAYS = 90
+
+const DAY_MS = 86_400_000
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export type VerificationFreshnessState =
+  /** Profile is a working Draft — provenance/expiry do not apply (WARN-AC-002 owns this). */
+  | 'draft'
+  /** Verified at rest but with no recorded provenance (legacy / pre-REQ-AC-007 / import). */
+  | 'verified-unattributed'
+  /** Verified with provenance, still inside the validity window and matching its source. */
+  | 'fresh'
+  /** Verified with provenance, but older than the validity window. */
+  | 'expired-aged'
+  /** Verified with provenance, but its source weighing report no longer matches the sign-off. */
+  | 'expired-source-changed'
+
+export interface VerificationFreshness {
+  readonly state: VerificationFreshnessState
+  /** True when the profile must NOT be trusted as a verified source for safety-critical use. */
+  readonly requiresReverification: boolean
+  /** The recorded sign-off, echoed back when present; `null` for Draft / unattributed. */
+  readonly provenance: AircraftProfileVerification | null
+  /** Computed expiry calendar date ('YYYY-MM-DD'); `null` when not computable. */
+  readonly expiresOn: string | null
+  /** Whole days until expiry (≤ 0 once expired); `null` when not computable. */
+  readonly daysUntilExpiry: number | null
+}
+
+/** Minimal profile shape the freshness evaluation needs. */
+export interface VerifiableProfile {
+  readonly status: 'draft' | 'verified'
+  readonly verification?: AircraftProfileVerification
+  readonly weighingReports: ReadonlyArray<{ readonly validFrom: string }>
+}
+
+/** Parse a 'YYYY-MM-DD' calendar date to its UTC-midnight epoch-day index, or null. */
+function toEpochDay(iso: string): number | null {
+  if (!ISO_DATE_RE.test(iso)) return null
+  const ms = Date.parse(`${iso}T00:00:00.000Z`)
+  if (Number.isNaN(ms)) return null
+  return Math.floor(ms / DAY_MS)
+}
+
+/** Format a UTC epoch-day index back to a 'YYYY-MM-DD' calendar date. */
+function fromEpochDay(day: number): string {
+  return new Date(day * DAY_MS).toISOString().slice(0, 10)
+}
+
+/** The active (latest) weighing report's `validFrom`, or null when none exist. */
+function activeSourceWeighingDate(
+  reports: ReadonlyArray<{ readonly validFrom: string }>,
+): string | null {
+  let latest: string | null = null
+  for (const r of reports) {
+    if (latest === null || r.validFrom.localeCompare(latest) > 0) {
+      latest = r.validFrom
+    }
+  }
+  return latest
+}
+
+/**
+ * Evaluate the freshness of a profile's verification at instant `now`.
+ *
+ * Resolution order (most-specific reason wins):
+ *   1. Not verified                 → `draft`
+ *   2. Verified, no provenance      → `verified-unattributed`
+ *   3. Source weighing report moved → `expired-source-changed`
+ *   4. Past the validity window     → `expired-aged`
+ *   5. Otherwise                    → `fresh`
+ *
+ * A `verified-unattributed` profile is intentionally NOT forced to re-verify:
+ * legacy/imported Verified records pre-date provenance capture and must not be
+ * mass-invalidated. New sign-offs always carry provenance (enforced upstream by
+ * the fleet store), so the unattributed state shrinks over time.
+ */
+export function evaluateVerificationFreshness(
+  profile: VerifiableProfile,
+  now: Date,
+): VerificationFreshness {
+  if (profile.status !== 'verified') {
+    return {
+      state: 'draft',
+      requiresReverification: false,
+      provenance: null,
+      expiresOn: null,
+      daysUntilExpiry: null,
+    }
+  }
+
+  const provenance = profile.verification ?? null
+  if (provenance === null) {
+    return {
+      state: 'verified-unattributed',
+      requiresReverification: false,
+      provenance: null,
+      expiresOn: null,
+      daysUntilExpiry: null,
+    }
+  }
+
+  // Source-change check (defence in depth against tampered/stale imports).
+  const currentSource = activeSourceWeighingDate(profile.weighingReports)
+  if (currentSource === null || currentSource !== provenance.sourceWeighingDate) {
+    return {
+      state: 'expired-source-changed',
+      requiresReverification: true,
+      provenance,
+      expiresOn: null,
+      daysUntilExpiry: null,
+    }
+  }
+
+  // Age check. A structurally-valid but unparseable date fails closed (expired).
+  const verifiedDay = toEpochDay(provenance.verifiedOn)
+  if (verifiedDay === null) {
+    return {
+      state: 'expired-aged',
+      requiresReverification: true,
+      provenance,
+      expiresOn: null,
+      daysUntilExpiry: null,
+    }
+  }
+
+  const expiryDay = verifiedDay + VERIFICATION_VALIDITY_DAYS
+  const nowDay = Math.floor(now.getTime() / DAY_MS)
+  const daysUntilExpiry = expiryDay - nowDay
+  const expiresOn = fromEpochDay(expiryDay)
+
+  if (daysUntilExpiry <= 0) {
+    return {
+      state: 'expired-aged',
+      requiresReverification: true,
+      provenance,
+      expiresOn,
+      daysUntilExpiry,
+    }
+  }
+
+  return {
+    state: 'fresh',
+    requiresReverification: false,
+    provenance,
+    expiresOn,
+    daysUntilExpiry,
+  }
+}

--- a/frontend/src/core/logic/profile-verification.ts
+++ b/frontend/src/core/logic/profile-verification.ts
@@ -10,11 +10,14 @@
  *    verification is treated as expired and the profile must be re-verified.
  *  - It is **invalidated when its source changes.** If the profile's active
  *    weighing report no longer matches the one the sign-off was bound to, the
- *    attestation is about data that no longer exists. This is a defence-in-depth
- *    check against an imported/tampered exchange file that claims `verified`
- *    while carrying a mismatched weighing report — the in-app edit flow already
- *    drops a Verified profile back to Draft, but an external document can pair
- *    any status with any data.
+ *    attestation is about data that no longer exists. The in-app edit flow
+ *    already drops a Verified profile back to Draft on any change, and
+ *    `profile.import` forces every imported document to Draft — so this check
+ *    is *defence in depth*: it catches the residual paths those guards do not,
+ *    namely direct IndexedDB corruption or a weighing report that was re-dated
+ *    or swapped under a sign-off that legitimately reached `verified`. Note it
+ *    keys on the report's `validFrom` date only; value tampering (bem/emptyCg)
+ *    under an unchanged `validFrom` is out of scope for this check.
  *
  * An expired or source-changed verification is a Garbage-In gate failure
  * (H-011): the profile must not be trusted as a verified source for a Go/No-Go

--- a/frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
@@ -95,6 +95,7 @@ function makeFleetStore(overrides: {
     const notifications = ref<unknown[]>([])
     const checkDraftWarning = vi.fn<(p: AircraftProfile) => void>()
     const verifyProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+    const reverifyProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
     const editVerifiedProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
     const deleteProfile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
     const loadAll = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
@@ -106,6 +107,7 @@ function makeFleetStore(overrides: {
       notifications,
       checkDraftWarning,
       verifyProfile,
+      reverifyProfile,
       editVerifiedProfile,
       deleteProfile,
       loadAll,
@@ -431,5 +433,132 @@ describe('FleetList — delete confirmation + undo (UX-001)', () => {
     await wrapper.vm.$nextTick()
 
     expect(document.querySelector('.confirm-dialog')).toBeNull()
+  })
+})
+
+// ─── REQ-AC-007: verification provenance + expiry display ───────────────────
+
+describe('FleetList — verification provenance + expiry (REQ-AC-007)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  /** Mount FleetList, returning both the wrapper and the (stub) fleet store. */
+  function mountWithStore(profiles: AircraftProfile[]) {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const fleet = makeFleetStore({ profiles })()
+    makeActiveStore(null)()
+    const router = makeRouter()
+    router.push('/fleet')
+    const wrapper = mount(FleetList, { global: { plugins: [pinia, router] } })
+    return { wrapper, fleet }
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+
+  // @UT-AC-VIEW-172@ (FROM: @IMP-AC-VIEW-022@)
+  it('shows the verify dialog when the Verify button is tapped on a Draft', async () => {
+    const { wrapper } = mountWithStore([makeProfile({ status: 'draft' })])
+    expect(document.querySelector('.verify-dialog')).toBeNull()
+
+    await wrapper.find('.btn-verify').trigger('click')
+
+    expect(document.querySelector('.verify-dialog')).not.toBeNull()
+  })
+
+  // @UT-AC-VIEW-173@ (FROM: @IMP-AC-VIEW-022@)
+  it('verifies a Draft with the captured sign-off provenance', async () => {
+    const { wrapper, fleet } = mountWithStore([makeProfile({ id: 'd1', status: 'draft' })])
+    const verifySpy = vi.spyOn(fleet, 'verifyProfile')
+    await wrapper.find('.btn-verify').trigger('click')
+
+    ;(
+      wrapper.vm as unknown as {
+        onConfirmVerify(s: { verifiedBy: string; pohRevision: string; verifiedOn: string }): void
+      }
+    ).onConfirmVerify({ verifiedBy: 'JS', pohRevision: 'Rev 7', verifiedOn: '2026-05-01' })
+    await flushPromises()
+
+    expect(verifySpy).toHaveBeenCalledWith('d1', {
+      verifiedBy: 'JS',
+      pohRevision: 'Rev 7',
+      verifiedOn: '2026-05-01',
+    })
+  })
+
+  // @UT-AC-VIEW-174@ (FROM: @IMP-AC-VIEW-022@)
+  it('renders the provenance line and no verify button for a fresh verified profile', () => {
+    const profile = makeProfile({
+      status: 'verified',
+      verification: {
+        verifiedOn: today,
+        verifiedBy: 'AB',
+        pohRevision: 'Rev 4',
+        sourceWeighingDate: '2025-01-01',
+      },
+    })
+    const { wrapper } = mountWithStore([profile])
+
+    expect(wrapper.text()).toContain('Verified by AB on')
+    expect(wrapper.text()).toContain('POH Rev 4')
+    expect(wrapper.find('.btn-verify').exists()).toBe(false)
+  })
+
+  // @UT-AC-VIEW-175@ (FROM: @IMP-AC-VIEW-022@)
+  it('flags an expired verification with the Expired badge and a re-verify affordance', () => {
+    const profile = makeProfile({
+      status: 'verified',
+      verification: {
+        verifiedOn: '2000-01-01',
+        verifiedBy: 'AB',
+        pohRevision: 'Rev 4',
+        sourceWeighingDate: '2025-01-01',
+      },
+    })
+    const { wrapper } = mountWithStore([profile])
+
+    expect(wrapper.find('.profile-status-badge').text()).toBe('Expired')
+    const verifyBtn = wrapper.find('.btn-verify')
+    expect(verifyBtn.exists()).toBe(true)
+    expect(verifyBtn.attributes('aria-label')).toContain('Re-verify')
+    expect(wrapper.text()).toContain('Verification expired')
+  })
+
+  // @UT-AC-VIEW-176@ (FROM: @IMP-AC-VIEW-022@)
+  it('re-attests an expired verified profile in place via reverifyProfile', async () => {
+    const profile = makeProfile({
+      id: 'v1',
+      status: 'verified',
+      verification: {
+        verifiedOn: '2000-01-01',
+        verifiedBy: 'AB',
+        pohRevision: 'Rev 4',
+        sourceWeighingDate: '2025-01-01',
+      },
+    })
+    const { wrapper, fleet } = mountWithStore([profile])
+    const reverifySpy = vi.spyOn(fleet, 'reverifyProfile')
+    const verifySpy = vi.spyOn(fleet, 'verifyProfile')
+
+    await wrapper.find('.btn-verify').trigger('click')
+    ;(
+      wrapper.vm as unknown as {
+        onConfirmVerify(s: { verifiedBy: string; pohRevision: string; verifiedOn: string }): void
+      }
+    ).onConfirmVerify({ verifiedBy: 'CD', pohRevision: 'Rev 5', verifiedOn: today })
+    await flushPromises()
+
+    expect(reverifySpy).toHaveBeenCalledWith('v1', {
+      verifiedBy: 'CD',
+      pohRevision: 'Rev 5',
+      verifiedOn: today,
+    })
+    expect(verifySpy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
@@ -79,3 +79,23 @@ describe('ProfileStatusBadge — Draft status', () => {
     expect(title).toContain('safety-critical')
   })
 })
+
+describe('ProfileStatusBadge — expired verification (REQ-AC-007)', () => {
+  // @UT-AC-VIEW-181@ (FROM: @IMP-AC-VIEW-004@)
+  it('renders an "Expired" badge with the critical class when a verified profile is expired', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'verified', expired: true } })
+    const badge = wrapper.find('[role="status"]')
+    expect(wrapper.text()).toBe('Expired')
+    expect(badge.classes()).toContain('status-expired')
+    expect(badge.classes()).not.toContain('status-verified')
+    expect(badge.attributes('aria-label')).toBe('Profile status: Expired')
+    expect(badge.attributes('title')).toContain('expired')
+  })
+
+  // @UT-AC-VIEW-182@ (FROM: @IMP-AC-VIEW-004@)
+  it('ignores the expired flag for a Draft (only verified can expire)', () => {
+    const wrapper = mount(ProfileStatusBadge, { props: { status: 'draft', expired: true } })
+    expect(wrapper.text()).toBe('Draft')
+    expect(wrapper.find('[role="status"]').classes()).toContain('status-draft')
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for VerifyProfileDialog.vue (REQ-AC-007).
+ * The dialog teleports into <body>, so assertions query the document.
+ *
+ * @see frontend/src/modules/aircraft/components/VerifyProfileDialog.vue
+ */
+
+// @UT-AC-VIEW-177@ (FROM: @IMP-AC-VIEW-020@, @IMP-AC-VIEW-021@)
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import VerifyProfileDialog from '../components/VerifyProfileDialog.vue'
+
+function setInput(selector: string, value: string): void {
+  const el = document.querySelector(selector) as HTMLInputElement | null
+  if (!el) throw new Error(`input not found: ${selector}`)
+  el.value = value
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('VerifyProfileDialog', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // @UT-AC-VIEW-177@ (FROM: @IMP-AC-VIEW-020@)
+  it('renders the sign-off fields and the aircraft registration when open', () => {
+    const wrapper = mount(VerifyProfileDialog, {
+      props: { open: true, registration: 'D-EBPN' },
+    })
+    expect(document.querySelector('.verify-dialog')).not.toBeNull()
+    expect(document.querySelector('.verify-dialog__title')?.textContent).toContain('D-EBPN')
+    expect(document.querySelector('input[aria-label="Verifier initials"]')).not.toBeNull()
+    expect(document.querySelector('input[aria-label="POH revision"]')).not.toBeNull()
+    expect(document.querySelector('input[aria-label="Verification date"]')).not.toBeNull()
+    wrapper.unmount()
+  })
+
+  // @UT-AC-VIEW-178@ (FROM: @IMP-AC-VIEW-021@)
+  it('keeps the Verify button disabled until initials and POH revision are entered', async () => {
+    const wrapper = mount(VerifyProfileDialog, {
+      props: { open: true, registration: 'D-EBPN' },
+    })
+    const confirmBtn = document.querySelector('.verify-dialog__btn--primary') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(true)
+
+    setInput('input[aria-label="Verifier initials"]', 'JS')
+    await wrapper.vm.$nextTick()
+    expect(confirmBtn.disabled).toBe(true)
+
+    setInput('input[aria-label="POH revision"]', 'Rev 7')
+    await wrapper.vm.$nextTick()
+    expect(confirmBtn.disabled).toBe(false)
+    wrapper.unmount()
+  })
+
+  // @UT-AC-VIEW-179@ (FROM: @IMP-AC-VIEW-021@)
+  it('emits confirm with a trimmed sign-off payload', async () => {
+    const wrapper = mount(VerifyProfileDialog, {
+      props: { open: true, registration: 'D-EBPN' },
+    })
+    setInput('input[aria-label="Verifier initials"]', '  JS  ')
+    setInput('input[aria-label="POH revision"]', '  Rev 7  ')
+    setInput('input[aria-label="Verification date"]', '2026-05-01')
+    await wrapper.vm.$nextTick()
+    ;(document.querySelector('.verify-dialog__btn--primary') as HTMLButtonElement).click()
+
+    const events = wrapper.emitted('confirm')
+    expect(events).toBeTruthy()
+    expect(events![0]![0]).toEqual({
+      verifiedBy: 'JS',
+      pohRevision: 'Rev 7',
+      verifiedOn: '2026-05-01',
+    })
+    wrapper.unmount()
+  })
+
+  // @UT-AC-VIEW-180@ (FROM: @IMP-AC-VIEW-021@)
+  it('emits cancel when the Cancel button is tapped', async () => {
+    const wrapper = mount(VerifyProfileDialog, {
+      props: { open: true, registration: 'D-EBPN' },
+    })
+    ;(document.querySelector('.verify-dialog__btn--cancel') as HTMLButtonElement).click()
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
@@ -9,10 +9,18 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useFleetStore, VerifiedMutationError, InvalidRegistrationError } from '../stores/fleet.store'
+import {
+  useFleetStore,
+  VerifiedMutationError,
+  InvalidRegistrationError,
+  IncompleteSignoffError,
+} from '../stores/fleet.store'
 import { useActiveAircraftStore } from '../stores/active-aircraft.store'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 import { fleetRepository } from '../services/fleet.repository'
+
+/** A complete verification sign-off for tests that just need to reach Verified. */
+const SIGNOFF = { verifiedBy: 'JS', pohRevision: 'Rev 7', verifiedOn: '2026-01-10' } as const
 
 // Mock the fleet repository so we don't need real IndexedDB in unit tests
 vi.mock('../services/fleet.repository', () => ({
@@ -104,7 +112,7 @@ describe('useFleetStore', () => {
     const draft = await store.createProfile(minimalProfileData())
     const draftId = draft.id
 
-    const verified = await store.verifyProfile(draftId)
+    const verified = await store.verifyProfile(draftId, SIGNOFF)
 
     expect(verified.status).toBe('verified')
     // New UUID must have been assigned
@@ -119,7 +127,7 @@ describe('useFleetStore', () => {
   it('editVerifiedProfile replaces the Verified record in place with a Draft', async () => {
     const store = useFleetStore()
     const draft = await store.createProfile(minimalProfileData())
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
     const verifiedId = verified.id
 
     const edited = await store.editVerifiedProfile(verifiedId, { registration: 'D-ECSM' })
@@ -138,7 +146,7 @@ describe('useFleetStore', () => {
   it('editVerifiedProfile converts status Verified → Draft and applies changes', async () => {
     const store = useFleetStore()
     const draft = await store.createProfile(minimalProfileData())
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
 
     const edited = await store.editVerifiedProfile(verified.id, { model: 'P2010' })
 
@@ -157,7 +165,7 @@ describe('useFleetStore', () => {
   it('blocks direct in-place mutation of Verified profile via updateProfile', async () => {
     const store = useFleetStore()
     const draft = await store.createProfile(minimalProfileData())
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
 
     await expect(
       store.updateProfile(verified.id, { registration: 'D-MUTATED' }),
@@ -190,7 +198,7 @@ describe('useFleetStore', () => {
   it('does not emit draft warning when profile is Verified', async () => {
     const store = useFleetStore()
     const draft = await store.createProfile(minimalProfileData())
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
     store.clearNotifications()
     store.checkDraftWarning(verified)
     expect(store.notifications.some((n) => n.code === 'WARN-AC-002')).toBe(false)
@@ -463,7 +471,7 @@ describe('useFleetStore', () => {
   it('editVerifiedProfile preserves untouched fields when converting Verified to Draft', async () => {
     const store = useFleetStore()
     const draft = await store.createProfile(minimalProfileData())
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
 
     const edited = await store.editVerifiedProfile(verified.id, {
       registration: 'D-ECSM',
@@ -484,8 +492,8 @@ describe('useFleetStore', () => {
   it('verifyProfile throws if profile is already Verified', async () => {
     const store = useFleetStore()
     const draft = await store.createProfile(minimalProfileData())
-    const verified = await store.verifyProfile(draft.id)
-    await expect(store.verifyProfile(verified.id)).rejects.toThrow(
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
+    await expect(store.verifyProfile(verified.id, SIGNOFF)).rejects.toThrow(
       `Profile "${verified.id}" is already verified.`,
     )
   })
@@ -493,7 +501,9 @@ describe('useFleetStore', () => {
   // @UT-AC-STORE-058@ (FROM: @IMP-AC-STORE-005@)
   it('verifyProfile throws if profile not found', async () => {
     const store = useFleetStore()
-    await expect(store.verifyProfile('no-such-id')).rejects.toThrow('Profile not found: no-such-id')
+    await expect(store.verifyProfile('no-such-id', SIGNOFF)).rejects.toThrow(
+      'Profile not found: no-such-id',
+    )
   })
 
   // @UT-AC-STORE-059@ (FROM: @IMP-AC-STORE-005@)
@@ -522,7 +532,7 @@ describe('useFleetStore', () => {
     const draft = await store.createProfile(minimalProfileData())
     activeStore.setActiveProfile(draft)
 
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
 
     expect(activeStore.activeProfile?.id).toBe(verified.id)
     expect(activeStore.activeProfile?.status).toBe('verified')
@@ -536,7 +546,7 @@ describe('useFleetStore', () => {
     const other = await store.createProfile({ ...minimalProfileData(), registration: 'D-OTHR' })
     activeStore.setActiveProfile(other)
 
-    await store.verifyProfile(draft.id)
+    await store.verifyProfile(draft.id, SIGNOFF)
 
     expect(activeStore.activeProfile?.id).toBe(other.id)
   })
@@ -570,7 +580,7 @@ describe('useFleetStore', () => {
       { name: 'Standard Adult', standardWeight: 86, unit: 'kg' as const },
     ]
     const draft = await store.createProfile({ ...minimalProfileData(), passengerProfiles })
-    const verified = await store.verifyProfile(draft.id)
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
 
     expect(verified.passengerProfiles).toEqual(passengerProfiles)
 
@@ -670,5 +680,121 @@ describe('useFleetStore', () => {
     expect(activeStore.activeProfile?.id).toBe(draft2.id)
 
     void draft1
+  })
+
+  // ── REQ-AC-007: verification provenance + expiry-on-source-edit ──
+
+  // @UT-AC-STORE-129@ (FROM: @IMP-AC-STORE-011@)
+  it('verifyProfile records the full sign-off provenance bound to the active weighing report', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile({
+      ...minimalProfileData(),
+      weighingReports: [
+        { bem: 432, emptyCg: 1.882, weighingDate: '2024-06-01', validFrom: '2024-06-01' },
+        { bem: 430, emptyCg: 1.88, weighingDate: '2025-03-01', validFrom: '2025-03-01' },
+      ],
+    })
+
+    const verified = await store.verifyProfile(draft.id, {
+      verifiedBy: 'AB',
+      pohRevision: 'Rev 3',
+      verifiedOn: '2026-02-15',
+    })
+
+    expect(verified.verification).toEqual({
+      verifiedOn: '2026-02-15',
+      verifiedBy: 'AB',
+      pohRevision: 'Rev 3',
+      // Bound to the LATEST weighing report, not insertion order.
+      sourceWeighingDate: '2025-03-01',
+    })
+  })
+
+  // @UT-AC-STORE-130@ (FROM: @IMP-AC-STORE-011@)
+  it('verifyProfile defaults verifiedOn to today when the sign-off omits a date', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile(minimalProfileData())
+    const today = new Date().toISOString().slice(0, 10)
+
+    const verified = await store.verifyProfile(draft.id, { verifiedBy: 'JS', pohRevision: 'Rev 1' })
+
+    expect(verified.verification?.verifiedOn).toBe(today)
+  })
+
+  // @UT-AC-STORE-131@ (FROM: @IMP-AC-STORE-011@)
+  it('verifyProfile rejects a sign-off with blank initials or POH revision', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile(minimalProfileData())
+
+    await expect(
+      store.verifyProfile(draft.id, { verifiedBy: '   ', pohRevision: 'Rev 1' }),
+    ).rejects.toThrow(IncompleteSignoffError)
+
+    const draft2 = await store.createProfile({ ...minimalProfileData(), registration: 'D-ECSM' })
+    await expect(
+      store.verifyProfile(draft2.id, { verifiedBy: 'JS', pohRevision: '' }),
+    ).rejects.toThrow(IncompleteSignoffError)
+  })
+
+  // @UT-AC-STORE-132@ (FROM: @IMP-AC-STORE-011@)
+  it('editVerifiedProfile strips the verification provenance when reverting to Draft', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile(minimalProfileData())
+    const verified = await store.verifyProfile(draft.id, SIGNOFF)
+    expect(verified.verification).toBeDefined()
+
+    const edited = await store.editVerifiedProfile(verified.id, { model: 'P2010' })
+
+    expect(edited.status).toBe('draft')
+    expect(edited.verification).toBeUndefined()
+  })
+
+  // @UT-AC-STORE-133@ (FROM: @IMP-AC-STORE-011@)
+  it('updateProfile never leaves verification provenance on a Draft', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile(minimalProfileData())
+
+    const updated = await store.updateProfile(draft.id, { model: 'P2010' })
+
+    expect(updated.status).toBe('draft')
+    expect(updated.verification).toBeUndefined()
+  })
+
+  // @UT-AC-STORE-134@ (FROM: @IMP-AC-STORE-011@)
+  it('reverifyProfile re-stamps provenance in place on an already-verified profile', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile(minimalProfileData())
+    const verified = await store.verifyProfile(draft.id, {
+      verifiedBy: 'AA',
+      pohRevision: 'Rev 1',
+      verifiedOn: '2025-01-01',
+    })
+
+    const reattested = await store.reverifyProfile(verified.id, {
+      verifiedBy: 'BB',
+      pohRevision: 'Rev 2',
+      verifiedOn: '2026-05-01',
+    })
+
+    expect(reattested.id).toBe(verified.id)
+    expect(reattested.status).toBe('verified')
+    expect(reattested.verification).toEqual({
+      verifiedOn: '2026-05-01',
+      verifiedBy: 'BB',
+      pohRevision: 'Rev 2',
+      sourceWeighingDate: '2025-01-01',
+    })
+    expect(store.profiles.filter((p) => p.id === verified.id)).toHaveLength(1)
+  })
+
+  // @UT-AC-STORE-135@ (FROM: @IMP-AC-STORE-011@)
+  it('reverifyProfile throws on a Draft profile and on a missing id', async () => {
+    const store = useFleetStore()
+    const draft = await store.createProfile(minimalProfileData())
+
+    await expect(store.reverifyProfile(draft.id, SIGNOFF)).rejects.toThrow('is not verified')
+    await expect(store.reverifyProfile('no-such-id', SIGNOFF)).rejects.toThrow(
+      'Profile not found: no-such-id',
+    )
   })
 })

--- a/frontend/src/modules/aircraft/components/FleetList.vue
+++ b/frontend/src/modules/aircraft/components/FleetList.vue
@@ -27,9 +27,24 @@
         role="listitem"
       >
         <div class="profile-item__info">
-          <span class="profile-item__registration">{{ profile.registration }}</span>
-          <span class="profile-item__model">{{ profile.manufacturer }} {{ profile.model }}</span>
-          <ProfileStatusBadge :status="profile.status" />
+          <div class="profile-item__identity">
+            <span class="profile-item__registration">{{ profile.registration }}</span>
+            <span class="profile-item__model">{{ profile.manufacturer }} {{ profile.model }}</span>
+            <ProfileStatusBadge
+              :status="profile.status"
+              :expired="freshnessFor(profile).requiresReverification"
+            />
+          </div>
+          <!-- @IMP-AC-VIEW-022@ (FROM: @REQ-AC-007@) -->
+          <p
+            v-if="provenanceLine(profile)"
+            class="profile-item__provenance"
+            :class="{
+              'profile-item__provenance--expired': freshnessFor(profile).requiresReverification,
+            }"
+          >
+            {{ provenanceLine(profile) }}
+          </p>
         </div>
 
         <div class="profile-item__actions">
@@ -85,14 +100,14 @@
             </span>
           </button>
 
-          <!-- Verify draft profile -->
+          <!-- Verify draft profile, or re-verify a verified profile whose sign-off expired -->
           <button
-            v-if="profile.status === 'draft'"
+            v-if="needsVerification(profile)"
             type="button"
             class="icon-btn icon-btn--verify btn-success btn-verify"
-            :aria-label="`Verify ${profile.registration}`"
-            :title="`Verify ${profile.registration}`"
-            @click="onVerify(profile.id)"
+            :aria-label="`${profile.status === 'verified' ? 'Re-verify' : 'Verify'} ${profile.registration}`"
+            :title="`${profile.status === 'verified' ? 'Re-verify' : 'Verify'} ${profile.registration}`"
+            @click="onVerify(profile)"
           >
             <svg
               class="icon-btn__icon"
@@ -228,6 +243,14 @@
       @undo="onUndoDelete"
       @dismiss="onDismissUndo"
     />
+
+    <!-- REQ-AC-007: verification sign-off capture (date + initials + POH revision) -->
+    <VerifyProfileDialog
+      :open="pendingVerify !== null"
+      :registration="pendingVerify?.registration ?? ''"
+      @confirm="onConfirmVerify"
+      @cancel="onCancelVerify"
+    />
   </div>
 </template>
 
@@ -235,11 +258,16 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
-import { useFleetStore } from '../stores/fleet.store'
+import {
+  evaluateVerificationFreshness,
+  type VerificationFreshness,
+} from '@/core/logic/profile-verification'
+import { useFleetStore, type VerificationSignoff } from '../stores/fleet.store'
 import { useActiveAircraftStore } from '../stores/active-aircraft.store'
 import { fleetRepository } from '../services/fleet.repository'
 import { downloadProfileAsJson } from '../services/profile.import'
 import ProfileStatusBadge from './ProfileStatusBadge.vue'
+import VerifyProfileDialog from './VerifyProfileDialog.vue'
 import ConfirmDialog from '@/shared/components/ConfirmDialog.vue'
 import UndoToast from '@/shared/components/UndoToast.vue'
 
@@ -248,6 +276,60 @@ import UndoToast from '@/shared/components/UndoToast.vue'
 const router = useRouter()
 const fleetStore = useFleetStore()
 const activeStore = useActiveAircraftStore()
+
+// ─── REQ-AC-007: verification provenance + expiry display ──────────────────
+// @IMP-AC-VIEW-022@ (FROM: @REQ-AC-007@)
+
+/** Freshness of a profile's verification, evaluated against the current date. */
+function freshnessFor(profile: AircraftProfile): VerificationFreshness {
+  return evaluateVerificationFreshness(profile, new Date())
+}
+
+/** Human one-line provenance summary, or null when there is nothing to show. */
+function provenanceLine(profile: AircraftProfile): string | null {
+  const f = freshnessFor(profile)
+  if (f.state === 'expired-source-changed') {
+    return 'Verification expired — the source weighing report changed. Re-verify before use.'
+  }
+  if (f.state === 'expired-aged' && f.provenance) {
+    return `Verification expired (signed off ${f.provenance.verifiedOn} by ${f.provenance.verifiedBy}). Re-verify before use.`
+  }
+  if (f.state === 'fresh' && f.provenance) {
+    return `Verified by ${f.provenance.verifiedBy} on ${f.provenance.verifiedOn} against POH ${f.provenance.pohRevision}.`
+  }
+  if (f.state === 'verified-unattributed') {
+    return 'Verified (no recorded sign-off — re-verify to add provenance).'
+  }
+  return null
+}
+
+/** A draft, or a verified profile whose sign-off has expired, needs (re-)verification. */
+function needsVerification(profile: AircraftProfile): boolean {
+  return profile.status === 'draft' || freshnessFor(profile).requiresReverification
+}
+
+const pendingVerify = ref<AircraftProfile | null>(null)
+
+function onVerify(profile: AircraftProfile): void {
+  pendingVerify.value = profile
+}
+
+async function onConfirmVerify(signoff: VerificationSignoff): Promise<void> {
+  const profile = pendingVerify.value
+  pendingVerify.value = null
+  if (!profile) return
+  // A Draft is promoted to a new Verified snapshot; an expired Verified profile
+  // is re-attested in place. Both record the same sign-off provenance.
+  if (profile.status === 'verified') {
+    await fleetStore.reverifyProfile(profile.id, signoff)
+  } else {
+    await fleetStore.verifyProfile(profile.id, signoff)
+  }
+}
+
+function onCancelVerify(): void {
+  pendingVerify.value = null
+}
 
 // ─── UX-001: confirm-then-undo destructive delete ──────────────────────────
 // @IMP-AC-VIEW-019@ (FROM: @REQ-AC-001@)
@@ -264,10 +346,6 @@ function onSelectActive(profile: AircraftProfile): void {
   // Emit draft warning if profile is a Draft (REQ-AC-005)
   fleetStore.checkDraftWarning(profile)
   activeStore.setActiveProfile(profile)
-}
-
-async function onVerify(id: string): Promise<void> {
-  await fleetStore.verifyProfile(id)
 }
 
 function onEdit(id: string): void {
@@ -387,10 +465,29 @@ function onDismissUndo(): void {
 
 .profile-item__info {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.25rem;
   flex: 1;
   min-width: 0;
+}
+
+.profile-item__identity {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.profile-item__provenance {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.profile-item__provenance--expired {
+  color: var(--color-critical, #991b1b);
+  font-weight: 600;
 }
 
 .profile-item__registration {

--- a/frontend/src/modules/aircraft/components/ProfileStatusBadge.vue
+++ b/frontend/src/modules/aircraft/components/ProfileStatusBadge.vue
@@ -17,20 +17,34 @@ import type { AircraftProfileStatus } from '@/core/adapters/aircraft.schema'
 
 interface Props {
   status: AircraftProfileStatus
+  /**
+   * When the profile is `verified` but its sign-off has expired (aged out or
+   * source-changed), the badge surfaces an "Expired" state in the critical
+   * colour so a stale verification is not mistaken for a live one (REQ-AC-007).
+   * Omitted / false ⇒ the badge behaves exactly as the plain Draft/Verified badge.
+   */
+  expired?: boolean
 }
 
 const props = defineProps<Props>()
 
+const isExpired = computed(() => props.status === 'verified' && props.expired === true)
+
 const statusLabel = computed(() => {
+  if (isExpired.value) return 'Expired'
   return props.status === 'verified' ? 'Verified' : 'Draft'
 })
 
 const statusClass = computed(() => ({
-  'status-verified': props.status === 'verified',
+  'status-verified': props.status === 'verified' && !isExpired.value,
   'status-draft': props.status === 'draft',
+  'status-expired': isExpired.value,
 }))
 
 const statusTitle = computed(() => {
+  if (isExpired.value) {
+    return 'Verification has expired — re-verify against the current POH before safety-critical use.'
+  }
   if (props.status === 'verified') {
     return 'Profile has been verified and is safe for calculations.'
   }
@@ -61,5 +75,11 @@ const ariaLabel = computed(() => `Profile status: ${statusLabel.value}`)
   background-color: var(--color-warning-bg, #fef3c7);
   color: var(--color-warning, #92400e);
   border: 1px solid var(--color-warning, #fcd34d);
+}
+
+.status-expired {
+  background-color: var(--color-critical-bg, #fef2f2);
+  color: var(--color-critical, #991b1b);
+  border: 1px solid var(--color-critical, #fecaca);
 }
 </style>

--- a/frontend/src/modules/aircraft/components/VerifyProfileDialog.vue
+++ b/frontend/src/modules/aircraft/components/VerifyProfileDialog.vue
@@ -1,0 +1,279 @@
+<template>
+  <!-- @IMP-AC-VIEW-020@ (FROM: @REQ-AC-007@) -->
+  <!--
+    Verification sign-off modal (REQ-AC-007, H-011). Verifying a profile is no
+    longer a single un-attributed tap: the pilot must record who checked the
+    data, against which POH revision, and on what date. The provenance is bound
+    to the profile's active weighing report by the fleet store and later drives
+    expiry. Mirrors ConfirmDialog's focus/escape/backdrop behaviour.
+  -->
+  <Teleport to="body">
+    <div v-if="open" class="verify-dialog__backdrop" @click.self="onCancel">
+      <div
+        class="verify-dialog"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        @keydown.esc.prevent="onCancel"
+      >
+        <h2 :id="titleId" class="verify-dialog__title">Verify {{ registration }}</h2>
+        <p class="verify-dialog__intro">
+          Confirm you have checked this profile against the official POH/AFM. Your
+          sign-off is recorded with the profile.
+        </p>
+
+        <label class="verify-dialog__field">
+          <span class="verify-dialog__label">Verifier initials</span>
+          <input
+            ref="initialsEl"
+            v-model="verifiedBy"
+            type="text"
+            class="verify-dialog__input"
+            maxlength="10"
+            autocomplete="off"
+            aria-label="Verifier initials"
+            placeholder="e.g. JS"
+          />
+        </label>
+
+        <label class="verify-dialog__field">
+          <span class="verify-dialog__label">POH / AFM revision</span>
+          <input
+            v-model="pohRevision"
+            type="text"
+            class="verify-dialog__input"
+            maxlength="40"
+            autocomplete="off"
+            aria-label="POH revision"
+            placeholder="e.g. Rev 7"
+          />
+        </label>
+
+        <label class="verify-dialog__field">
+          <span class="verify-dialog__label">Verification date</span>
+          <input
+            v-model="verifiedOn"
+            type="date"
+            class="verify-dialog__input"
+            aria-label="Verification date"
+          />
+        </label>
+
+        <p v-if="!canConfirm" class="verify-dialog__hint" role="status">
+          Enter your initials and the POH revision to sign off.
+        </p>
+
+        <div class="verify-dialog__actions">
+          <button
+            ref="cancelBtn"
+            type="button"
+            class="verify-dialog__btn verify-dialog__btn--cancel"
+            @click="onCancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="verify-dialog__btn verify-dialog__btn--primary"
+            :disabled="!canConfirm"
+            @click="onConfirm"
+          >
+            Verify
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// @IMP-AC-VIEW-021@ (FROM: @REQ-AC-007@)
+import { computed, nextTick, ref, watch } from 'vue'
+import type { VerificationSignoff } from '../stores/fleet.store'
+
+let uid = 0
+const titleId = `verify-${++uid}-title`
+
+const props = defineProps<{
+  open: boolean
+  registration: string
+}>()
+
+const emit = defineEmits<{
+  confirm: [signoff: VerificationSignoff]
+  cancel: []
+}>()
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+const verifiedBy = ref('')
+const pohRevision = ref('')
+const verifiedOn = ref(todayIso())
+
+const initialsEl = ref<HTMLInputElement | null>(null)
+const cancelBtn = ref<HTMLButtonElement | null>(null)
+let lastFocused: HTMLElement | null = null
+
+const canConfirm = computed(
+  () => verifiedBy.value.trim() !== '' && pohRevision.value.trim() !== '' && verifiedOn.value !== '',
+)
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      // Reset the form each time the dialog opens so a prior attempt's text
+      // never leaks into a different aircraft's sign-off.
+      verifiedBy.value = ''
+      pohRevision.value = ''
+      verifiedOn.value = todayIso()
+      lastFocused = document.activeElement as HTMLElement | null
+      await nextTick()
+      initialsEl.value?.focus()
+    } else {
+      lastFocused?.focus?.()
+      lastFocused = null
+    }
+  },
+)
+
+function onConfirm(): void {
+  if (!canConfirm.value) return
+  emit('confirm', {
+    verifiedBy: verifiedBy.value.trim(),
+    pohRevision: pohRevision.value.trim(),
+    verifiedOn: verifiedOn.value,
+  })
+}
+
+function onCancel(): void {
+  emit('cancel')
+}
+</script>
+
+<style scoped>
+.verify-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4, 1rem);
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.verify-dialog {
+  width: 100%;
+  max-width: 28rem;
+  padding: var(--space-5, 1.5rem);
+  border-radius: var(--radius-xl, 12px);
+  background: var(--color-surface-card, var(--color-surface, #fff));
+  color: var(--color-text-primary, #212121);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--color-border, #e5e7eb);
+}
+
+.verify-dialog__title {
+  margin: 0 0 var(--space-2, 0.5rem);
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: 700;
+}
+
+.verify-dialog__intro {
+  margin: 0 0 var(--space-4, 1rem);
+  font-size: var(--text-sm, 0.875rem);
+  line-height: 1.5;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.verify-dialog__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 0.25rem);
+  margin-bottom: var(--space-3, 0.75rem);
+}
+
+.verify-dialog__label {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.verify-dialog__input {
+  min-height: 44px;
+  padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+  font: inherit;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #212121);
+}
+
+.verify-dialog__input:focus-visible {
+  outline: 2px solid var(--color-focus, var(--color-primary, #3b82f6));
+  outline-offset: 2px;
+  border-color: var(--color-primary, #3b82f6);
+}
+
+.verify-dialog__hint {
+  margin: 0 0 var(--space-3, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.verify-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3, 0.75rem);
+  flex-wrap: wrap;
+  margin-top: var(--space-2, 0.5rem);
+}
+
+.verify-dialog__btn {
+  min-height: 44px;
+  padding: var(--space-2, 0.5rem) var(--space-5, 1.5rem);
+  border-radius: var(--radius-md, 6px);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background var(--transition-fast, 150ms ease),
+    border-color var(--transition-fast, 150ms ease),
+    color var(--transition-fast, 150ms ease);
+}
+
+.verify-dialog__btn:focus-visible {
+  outline: 2px solid var(--color-focus, var(--color-primary, #3b82f6));
+  outline-offset: 2px;
+}
+
+.verify-dialog__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.verify-dialog__btn--cancel {
+  background: var(--color-surface-alt, #f3f4f6);
+  color: var(--color-text-primary, #212121);
+  border-color: var(--color-border, #e5e7eb);
+}
+
+.verify-dialog__btn--cancel:hover {
+  background: var(--color-surface-hover, #e5e7eb);
+}
+
+.verify-dialog__btn--primary {
+  background: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #fff);
+}
+
+.verify-dialog__btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-hover, var(--color-primary, #2563eb));
+}
+</style>

--- a/frontend/src/modules/aircraft/stores/fleet.store.ts
+++ b/frontend/src/modules/aircraft/stores/fleet.store.ts
@@ -52,6 +52,36 @@ export type FleetNotification = {
   message: string
 }
 
+/** Thrown when a verification sign-off is missing its mandatory provenance. */
+export class IncompleteSignoffError extends Error {
+  constructor() {
+    super('Verification requires verifier initials and the POH revision verified against.')
+    this.name = 'IncompleteSignoffError'
+  }
+}
+
+/**
+ * Sign-off provenance the pilot must supply to verify a profile (REQ-AC-007).
+ * `verifiedOn` defaults to today's calendar date when omitted; `sourceWeighingDate`
+ * is derived by the store from the profile's active weighing report.
+ */
+export interface VerificationSignoff {
+  verifiedBy: string
+  pohRevision: string
+  verifiedOn?: string
+}
+
+/** Today's calendar date as 'YYYY-MM-DD' (UTC). */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** The active (latest by `validFrom`) weighing report date for an aircraft profile. */
+function activeWeighingDate(profile: AircraftProfile): string {
+  return [...profile.weighingReports].sort((a, b) => b.validFrom.localeCompare(a.validFrom))[0]!
+    .validFrom
+}
+
 /** IndexedDB fleet hydration lifecycle for UI feedback (refs #158). */
 export type FleetLoadState = 'LOADING' | 'READY' | 'ERROR'
 
@@ -198,6 +228,8 @@ export const useFleetStore = defineStore('fleet', () => {
       ...changes,
       id,
       status: 'draft',
+      // A Draft is by definition unverified — never carry a stale sign-off (REQ-AC-007).
+      verification: undefined,
     })
 
     await fleetRepository.update(updated)
@@ -221,10 +253,17 @@ export const useFleetStore = defineStore('fleet', () => {
    * Creates a new immutable verified snapshot (new UUID, same data, status='verified').
    * Deletes the original Draft.
    *
+   * A verification sign-off (REQ-AC-007) is mandatory: the pilot must supply
+   * their initials and the POH revision checked against. The store stamps the
+   * provenance with the sign-off date (defaulting to today) and binds it to the
+   * profile's active weighing report, so a later source edit or an aged sign-off
+   * is detectable by {@link evaluateVerificationFreshness}.
+   *
    * SAFETY: The new Verified snapshot is written to IndexedDB before the Draft is removed.
    * If any step fails the fleet remains consistent.
    */
-  async function verifyProfile(id: string): Promise<AircraftProfile> {
+  // @IMP-AC-STORE-011@ (FROM: @REQ-AC-005@, @REQ-AC-007@)
+  async function verifyProfile(id: string, signoff: VerificationSignoff): Promise<AircraftProfile> {
     const draft = profiles.value.find((p) => p.id === id)
     if (!draft) {
       throw new Error(`Profile not found: ${id}`)
@@ -233,10 +272,22 @@ export const useFleetStore = defineStore('fleet', () => {
       throw new Error(`Profile "${id}" is already verified.`)
     }
 
+    const verifiedBy = signoff.verifiedBy.trim()
+    const pohRevision = signoff.pohRevision.trim()
+    if (verifiedBy === '' || pohRevision === '') {
+      throw new IncompleteSignoffError()
+    }
+
     const snapshot: AircraftProfile = AircraftProfileSchema.parse({
       ...draft,
       id: uuidv4(),
       status: 'verified',
+      verification: {
+        verifiedOn: signoff.verifiedOn?.trim() || todayIso(),
+        verifiedBy,
+        pohRevision,
+        sourceWeighingDate: activeWeighingDate(draft),
+      },
     })
 
     // Write the Verified snapshot first, then delete the Draft
@@ -253,6 +304,61 @@ export const useFleetStore = defineStore('fleet', () => {
     }
 
     return snapshot
+  }
+
+  /**
+   * Re-attest an already-Verified profile (REQ-AC-007).
+   *
+   * Used to refresh an *expired* or *source-changed* verification without
+   * touching the safety data: it re-stamps the provenance (new sign-off date,
+   * initials, POH revision) and re-binds it to the profile's current active
+   * weighing report, keeping the same id and `verified` status. This is a
+   * re-attestation, not a data mutation — the envelope/MTOM/weighing values are
+   * untouched, so it does not breach the Verified-data immutability contract.
+   */
+  // @IMP-AC-STORE-011@ (FROM: @REQ-AC-005@, @REQ-AC-007@)
+  async function reverifyProfile(
+    id: string,
+    signoff: VerificationSignoff,
+  ): Promise<AircraftProfile> {
+    const existing = profiles.value.find((p) => p.id === id)
+    if (!existing) {
+      throw new Error(`Profile not found: ${id}`)
+    }
+    if (existing.status !== 'verified') {
+      throw new Error(`Profile "${id}" is not verified — use verifyProfile() for draft profiles.`)
+    }
+
+    const verifiedBy = signoff.verifiedBy.trim()
+    const pohRevision = signoff.pohRevision.trim()
+    if (verifiedBy === '' || pohRevision === '') {
+      throw new IncompleteSignoffError()
+    }
+
+    const reattested: AircraftProfile = AircraftProfileSchema.parse({
+      ...existing,
+      id,
+      status: 'verified',
+      verification: {
+        verifiedOn: signoff.verifiedOn?.trim() || todayIso(),
+        verifiedBy,
+        pohRevision,
+        sourceWeighingDate: activeWeighingDate(existing),
+      },
+    })
+
+    await fleetRepository.update(reattested)
+    const idx = profiles.value.findIndex((p) => p.id === id)
+    if (idx !== -1) {
+      profiles.value[idx] = reattested
+    }
+
+    const activeStore = useActiveAircraftStore()
+    if (activeStore.activeProfile?.id === id) {
+      activeStore.setActiveProfile(reattested)
+    }
+
+    return reattested
   }
 
   /**
@@ -285,6 +391,9 @@ export const useFleetStore = defineStore('fleet', () => {
       ...changes,
       id,
       status: 'draft',
+      // Editing a Verified record invalidates its sign-off — drop the provenance
+      // so the new Draft cannot misrepresent stale verification (REQ-AC-007).
+      verification: undefined,
     })
 
     await fleetRepository.update(draftCopy)
@@ -327,6 +436,7 @@ export const useFleetStore = defineStore('fleet', () => {
     updateProfile,
     deleteProfile,
     verifyProfile,
+    reverifyProfile,
     editVerifiedProfile,
     checkDraftWarning,
     clearNotifications,

--- a/frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
+++ b/frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
@@ -9,7 +9,7 @@
       <div v-if="source" class="editor-subtitle">
         <strong>{{ source.registration }}</strong>
         — {{ source.manufacturer }} {{ source.model }}
-        <ProfileStatusBadge :status="source.status" />
+        <ProfileStatusBadge :status="source.status" :expired="sourceVerificationExpired" />
       </div>
     </header>
 
@@ -130,6 +130,7 @@ import type {
   AircraftProfileWeighingReport,
 } from '@/core/adapters/aircraft.schema'
 import { sortEnvelopeCcw } from '@/core/logic/envelope-sort'
+import { evaluateVerificationFreshness } from '@/core/logic/profile-verification'
 import { useFleetStore } from '../stores/fleet.store'
 import { validateIcaoRegistration } from '../services/profile.validator'
 import AccordionSection from '../components/AccordionSection.vue'
@@ -230,6 +231,13 @@ const loadPoints = computed<AircraftProfileLoadPoint[]>({
 })
 
 const isElectric = computed(() => draft.value?.powertrain === 'electric')
+
+// @IMP-AC-VIEW-023@ (FROM: @REQ-AC-007@)
+// Reflect an expired/source-changed sign-off in the header badge so the pilot
+// sees that the loaded Verified profile is no longer a live verification.
+const sourceVerificationExpired = computed(
+  () => source.value !== null && evaluateVerificationFreshness(source.value, new Date()).requiresReverification,
+)
 
 // Fallback seed mirrors the wizard's BatteryPackSection default — only used in
 // the unlikely case that a legacy electric profile slipped through without a

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -56,10 +56,44 @@ const isFleetEmpty = computed(
   () => fleetStore.fleetLoadState === 'READY' && fleetStore.profiles.length === 0,
 )
 
-/** Fleet profiles sorted alphabetically by registration for the picker. */
-const sortedProfiles = computed(() =>
-  [...fleetStore.profiles].sort((a, b) => a.registration.localeCompare(b.registration)),
+// @IMP-MB-VIEW-011@ (FROM: @REQ-AC-005@, @REQ-AC-007@)
+// Draft-aware aircraft picker (UX-005 / UX-007). The legacy alphabetical-only
+// list let a pilot pick an unverified Draft envelope with no grouping or guard.
+// The picker now: groups options into Verified / Draft <optgroup>s, surfaces the
+// last-used airframe in its own group at the top for quick re-selection, marks
+// Drafts with a destructive `[Draft]` tag, and routes a Draft selection through
+// an inline WARN-AC-002 acknowledgement before the profile is loaded for
+// computation (H-011 mitigation).
+
+function byRegistration(a: AircraftProfile, b: AircraftProfile): number {
+  return a.registration.localeCompare(b.registration)
+}
+
+/** The last-used airframe (the active aircraft), pinned at the top of the picker. */
+const lastUsedProfile = computed<AircraftProfile | null>(() => {
+  const id = activeAircraftStore.activeProfile?.id
+  if (!id) return null
+  return fleetStore.profiles.find((p) => p.id === id) ?? null
+})
+
+/** Verified fleet profiles, alphabetical by registration. */
+const verifiedProfiles = computed(() =>
+  fleetStore.profiles.filter((p) => p.status === 'verified').sort(byRegistration),
 )
+
+/** Draft fleet profiles, alphabetical by registration. */
+const draftProfiles = computed(() =>
+  fleetStore.profiles.filter((p) => p.status === 'draft').sort(byRegistration),
+)
+
+/** Option label — keeps the `[Draft]` suffix the E2E suite asserts on. */
+function optionLabel(aircraft: AircraftProfile): string {
+  const base = `${aircraft.registration} — ${aircraft.manufacturer} ${aircraft.model}`
+  return aircraft.status === 'draft' ? `${base} [Draft]` : base
+}
+
+/** A Draft awaiting the pilot's inline WARN-AC-002 acknowledgement before load. */
+const pendingDraft = ref<AircraftProfile | null>(null)
 
 // ---------------------------------------------------------------------------
 // Stacking sticky strips (REQ-UI-SCROLL)
@@ -491,15 +525,41 @@ function onAircraftSelected(event: Event): void {
   const fleetProfile = fleetStore.profiles.find((a) => a.id === id)
   if (!fleetProfile) return
 
+  // A Draft envelope must not be loaded for computation until the pilot
+  // explicitly acknowledges WARN-AC-002 inline (REQ-AC-005, H-011). The
+  // controlled `:value` binding reverts the <select> to the current aircraft
+  // until the acknowledgement resolves.
+  if (fleetProfile.status === 'draft') {
+    pendingDraft.value = fleetProfile
+    return
+  }
+
+  loadSelectedProfile(fleetProfile)
+}
+
+/** Map → validate → load a selected fleet profile into the M&B store. */
+function loadSelectedProfile(fleetProfile: AircraftProfile): void {
   const mapped = mapFleetProfileToContext(fleetProfile)
   const validation = AircraftContextSchema.safeParse(mapped)
   if (!validation.success) {
-    catalogueError.value = `Aircraft profile "${id}" failed validation — data may be corrupted.`
+    catalogueError.value = `Aircraft profile "${fleetProfile.id}" failed validation — data may be corrupted.`
     return
   }
 
   activeAircraftStore.setActiveProfile(fleetProfile)
   store.loadProfile(validation.data)
+}
+
+/** Pilot confirmed the WARN-AC-002 acknowledgement — load the Draft profile. */
+function onConfirmDraftSelection(): void {
+  const draft = pendingDraft.value
+  pendingDraft.value = null
+  if (draft) loadSelectedProfile(draft)
+}
+
+/** Pilot declined — leave the current aircraft loaded, drop the pending Draft. */
+function onCancelDraftSelection(): void {
+  pendingDraft.value = null
 }
 </script>
 
@@ -663,15 +723,52 @@ function onAircraftSelected(event: Event): void {
             @change="onAircraftSelected"
           >
             <option value="">— choose aircraft —</option>
-            <option
-              v-for="aircraft in sortedProfiles"
-              :key="aircraft.id"
-              :value="aircraft.id"
-            >
-              {{ aircraft.registration }} — {{ aircraft.manufacturer }} {{ aircraft.model
-              }}{{ aircraft.status === 'draft' ? ' [Draft]' : '' }}
-            </option>
+            <optgroup v-if="lastUsedProfile" label="Last used">
+              <option
+                :value="lastUsedProfile.id"
+                :class="{ 'opt-draft': lastUsedProfile.status === 'draft' }"
+              >
+                {{ optionLabel(lastUsedProfile) }}
+              </option>
+            </optgroup>
+            <optgroup v-if="verifiedProfiles.length > 0" label="Verified">
+              <option v-for="aircraft in verifiedProfiles" :key="aircraft.id" :value="aircraft.id">
+                {{ optionLabel(aircraft) }}
+              </option>
+            </optgroup>
+            <optgroup v-if="draftProfiles.length > 0" label="Draft">
+              <option
+                v-for="aircraft in draftProfiles"
+                :key="aircraft.id"
+                :value="aircraft.id"
+                class="opt-draft"
+              >
+                {{ optionLabel(aircraft) }}
+              </option>
+            </optgroup>
           </select>
+
+          <!-- Inline WARN-AC-002 acknowledgement before a Draft envelope loads -->
+          <div
+            v-if="pendingDraft"
+            class="draft-ack"
+            role="alertdialog"
+            aria-label="Draft profile acknowledgement"
+          >
+            <p class="draft-ack__message">
+              <strong>WARN-AC-002 — Draft Profile.</strong>
+              “{{ pendingDraft.registration }}” is unverified. Verify its data against the POH/AFM
+              before using it for a Go/No-Go decision.
+            </p>
+            <div class="draft-ack__actions">
+              <button type="button" class="draft-ack__btn draft-ack__btn--cancel" @click="onCancelDraftSelection">
+                Cancel
+              </button>
+              <button type="button" class="draft-ack__btn draft-ack__btn--continue" @click="onConfirmDraftSelection">
+                Continue with draft
+              </button>
+            </div>
+          </div>
         </div>
 
         <div v-if="categories.length > 1" class="aircraft-selector-field">
@@ -1349,6 +1446,67 @@ function onAircraftSelected(event: Event): void {
 
 .aircraft-select:hover {
   border-color: var(--color-primary);
+}
+
+/* Draft options carry the destructive colour where the browser honours
+ * <option> styling (Firefox; most Chromium/WebKit ignore it — the `[Draft]`
+ * suffix and the dedicated "Draft" optgroup remain the reliable signal). */
+.aircraft-select .opt-draft {
+  color: var(--color-critical, #dc2626);
+}
+
+/* ─── Inline draft acknowledgement (WARN-AC-002) ─────────────────────────── */
+
+.draft-ack {
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-warning, #fcd34d);
+  border-left: 4px solid var(--color-warning, #f59e0b);
+  border-radius: var(--radius-md);
+  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.draft-ack__message {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.draft-ack__actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.draft-ack__btn {
+  min-height: 44px;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.draft-ack__btn:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.draft-ack__btn--cancel {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+
+.draft-ack__btn--continue {
+  background: var(--color-warning, #d97706);
+  color: var(--neutral-0, #fff);
 }
 
 .aircraft-select:focus-visible {

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -9,6 +9,11 @@ import { useActiveAircraftStore } from '@/modules/aircraft/stores/active-aircraf
 import { useSessionPersistenceStore } from '@/stores/session-persistence.store'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
 import type { SessionDropNotification } from '@/stores/session-persistence.store'
+import {
+  VERIFICATION_VALIDITY_DAYS,
+  evaluateVerificationFreshness,
+  type VerificationFreshness,
+} from '@/core/logic/profile-verification'
 import InputGroupCard from '@/modules/mass-balance/components/InputGroupCard.vue'
 import MassStationInput from '@/modules/mass-balance/components/MassStationInput.vue'
 import CGEnvelopeChart from '@/modules/mass-balance/components/CGEnvelopeChart.vue'
@@ -64,9 +69,26 @@ const isFleetEmpty = computed(
 // Drafts with a destructive `[Draft]` tag, and routes a Draft selection through
 // an inline WARN-AC-002 acknowledgement before the profile is loaded for
 // computation (H-011 mitigation).
+//
+// A Verified profile whose sign-off has *expired* — aged past the validity
+// window or bound to a weighing report that has since changed — is treated as
+// unverified at this Go/No-Go entry point (REQ-AC-007): it is marked `[Expired]`
+// destructively and routed through the same inline acknowledgement before load,
+// so an expired envelope can never reach the M&B store silently. The same gate
+// guards the on-mount auto-load / session-restore path below.
 
 function byRegistration(a: AircraftProfile, b: AircraftProfile): number {
   return a.registration.localeCompare(b.registration)
+}
+
+/** Freshness of a profile's verification, evaluated against the current date. */
+function freshnessFor(profile: AircraftProfile): VerificationFreshness {
+  return evaluateVerificationFreshness(profile, new Date())
+}
+
+/** A Verified profile whose sign-off is expired/stale and must be re-verified before use. */
+function isExpiredVerified(profile: AircraftProfile): boolean {
+  return profile.status === 'verified' && freshnessFor(profile).requiresReverification
 }
 
 /** The last-used airframe (the active aircraft), pinned at the top of the picker. */
@@ -86,14 +108,67 @@ const draftProfiles = computed(() =>
   fleetStore.profiles.filter((p) => p.status === 'draft').sort(byRegistration),
 )
 
-/** Option label — keeps the `[Draft]` suffix the E2E suite asserts on. */
+/** Option label — keeps the `[Draft]` suffix the E2E suite asserts on; an expired Verified profile is marked `[Expired]`. */
 function optionLabel(aircraft: AircraftProfile): string {
   const base = `${aircraft.registration} — ${aircraft.manufacturer} ${aircraft.model}`
-  return aircraft.status === 'draft' ? `${base} [Draft]` : base
+  if (aircraft.status === 'draft') return `${base} [Draft]`
+  if (isExpiredVerified(aircraft)) return `${base} [Expired]`
+  return base
 }
 
-/** A Draft awaiting the pilot's inline WARN-AC-002 acknowledgement before load. */
-const pendingDraft = ref<AircraftProfile | null>(null)
+/**
+ * Why a selection must be acknowledged before it loads into the M&B store:
+ * `draft` (unverified) or an expired Verified sign-off (aged / source-changed),
+ * which REQ-AC-007 requires be surfaced as unverified for safety-critical use.
+ */
+type PendingReason = 'draft' | 'expired-aged' | 'expired-source-changed'
+
+interface PendingSelection {
+  readonly profile: AircraftProfile
+  readonly reason: PendingReason
+}
+
+/** A selection awaiting the pilot's inline acknowledgement before load (H-011, REQ-AC-005/007). */
+const pendingSelection = ref<PendingSelection | null>(null)
+
+/**
+ * A restored session payload held back until its (expired/draft) profile is
+ * acknowledged. Applied on confirm; discarded — with the stale session — on cancel.
+ */
+const pendingRestoredPayload = ref<ReturnType<
+  typeof sessionPersistenceStore.restoreSession
+> | null>(null)
+
+/** Reason a profile must be gated before load, or null when it may load directly. */
+function guardReasonFor(profile: AircraftProfile): PendingReason | null {
+  if (profile.status === 'draft') return 'draft'
+  const f = freshnessFor(profile)
+  if (f.state === 'expired-aged' || f.state === 'expired-source-changed') return f.state
+  return null
+}
+
+/** Heading + body for the inline acknowledgement, derived from the pending reason. */
+const pendingAck = computed(() => {
+  const p = pendingSelection.value
+  if (!p) return null
+  const reg = p.profile.registration
+  if (p.reason === 'draft') {
+    return {
+      heading: 'WARN-AC-002 — Draft Profile.',
+      body: `“${reg}” is unverified. Verify its data against the POH/AFM before using it for a Go/No-Go decision.`,
+    }
+  }
+  if (p.reason === 'expired-source-changed') {
+    return {
+      heading: 'Verification expired.',
+      body: `“${reg}” was verified, but its source weighing report has since changed. Re-verify it against the POH/AFM before using it for a Go/No-Go decision.`,
+    }
+  }
+  return {
+    heading: 'Verification expired.',
+    body: `“${reg}” was verified more than ${VERIFICATION_VALIDITY_DAYS} days ago. Re-verify it against the POH/AFM before using it for a Go/No-Go decision.`,
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Stacking sticky strips (REQ-UI-SCROLL)
@@ -305,7 +380,14 @@ onMounted(async () => {
     // In-memory active aircraft survives SPA navigation but not a full reload.
     const active = activeAircraftStore.activeProfile
     if (active) {
-      loadProfileIntoStore(active)
+      // An expired/draft active aircraft must be re-acknowledged as unverified
+      // before it silently reloads into the Go/No-Go view (REQ-AC-007, H-011).
+      const reason = guardReasonFor(active)
+      if (reason) {
+        pendingSelection.value = { profile: active, reason }
+      } else {
+        loadProfileIntoStore(active)
+      }
     } else {
       // Full-reload path: attempt to restore the pilot's last session from
       // localStorage. An invalid/stale payload has already been cleared by
@@ -313,13 +395,23 @@ onMounted(async () => {
       const payload = sessionPersistenceStore.restoreSession()
       if (payload) {
         const fleetProfile = fleetStore.profiles.find((p) => p.id === payload.aircraftId)
-        if (fleetProfile && loadProfileIntoStore(fleetProfile)) {
-          activeAircraftStore.setActiveProfile(fleetProfile)
-          store.applyRestoredSession(payload)
-        } else {
+        if (!fleetProfile) {
           // Aircraft no longer in the fleet (deleted between sessions) —
           // discard the payload so it doesn't haunt future reloads.
           sessionPersistenceStore.clearSession()
+        } else {
+          const reason = guardReasonFor(fleetProfile)
+          if (reason) {
+            // Defer the restore behind the acknowledgement: an expired/draft
+            // profile must not silently reload into the Go/No-Go view.
+            pendingSelection.value = { profile: fleetProfile, reason }
+            pendingRestoredPayload.value = payload
+          } else if (loadProfileIntoStore(fleetProfile)) {
+            activeAircraftStore.setActiveProfile(fleetProfile)
+            store.applyRestoredSession(payload)
+          } else {
+            sessionPersistenceStore.clearSession()
+          }
         }
       }
       // Drain any drop notification produced by `restoreSession()` and surface
@@ -525,12 +617,13 @@ function onAircraftSelected(event: Event): void {
   const fleetProfile = fleetStore.profiles.find((a) => a.id === id)
   if (!fleetProfile) return
 
-  // A Draft envelope must not be loaded for computation until the pilot
-  // explicitly acknowledges WARN-AC-002 inline (REQ-AC-005, H-011). The
-  // controlled `:value` binding reverts the <select> to the current aircraft
-  // until the acknowledgement resolves.
-  if (fleetProfile.status === 'draft') {
-    pendingDraft.value = fleetProfile
+  // A Draft, or a Verified profile whose sign-off has expired, must not be
+  // loaded for computation until the pilot explicitly acknowledges it inline
+  // (REQ-AC-005/007, H-011). The controlled `:value` binding reverts the
+  // <select> to the current aircraft until the acknowledgement resolves.
+  const reason = guardReasonFor(fleetProfile)
+  if (reason) {
+    pendingSelection.value = { profile: fleetProfile, reason }
     return
   }
 
@@ -539,6 +632,11 @@ function onAircraftSelected(event: Event): void {
 
 /** Map → validate → load a selected fleet profile into the M&B store. */
 function loadSelectedProfile(fleetProfile: AircraftProfile): void {
+  // Loading a profile resolves any pending acknowledgement — clearing it here
+  // also dismisses a stale banner if the pilot picks a clean profile while one
+  // is still showing.
+  pendingSelection.value = null
+
   const mapped = mapFleetProfileToContext(fleetProfile)
   const validation = AircraftContextSchema.safeParse(mapped)
   if (!validation.success) {
@@ -550,16 +648,27 @@ function loadSelectedProfile(fleetProfile: AircraftProfile): void {
   store.loadProfile(validation.data)
 }
 
-/** Pilot confirmed the WARN-AC-002 acknowledgement — load the Draft profile. */
-function onConfirmDraftSelection(): void {
-  const draft = pendingDraft.value
-  pendingDraft.value = null
-  if (draft) loadSelectedProfile(draft)
+/** Pilot confirmed the acknowledgement — load the gated (draft/expired) profile. */
+function onConfirmSelection(): void {
+  const pending = pendingSelection.value
+  const payload = pendingRestoredPayload.value
+  pendingSelection.value = null
+  pendingRestoredPayload.value = null
+  if (!pending) return
+  loadSelectedProfile(pending.profile)
+  // Restored station weights are re-applied only once the profile loads cleanly.
+  if (payload && store.aircraft) store.applyRestoredSession(payload)
 }
 
-/** Pilot declined — leave the current aircraft loaded, drop the pending Draft. */
-function onCancelDraftSelection(): void {
-  pendingDraft.value = null
+/** Pilot declined — leave the current aircraft loaded, drop the pending selection. */
+function onCancelSelection(): void {
+  pendingSelection.value = null
+  // Declining a deferred restore discards the stale session so it doesn't
+  // reload on the next mount.
+  if (pendingRestoredPayload.value) {
+    pendingRestoredPayload.value = null
+    sessionPersistenceStore.clearSession()
+  }
 }
 </script>
 
@@ -726,13 +835,20 @@ function onCancelDraftSelection(): void {
             <optgroup v-if="lastUsedProfile" label="Last used">
               <option
                 :value="lastUsedProfile.id"
-                :class="{ 'opt-draft': lastUsedProfile.status === 'draft' }"
+                :class="{
+                  'opt-draft': lastUsedProfile.status === 'draft' || isExpiredVerified(lastUsedProfile),
+                }"
               >
                 {{ optionLabel(lastUsedProfile) }}
               </option>
             </optgroup>
             <optgroup v-if="verifiedProfiles.length > 0" label="Verified">
-              <option v-for="aircraft in verifiedProfiles" :key="aircraft.id" :value="aircraft.id">
+              <option
+                v-for="aircraft in verifiedProfiles"
+                :key="aircraft.id"
+                :value="aircraft.id"
+                :class="{ 'opt-draft': isExpiredVerified(aircraft) }"
+              >
                 {{ optionLabel(aircraft) }}
               </option>
             </optgroup>
@@ -748,24 +864,25 @@ function onCancelDraftSelection(): void {
             </optgroup>
           </select>
 
-          <!-- Inline WARN-AC-002 acknowledgement before a Draft envelope loads -->
+          <!-- Inline acknowledgement before an unverified (draft) or expired
+               Verified envelope loads — both are gated at this Go/No-Go entry
+               point (REQ-AC-005/007, H-011). -->
           <div
-            v-if="pendingDraft"
+            v-if="pendingAck"
             class="draft-ack"
             role="alertdialog"
-            aria-label="Draft profile acknowledgement"
+            aria-label="Unverified profile acknowledgement"
           >
             <p class="draft-ack__message">
-              <strong>WARN-AC-002 — Draft Profile.</strong>
-              “{{ pendingDraft.registration }}” is unverified. Verify its data against the POH/AFM
-              before using it for a Go/No-Go decision.
+              <strong>{{ pendingAck.heading }}</strong>
+              {{ pendingAck.body }}
             </p>
             <div class="draft-ack__actions">
-              <button type="button" class="draft-ack__btn draft-ack__btn--cancel" @click="onCancelDraftSelection">
+              <button type="button" class="draft-ack__btn draft-ack__btn--cancel" @click="onCancelSelection">
                 Cancel
               </button>
-              <button type="button" class="draft-ack__btn draft-ack__btn--continue" @click="onConfirmDraftSelection">
-                Continue with draft
+              <button type="button" class="draft-ack__btn draft-ack__btn--continue" @click="onConfirmSelection">
+                Continue anyway
               </button>
             </div>
           </div>

--- a/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+++ b/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
@@ -368,4 +368,96 @@ describe('MassBalanceView — fleet picker', () => {
     expect(loadSpy).not.toHaveBeenCalled()
     expect(wrapper.find('.draft-ack').exists()).toBe(false)
   })
+
+  // ── 7. Expired-verification gate at the Go/No-Go entry point (REQ-AC-007) ──
+  //
+  // An expired (aged-out or source-changed) Verified profile must be treated as
+  // unverified at the picker: marked destructively and gated behind the same
+  // inline acknowledgement, never loaded silently into the M&B store (H-011).
+
+  /** A Verified profile whose 2020 sign-off is long past the 90-day window. */
+  function buildExpiredVerified(overrides: Partial<AircraftProfile> = {}): AircraftProfile {
+    return buildFleetProfile({
+      id: 'dddddddd-0000-4000-d000-000000000004',
+      registration: 'D-EXPIRD',
+      status: 'verified',
+      verification: {
+        verifiedOn: '2020-01-01',
+        verifiedBy: 'JS',
+        pohRevision: 'Rev 1',
+        // Matches the default weighing report's validFrom so the only failure is age.
+        sourceWeighingDate: '2025-01-01',
+      },
+      ...overrides,
+    })
+  }
+
+  // @UT-MB-VIEW-027@ (FROM: @IMP-MB-VIEW-011@)
+  it('marks an expired Verified profile with an [Expired] suffix in the picker', () => {
+    const expired = buildExpiredVerified()
+    seedFleet([expired])
+    const wrapper = mountView()
+
+    const option = wrapper
+      .findAll('select#aircraft-select option')
+      .find((o) => o.attributes('value') === expired.id)
+    expect(option?.text()).toContain('[Expired]')
+    expect(option?.text()).not.toContain('[Draft]')
+  })
+
+  // @UT-MB-VIEW-028@ (FROM: @IMP-MB-VIEW-011@)
+  it('does NOT load an expired Verified profile on selection — shows the inline acknowledgement first', async () => {
+    const expired = buildExpiredVerified()
+    seedFleet([expired])
+
+    const mbStore = useMassBalanceStore()
+    const activeStore = useActiveAircraftStore()
+    const loadSpy = vi.spyOn(mbStore, 'loadProfile')
+    const setActiveSpy = vi.spyOn(activeStore, 'setActiveProfile')
+
+    const wrapper = mountView()
+    await wrapper.find('select#aircraft-select').setValue(expired.id)
+
+    expect(loadSpy).not.toHaveBeenCalled()
+    expect(setActiveSpy).not.toHaveBeenCalled()
+    const ack = wrapper.find('.draft-ack')
+    expect(ack.exists()).toBe(true)
+    expect(ack.text()).toContain('Verification expired')
+    expect(ack.text()).toContain('D-EXPIRD')
+  })
+
+  // @UT-MB-VIEW-029@ (FROM: @IMP-MB-VIEW-011@)
+  it('loads the expired Verified profile only after the acknowledgement is confirmed', async () => {
+    const expired = buildExpiredVerified()
+    seedFleet([expired])
+
+    const mbStore = useMassBalanceStore()
+    const activeStore = useActiveAircraftStore()
+    const loadSpy = vi.spyOn(mbStore, 'loadProfile')
+    const setActiveSpy = vi.spyOn(activeStore, 'setActiveProfile')
+
+    const wrapper = mountView()
+    await wrapper.find('select#aircraft-select').setValue(expired.id)
+    await wrapper.find('.draft-ack__btn--continue').trigger('click')
+
+    expect(setActiveSpy).toHaveBeenCalledWith(expired)
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('.draft-ack').exists()).toBe(false)
+  })
+
+  // @UT-MB-VIEW-030@ (FROM: @IMP-MB-VIEW-011@)
+  it('cancelling the acknowledgement leaves an expired Verified profile unloaded', async () => {
+    const expired = buildExpiredVerified()
+    seedFleet([expired])
+
+    const mbStore = useMassBalanceStore()
+    const loadSpy = vi.spyOn(mbStore, 'loadProfile')
+
+    const wrapper = mountView()
+    await wrapper.find('select#aircraft-select').setValue(expired.id)
+    await wrapper.find('.draft-ack__btn--cancel').trigger('click')
+
+    expect(loadSpy).not.toHaveBeenCalled()
+    expect(wrapper.find('.draft-ack').exists()).toBe(false)
+  })
 })

--- a/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+++ b/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
@@ -284,4 +284,88 @@ describe('MassBalanceView — fleet picker', () => {
 
     expect(loadAllSpy).toHaveBeenCalledTimes(1)
   })
+
+  // ── 6. Draft-aware grouping + inline acknowledgement (REQ-AC-005/007) ──────
+
+  // @UT-MB-VIEW-022@ (FROM: @IMP-MB-VIEW-011@)
+  it('groups picker options into Verified and Draft optgroups', () => {
+    const draft = buildFleetProfile({ id: 'bbbbbbbb-0000-4000-b000-000000000002', registration: 'D-DRAFT', status: 'draft' })
+    const verified = buildFleetProfile({ id: 'aaaaaaaa-0000-4000-a000-000000000001', registration: 'D-VERIF', status: 'verified' })
+    seedFleet([draft, verified])
+    const wrapper = mountView()
+
+    const labels = wrapper.findAll('select#aircraft-select optgroup').map((g) => g.attributes('label'))
+    expect(labels).toContain('Verified')
+    expect(labels).toContain('Draft')
+  })
+
+  // @UT-MB-VIEW-023@ (FROM: @IMP-MB-VIEW-011@)
+  it('surfaces the active aircraft in a Last used optgroup at the top', () => {
+    const profile = buildFleetProfile()
+    seedFleet([profile])
+    const activeStore = useActiveAircraftStore()
+    activeStore.activeProfile = profile
+    const wrapper = mountView()
+
+    const groups = wrapper.findAll('select#aircraft-select optgroup')
+    expect(groups[0]!.attributes('label')).toBe('Last used')
+    expect(groups[0]!.find('option').attributes('value')).toBe(profile.id)
+  })
+
+  // @UT-MB-VIEW-024@ (FROM: @IMP-MB-VIEW-011@)
+  it('does NOT load a Draft on selection — shows the inline WARN-AC-002 acknowledgement first', async () => {
+    const draft = buildFleetProfile({ id: 'bbbbbbbb-0000-4000-b000-000000000002', registration: 'D-DRAFT', status: 'draft' })
+    seedFleet([draft])
+
+    const mbStore = useMassBalanceStore()
+    const activeStore = useActiveAircraftStore()
+    const loadSpy = vi.spyOn(mbStore, 'loadProfile')
+    const setActiveSpy = vi.spyOn(activeStore, 'setActiveProfile')
+
+    const wrapper = mountView()
+    await wrapper.find('select#aircraft-select').setValue(draft.id)
+
+    // Draft is NOT loaded until acknowledged.
+    expect(loadSpy).not.toHaveBeenCalled()
+    expect(setActiveSpy).not.toHaveBeenCalled()
+    const ack = wrapper.find('.draft-ack')
+    expect(ack.exists()).toBe(true)
+    expect(ack.text()).toContain('WARN-AC-002')
+    expect(ack.text()).toContain('D-DRAFT')
+  })
+
+  // @UT-MB-VIEW-025@ (FROM: @IMP-MB-VIEW-011@)
+  it('loads the Draft only after the acknowledgement is confirmed', async () => {
+    const draft = buildFleetProfile({ id: 'bbbbbbbb-0000-4000-b000-000000000002', registration: 'D-DRAFT', status: 'draft' })
+    seedFleet([draft])
+
+    const mbStore = useMassBalanceStore()
+    const activeStore = useActiveAircraftStore()
+    const loadSpy = vi.spyOn(mbStore, 'loadProfile')
+    const setActiveSpy = vi.spyOn(activeStore, 'setActiveProfile')
+
+    const wrapper = mountView()
+    await wrapper.find('select#aircraft-select').setValue(draft.id)
+    await wrapper.find('.draft-ack__btn--continue').trigger('click')
+
+    expect(setActiveSpy).toHaveBeenCalledWith(draft)
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('.draft-ack').exists()).toBe(false)
+  })
+
+  // @UT-MB-VIEW-026@ (FROM: @IMP-MB-VIEW-011@)
+  it('cancelling the acknowledgement leaves the Draft unloaded', async () => {
+    const draft = buildFleetProfile({ id: 'bbbbbbbb-0000-4000-b000-000000000002', registration: 'D-DRAFT', status: 'draft' })
+    seedFleet([draft])
+
+    const mbStore = useMassBalanceStore()
+    const loadSpy = vi.spyOn(mbStore, 'loadProfile')
+
+    const wrapper = mountView()
+    await wrapper.find('select#aircraft-select').setValue(draft.id)
+    await wrapper.find('.draft-ack__btn--cancel').trigger('click')
+
+    expect(loadSpy).not.toHaveBeenCalled()
+    expect(wrapper.find('.draft-ack').exists()).toBe(false)
+  })
 })

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
@@ -27,6 +27,20 @@ Feature: Fleet-based aircraft selection on the Flight Prep page
     When the pilot selects the "D-EBPN" aircraft from the dropdown
     Then the M&B section becomes unlocked
 
+  # @E2E-B-011@ (FROM: @UJ-B-005@)
+  # @wip: depends on the wizard-creation flow (completeWizardFlow helper), which is
+  # not yet stable end-to-end — un-wip together with aircraft-wizard-creation.feature.
+  @wip @UJ-B-005 @phase-B @e2e @E2E-B-011
+  Scenario: Selecting a draft aircraft requires acknowledging the unverified-data warning
+    Given the pilot has added an aircraft with registration "D-EBPN" via the wizard
+    When the pilot navigates to the Flight Prep page
+    And the pilot selects the "D-EBPN" aircraft from the dropdown
+    Then an inline draft acknowledgement warning is shown
+    And the Mass & Balance section remains locked
+
+    When the pilot acknowledges the draft warning to continue
+    Then the M&B section becomes unlocked
+
   # @E2E-B-010@ (FROM: @UJ-B-005@)
   @UJ-B-005 @phase-B @e2e @E2E-B-010
   Scenario: Hardcoded catalogue aircraft are not in the dropdown when the fleet is empty — regression against AIRCRAFT_CATALOGUE leak

--- a/frontend/tests/e2e/steps/flight-prep-fleet.steps.ts
+++ b/frontend/tests/e2e/steps/flight-prep-fleet.steps.ts
@@ -92,6 +92,22 @@ Then('the M&B section becomes unlocked', async ({ page }) => {
   await expect(page.getByRole('region', { name: /Mass and Balance/i })).toBeVisible()
 })
 
+// ─── Draft acknowledgement (REQ-AC-005 / REQ-AC-007, WARN-AC-002) ──────────
+
+Then('an inline draft acknowledgement warning is shown', async ({ page }) => {
+  const ack = page.locator('.draft-ack')
+  await expect(ack).toBeVisible()
+  await expect(ack).toContainText('WARN-AC-002')
+})
+
+Then('the Mass & Balance section remains locked', async ({ page }) => {
+  await expect(page.locator('.locked-placeholder')).toBeVisible()
+})
+
+When('the pilot acknowledges the draft warning to continue', async ({ page }) => {
+  await page.locator('.draft-ack__btn--continue').click()
+})
+
 // ─── Catalogue leak regression assertions ─────────────────────────────────
 
 Then(

--- a/trace/e2e/flight-prep.yaml
+++ b/trace/e2e/flight-prep.yaml
@@ -51,7 +51,7 @@ Phase B End-to-End Tests
 
 B (auto)
   E2E-B-011
-    title: TODO: describe this artifact
+    title: Selecting a draft aircraft requires acknowledging the unverified-data warning
     files:
       - frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
     uj:

--- a/trace/e2e/flight-prep.yaml
+++ b/trace/e2e/flight-prep.yaml
@@ -48,3 +48,11 @@ Phase B End-to-End Tests
     title: Hardcoded catalogue aircraft are not in the dropdown when the fleet is empty
     files:
       - frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+
+B (auto)
+  E2E-B-011
+    title: TODO: describe this artifact
+    files:
+      - frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+    uj:
+      - UJ-B-005

--- a/trace/hazards/hazards.yaml
+++ b/trace/hazards/hazards.yaml
@@ -99,6 +99,7 @@ Safety Hazards
     status: Mitigated
     mitigated_by:
       - REQ-AC-005
+      - REQ-AC-007
       - REQ-UI-023
       - REQ-UQ-006
 

--- a/trace/implementation/ac.yaml
+++ b/trace/implementation/ac.yaml
@@ -19,6 +19,20 @@ AC Core — Aircraft Profile Schema
     files:
       - frontend/src/core/adapters/aircraft.schema.ts
 
+  IMP-AC-CORE-004
+    title: VerificationProvenanceSchema — verifiedOn/verifiedBy/pohRevision/sourceWeighingDate sign-off block (REQ-AC-007)
+    req:
+      - REQ-AC-007
+    files:
+      - frontend/src/core/adapters/aircraft.schema.ts
+
+  IMP-AC-CORE-005
+    title: evaluateVerificationFreshness — pure draft/fresh/expired-aged/expired-source-changed verification freshness evaluation (REQ-AC-007, H-011)
+    req:
+      - REQ-AC-007
+    files:
+      - frontend/src/core/logic/profile-verification.ts
+
 AC Store — Fleet Repository
   IMP-AC-STORE-001
     title: Fleet Repository — IndexedDB CRUD persistence layer for AircraftProfile documents
@@ -73,6 +87,14 @@ AC Store — Fleet Repository
       - REQ-AC-005
     files:
       - frontend/src/modules/aircraft/stores/active-aircraft.store.ts
+
+  IMP-AC-STORE-011
+    title: verifyProfile / reverifyProfile sign-off — records verification provenance (date/initials/POH rev) bound to the active weighing report, re-attests in place, and strips it on Verified→Draft
+    req:
+      - REQ-AC-005
+      - REQ-AC-007
+    files:
+      - frontend/src/modules/aircraft/stores/fleet.store.ts
 
 AC Core — schemaVersion Migration Registry (#259)
   IMP-AC-CORE-003
@@ -284,6 +306,35 @@ AC View — Model Catalogue and Components
       - REQ-AC-001
     files:
       - frontend/src/modules/aircraft/components/FleetList.vue
+
+AC View — Verification Provenance (REQ-AC-007)
+  IMP-AC-VIEW-020
+    title: VerifyProfileDialog template — sign-off capture modal (initials, POH revision, date)
+    req:
+      - REQ-AC-007
+    files:
+      - frontend/src/modules/aircraft/components/VerifyProfileDialog.vue
+
+  IMP-AC-VIEW-021
+    title: VerifyProfileDialog script — sign-off form state, validation, and confirm/cancel emit
+    req:
+      - REQ-AC-007
+    files:
+      - frontend/src/modules/aircraft/components/VerifyProfileDialog.vue
+
+  IMP-AC-VIEW-022
+    title: FleetList verification provenance — per-profile freshness line, Expired badge, and verify/re-verify wiring
+    req:
+      - REQ-AC-007
+    files:
+      - frontend/src/modules/aircraft/components/FleetList.vue
+
+  IMP-AC-VIEW-023
+    title: AircraftProfileEditorView — header badge reflects expired/source-changed verification
+    req:
+      - REQ-AC-007
+    files:
+      - frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
 
 AC (auto)
   IMP-AC-VIEW-031

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -404,6 +404,14 @@ MB (auto)
     req:
       - REQ-AD-020
 
+  IMP-MB-VIEW-011
+    title: Draft-aware aircraft picker — Verified/Draft/Last-used optgroups, destructive [Draft] marker, inline WARN-AC-002 acknowledgement before loading a Draft
+    files:
+      - frontend/src/modules/mass-balance/views/MassBalanceView.vue
+    req:
+      - REQ-AC-005
+      - REQ-AC-007
+
   IMP-MB-STORE-023
     title: Zero-Value Plausibility Warning (WARN-UQ-001) for mandatory non-fuel stations
     files:

--- a/trace/journeys/a.yaml
+++ b/trace/journeys/a.yaml
@@ -5,6 +5,7 @@ Phase A — Fleet Management & Setup
     req:
       - REQ-AC-001
       - REQ-AC-005
+      - REQ-AC-007
       - REQ-AD-005
       - REQ-AD-012
       - REQ-AD-014

--- a/trace/requirements/ac.yaml
+++ b/trace/requirements/ac.yaml
@@ -24,3 +24,9 @@ Aircraft Management Requirements
   REQ-AC-006
     title: Passenger Profiles
     file: docs/requirements/aircraft_management.md
+
+  REQ-AC-007
+    title: Verification Provenance & Expiry
+    file: docs/requirements/aircraft_management.md
+    hazard:
+      - H-011

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -1857,3 +1857,242 @@ AC (auto)
     title: TODO: describe this artifact
     files:
       - frontend/src/modules/aircraft/__tests__/IdentitySection.spec.ts
+
+  UT-AC-CORE-116
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+    impl:
+      - IMP-AC-CORE-004
+
+  UT-AC-CORE-117
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+    impl:
+      - IMP-AC-CORE-004
+
+  UT-AC-CORE-118
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+    impl:
+      - IMP-AC-CORE-004
+
+  UT-AC-CORE-119
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+    impl:
+      - IMP-AC-CORE-004
+
+  UT-AC-CORE-104
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-105
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-106
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-107
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-108
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-109
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-110
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-111
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-112
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-113
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-114
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-CORE-115
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/core/logic/profile-verification.spec.ts
+    impl:
+      - IMP-AC-CORE-005
+
+  UT-AC-VIEW-172
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+    impl:
+      - IMP-AC-VIEW-022
+
+  UT-AC-VIEW-173
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+    impl:
+      - IMP-AC-VIEW-022
+
+  UT-AC-VIEW-174
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+    impl:
+      - IMP-AC-VIEW-022
+
+  UT-AC-VIEW-175
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+    impl:
+      - IMP-AC-VIEW-022
+
+  UT-AC-VIEW-176
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
+    impl:
+      - IMP-AC-VIEW-022
+
+  UT-AC-VIEW-181
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
+    impl:
+      - IMP-AC-VIEW-004
+
+  UT-AC-VIEW-182
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
+    impl:
+      - IMP-AC-VIEW-004
+
+  UT-AC-VIEW-177
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
+    impl:
+      - IMP-AC-VIEW-020
+      - IMP-AC-VIEW-021
+
+  UT-AC-VIEW-178
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
+    impl:
+      - IMP-AC-VIEW-021
+
+  UT-AC-VIEW-179
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
+    impl:
+      - IMP-AC-VIEW-021
+
+  UT-AC-VIEW-180
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
+    impl:
+      - IMP-AC-VIEW-021
+
+  UT-AC-STORE-129
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011
+
+  UT-AC-STORE-130
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011
+
+  UT-AC-STORE-131
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011
+
+  UT-AC-STORE-132
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011
+
+  UT-AC-STORE-133
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011
+
+  UT-AC-STORE-134
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011
+
+  UT-AC-STORE-135
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
+    impl:
+      - IMP-AC-STORE-011

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -1859,168 +1859,175 @@ AC (auto)
       - frontend/src/modules/aircraft/__tests__/IdentitySection.spec.ts
 
   UT-AC-CORE-116
-    title: TODO: describe this artifact
+    title: accepts a Verified profile carrying a full verification block
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
     impl:
       - IMP-AC-CORE-004
 
   UT-AC-CORE-117
-    title: TODO: describe this artifact
+    title: leaves verification undefined when omitted (optional for legacy records)
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
     impl:
       - IMP-AC-CORE-004
 
   UT-AC-CORE-118
-    title: TODO: describe this artifact
+    title: rejects a verifiedOn that is not a YYYY-MM-DD calendar date
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
     impl:
       - IMP-AC-CORE-004
 
   UT-AC-CORE-119
-    title: TODO: describe this artifact
+    title: rejects empty verifiedBy / pohRevision and over-long values
+    files:
+      - frontend/src/core/adapters/aircraft.schema.spec.ts
+    impl:
+      - IMP-AC-CORE-004
+
+  UT-AC-CORE-120
+    title: rejects a verifiedOn that is well-formed but an impossible calendar date
     files:
       - frontend/src/core/adapters/aircraft.schema.spec.ts
     impl:
       - IMP-AC-CORE-004
 
   UT-AC-CORE-104
-    title: TODO: describe this artifact
+    title: profile verification freshness — unit suite for evaluateVerificationFreshness (REQ-AC-007, H-011)
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-105
-    title: TODO: describe this artifact
+    title: reports draft for a non-verified profile and never requires re-verification
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-106
-    title: TODO: describe this artifact
+    title: reports verified-unattributed for a legacy Verified profile without provenance
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-107
-    title: TODO: describe this artifact
+    title: is fresh on the verification day with the full window remaining
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-108
-    title: TODO: describe this artifact
+    title: is fresh one day before expiry
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-109
-    title: TODO: describe this artifact
+    title: is expired exactly on the expiry day (boundary)
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-110
-    title: TODO: describe this artifact
+    title: is expired well past the window with a negative days-remaining
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-111
-    title: TODO: describe this artifact
+    title: fails closed (expired) when verifiedOn is structurally unparseable
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-112
-    title: TODO: describe this artifact
+    title: is expired-source-changed when the active weighing report no longer matches the sign-off
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-113
-    title: TODO: describe this artifact
+    title: source-change takes precedence over an otherwise-fresh window
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-114
-    title: TODO: describe this artifact
+    title: is expired-source-changed when the profile has no weighing report at all
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-CORE-115
-    title: TODO: describe this artifact
+    title: matches the LATEST weighing report by validFrom, regardless of array order
     files:
       - frontend/src/core/logic/profile-verification.spec.ts
     impl:
       - IMP-AC-CORE-005
 
   UT-AC-VIEW-172
-    title: TODO: describe this artifact
+    title: shows the verify dialog when the Verify button is tapped on a Draft
     files:
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
     impl:
       - IMP-AC-VIEW-022
 
   UT-AC-VIEW-173
-    title: TODO: describe this artifact
+    title: verifies a Draft with the captured sign-off provenance
     files:
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
     impl:
       - IMP-AC-VIEW-022
 
   UT-AC-VIEW-174
-    title: TODO: describe this artifact
+    title: renders the provenance line and no verify button for a fresh verified profile
     files:
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
     impl:
       - IMP-AC-VIEW-022
 
   UT-AC-VIEW-175
-    title: TODO: describe this artifact
+    title: flags an expired verification with the Expired badge and a re-verify affordance
     files:
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
     impl:
       - IMP-AC-VIEW-022
 
   UT-AC-VIEW-176
-    title: TODO: describe this artifact
+    title: re-attests an expired verified profile in place via reverifyProfile
     files:
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
     impl:
       - IMP-AC-VIEW-022
 
   UT-AC-VIEW-181
-    title: TODO: describe this artifact
+    title: renders an "Expired" badge with the critical class when a verified profile is expired
     files:
       - frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
     impl:
       - IMP-AC-VIEW-004
 
   UT-AC-VIEW-182
-    title: TODO: describe this artifact
+    title: ignores the expired flag for a Draft (only verified can expire)
     files:
       - frontend/src/modules/aircraft/__tests__/ProfileStatusBadge.spec.ts
     impl:
       - IMP-AC-VIEW-004
 
   UT-AC-VIEW-177
-    title: TODO: describe this artifact
+    title: renders the sign-off fields and the aircraft registration when open
     files:
       - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
     impl:
@@ -2028,70 +2035,70 @@ AC (auto)
       - IMP-AC-VIEW-021
 
   UT-AC-VIEW-178
-    title: TODO: describe this artifact
+    title: keeps the Verify button disabled until initials and POH revision are entered
     files:
       - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
     impl:
       - IMP-AC-VIEW-021
 
   UT-AC-VIEW-179
-    title: TODO: describe this artifact
+    title: emits confirm with a trimmed sign-off payload
     files:
       - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
     impl:
       - IMP-AC-VIEW-021
 
   UT-AC-VIEW-180
-    title: TODO: describe this artifact
+    title: emits cancel when the Cancel button is tapped
     files:
       - frontend/src/modules/aircraft/__tests__/VerifyProfileDialog.spec.ts
     impl:
       - IMP-AC-VIEW-021
 
   UT-AC-STORE-129
-    title: TODO: describe this artifact
+    title: verifyProfile records the full sign-off provenance bound to the active weighing report
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:
       - IMP-AC-STORE-011
 
   UT-AC-STORE-130
-    title: TODO: describe this artifact
+    title: verifyProfile defaults verifiedOn to today when the sign-off omits a date
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:
       - IMP-AC-STORE-011
 
   UT-AC-STORE-131
-    title: TODO: describe this artifact
+    title: verifyProfile rejects a sign-off with blank initials or POH revision
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:
       - IMP-AC-STORE-011
 
   UT-AC-STORE-132
-    title: TODO: describe this artifact
+    title: editVerifiedProfile strips the verification provenance when reverting to Draft
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:
       - IMP-AC-STORE-011
 
   UT-AC-STORE-133
-    title: TODO: describe this artifact
+    title: updateProfile never leaves verification provenance on a Draft
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:
       - IMP-AC-STORE-011
 
   UT-AC-STORE-134
-    title: TODO: describe this artifact
+    title: reverifyProfile re-stamps provenance in place on an already-verified profile
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:
       - IMP-AC-STORE-011
 
   UT-AC-STORE-135
-    title: TODO: describe this artifact
+    title: reverifyProfile throws on a Draft profile and on a missing id
     files:
       - frontend/src/modules/aircraft/__tests__/fleet.store.spec.ts
     impl:

--- a/trace/unit_test/mb.yaml
+++ b/trace/unit_test/mb.yaml
@@ -1397,35 +1397,63 @@ MB (auto)
       - IMP-MB-STORE-023
 
   UT-MB-VIEW-022
-    title: TODO: describe this artifact
+    title: groups picker options into Verified and Draft optgroups
     files:
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:
       - IMP-MB-VIEW-011
 
   UT-MB-VIEW-023
-    title: TODO: describe this artifact
+    title: surfaces the active aircraft in a Last used optgroup at the top
     files:
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:
       - IMP-MB-VIEW-011
 
   UT-MB-VIEW-024
-    title: TODO: describe this artifact
+    title: does NOT load a Draft on selection — shows the inline WARN-AC-002 acknowledgement first
     files:
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:
       - IMP-MB-VIEW-011
 
   UT-MB-VIEW-025
-    title: TODO: describe this artifact
+    title: loads the Draft only after the acknowledgement is confirmed
     files:
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:
       - IMP-MB-VIEW-011
 
   UT-MB-VIEW-026
-    title: TODO: describe this artifact
+    title: cancelling the acknowledgement leaves the Draft unloaded
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-027
+    title: marks an expired Verified profile with an [Expired] suffix in the picker
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-028
+    title: does NOT load an expired Verified profile on selection — shows the inline acknowledgement first
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-029
+    title: loads the expired Verified profile only after the acknowledgement is confirmed
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-030
+    title: cancelling the acknowledgement leaves an expired Verified profile unloaded
     files:
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:

--- a/trace/unit_test/mb.yaml
+++ b/trace/unit_test/mb.yaml
@@ -1395,3 +1395,38 @@ MB (auto)
       - frontend/src/modules/mass-balance/stores/__tests__/mass-balance.store.spec.ts
     impl:
       - IMP-MB-STORE-023
+
+  UT-MB-VIEW-022
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-023
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-024
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-025
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011
+
+  UT-MB-VIEW-026
+    title: TODO: describe this artifact
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-011


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Closes the H-011 "single-tap Verified" gap and the alphabetical-only Mass & Balance aircraft picker (audit findings UX-005 / UX-007), deferred to v0.4.

- **P1 (`src/core/`)** — `aircraft.schema.ts` gains an optional `verification` block (`verifiedOn`, `verifiedBy`, `pohRevision`, `sourceWeighingDate`). New pure module `core/logic/profile-verification.ts` exposes `VERIFICATION_VALIDITY_DAYS = 90` and `evaluateVerificationFreshness(profile, now)` returning `draft | verified-unattributed | fresh | expired-aged | expired-source-changed`.
- **P2 (`modules/aircraft/stores`)** — `verifyProfile()` now requires a sign-off and records provenance bound to the active weighing report; `reverifyProfile()` re-attests an expired profile in place; provenance is stripped on every Verified→Draft transition.
- **P3 (UI)** — `VerifyProfileDialog.vue` captures the sign-off; `FleetList` renders the provenance line ("Verified by … on … against POH …"), an **Expired** badge and a (re-)verify affordance; the editor header badge reflects expiry; the M&B picker groups **Last used / Verified / Draft** `<optgroup>`s, marks `[Draft]` destructively, and gates a draft selection behind an inline `WARN-AC-002` acknowledgement before the envelope is loaded for computation.
- **Docs/trace** — new `REQ-AC-007` (FROM `H-011`), hazard-log linkage, registries, `@wip` E2E scenario `E2E-B-011`, CHANGELOG.

#### Formal Review Request (P1 / safety-critical)

| Field | Value |
| :---- | :---- |
| REQ | REQ-AC-007 (new) refining REQ-AC-005 |
| Hazard | H-011 — aircraft data integrity ("Garbage-In") |
| Output impact | Strengthens the verified-source gate feeding the Go/No-Go advisory; never relaxes it (drafts/expired still warn). |
| Pure-TS guarantee | `profile-verification.ts` imports only a P1 type; no `vue`/`pinia`/UI. |
| Deterministic guarantee | `now` is injected; calendar math in whole UTC days; no `Date.now()` inside the function. |
| Zod plan | `verification` validated by `VerificationProvenanceSchema` (`verifiedOn` `YYYY-MM-DD` regex, bounded `verifiedBy`/`pohRevision`); optional so legacy/imported Verified records remain valid at rest. |
| Formula | `expiryDay = epochDay(verifiedOn) + 90`; expired ⇔ `nowDay ≥ expiryDay` **or** `latest(weighingReports.validFrom) ≠ verification.sourceWeighingDate`. |
| Unit normalization | N/A — dates only, no physical units. |
| Edge cases (≥3) | boundary day = expiry (expired); source-changed overrides fresh; unparseable `verifiedOn` fails closed; no weighing report fails closed; legacy unattributed not mass-invalidated. |
| ADR need | No — additive optional field + pure helper; no change to M&B/performance math or the P1 dependency-isolation contract. |

### Related Issues
Closes #276

### Issue State Management (Post-Merge)
- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items
- **Requirements Implemented/Affected:** `REQ-AC-007` (new), `REQ-AC-005` (refined)

### Documentation Updates
- [x] **Requirements:** Created/Updated ID(s): `REQ-AC-007` in `docs/requirements/aircraft_management.md`
- [x] **Architecture:** `N/A` (Reason: additive optional schema field + pure helper; no architectural surface or ADR change)
- [x] **Risk Management:** Hazards updated/mitigated ID(s): `H-011` (added `REQ-AC-007` to mitigators in `docs/risk_management/safety_hazards.md` + `trace/hazards/hazards.yaml`)
- [x] **Journeys:** Created/Updated ID(s): `UJ-A-001` (added `REQ-AC-007`), `E2E-B-011` `@wip` scenario for the draft acknowledgement
- [x] **Code Docs:** API docs/README/Changelog updated (CHANGELOG `### Added`)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. (H-011 → REQ-AC-005/REQ-AC-007 → UJ-A-001/UJ-B-005 → E2E preserved)
- [x] No new hazards introduced. (mitigation strengthening only)
- [x] Existing mitigations preserved. (WARN-AC-002 still emitted; verified-source gate only tightened)
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). (`pnpm --filter frontend test:p1` green; `profile-verification.ts` is pure TS)

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added/updated and passing locally. (P1 freshness + schema, fleet store sign-off/strip/reverify, VerifyProfileDialog, ProfileStatusBadge expired, FleetList provenance, M&B grouped picker + acknowledgement — full suite 1399 green)
- [x] **Integration Tests:** Passing. (64 green; no new integration surface required)
- [x] **Manual Testing:** `N/A` (Reason: headless CI run; behaviour verified via unit/component tests — golden path + boundary/source-change/cancel paths. Real-cockpit manual flight testing is not performed by automation.)
- [x] **DoD:** All Definition of Done items from #276 are met (provenance captured + displayed; expiry on source edit/age; draft-aware grouped picker + inline acknowledgement).
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` — additive optional field + pure helper; no fundamental change to a P1 module's operation or the dependency-isolation contract.

<!-- Note: the P1 / safety-critical change still requires Lead Developer approval per ADR-317 / CONTRIBUTING §7 — this Draft PR carries the FRR above for that review. -->
