### PR TITLE
feat: [Feature]: Colour-independent CG envelope signalling (WARNING shape + dark-mode contrast) (#277)

### DIFF
--- a/docs/ux/design_system.md
+++ b/docs/ux/design_system.md
@@ -63,6 +63,7 @@ Color must never be the sole indicator of application state or physical safety.
 
 - **Form Fields:** Warning or Error input fields must feature an explicit, bold icon (e.g., `!` or `X`) integrated into the input box or helper text, redundantly reinforcing the colored border.
 - **Visualizations (Charts/Graphs):** Data elements conveying an unsafe state must alter their physical characteristics. For example, a boundary-violating chart point must change from a standard circle to an explicit `X` or Triangle. Erroneous bounding areas (polygons) must use a crosshatched pattern-fill, ensuring the breach is definitively readable by color-blind users or in monochrome environments.
+  - **CG envelope chart mapping (`IMP-MB-UI-009`):** mass points render SAFE → circle, WARNING → triangle (▲), CRITICAL → cross (×); the CRITICAL envelope fill uses a dense crosshatch. Severity is never colour-only. Each severity's marker colour clears WCAG AAA (≥ 7:1) against the dark chart backdrop (`--color-surface-card`, `#252525`).
 
 ---
 

--- a/frontend/src/modules/mass-balance/components/CGEnvelopeChart.vue
+++ b/frontend/src/modules/mass-balance/components/CGEnvelopeChart.vue
@@ -236,6 +236,28 @@ const palette = computed(() => {
 const pathDash = computed(() => (isCritical.value ? '6,4' : isNeutral.value ? '4,3' : 'none'))
 const pathStroke = computed(() => (isCritical.value ? 3 : 2))
 
+// ─── Colour-independent severity signalling ─────────────────────────────────
+// @IMP-MB-UI-009@ (FROM: @REQ-UI-019@)
+// DES-UX §3.3: colour must never be the sole differentiator of a safety
+// state. Each severity maps to a distinct marker SHAPE so SAFE, WARNING, and
+// CRITICAL stay tellable apart under cockpit glare and for colour-blind
+// pilots — not just by hue:
+//   success / neutral → circle ·  warning → triangle (▲) ·  critical → cross (×)
+const TRI_R = 7
+
+const markerShape = computed<'cross' | 'triangle' | 'circle'>(() =>
+  props.severity === 'critical' ? 'cross'
+  : props.severity === 'warning' ? 'triangle'
+  : 'circle',
+)
+
+/** Equilateral upward "caution" triangle (circumradius TRI_R) centred on (cx, cy). */
+function trianglePoints(cx: number, cy: number): string {
+  const dx = TRI_R * 0.866
+  const dy = TRI_R * 0.5
+  return `${cx},${cy - TRI_R} ${cx + dx},${cy + dy} ${cx - dx},${cy + dy}`
+}
+
 const xAxisLabel = computed(() => (props.graphType === 'moment' ? 'CG Moment' : 'CG Arm'))
 
 // ─── Accessibility ─────────────────────────────────────────────────────────
@@ -274,14 +296,19 @@ const ariaLabel = computed(() => {
     >
       <!-- ─── Defs ──────────────────────────────────────────────────────── -->
       <defs>
+        <!-- CRITICAL fill: a dense, true crosshatch (two perpendicular line
+             sets, 5px tile, raised opacity). Pattern-fills the breach so it
+             reads as unsafe in monochrome / colour-blind / glare conditions,
+             independent of the red hue (DES-UX §3.3). -->
         <pattern
           id="cg-crosshatch"
           patternUnits="userSpaceOnUse"
-          width="8"
-          height="8"
+          width="5"
+          height="5"
           patternTransform="rotate(45)"
         >
-          <line x1="0" y1="0" x2="0" y2="8" :stroke="palette.envStroke" stroke-width="1.5" opacity="0.25" />
+          <line x1="0" y1="0" x2="0" y2="5" :stroke="palette.envStroke" stroke-width="1.2" opacity="0.4" />
+          <line x1="0" y1="0" x2="5" y2="0" :stroke="palette.envStroke" stroke-width="1.2" opacity="0.4" />
         </pattern>
         <marker id="cg-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
           <polygon points="0,0 8,3 0,6" :fill="palette.line" />
@@ -396,8 +423,12 @@ const ariaLabel = computed(() => {
       <!-- ─── CG point markers ────────────────────────────────────────── -->
       <template v-if="cgMarkers">
         <template v-for="m in cgMarkers" :key="m.key">
-          <!-- Critical → cross (×) mark — shape change independent of colour -->
-          <g v-if="isCritical" :transform="`translate(${m.cx},${m.cy})`">
+          <!-- Critical → cross (×): boundary breach — shape independent of colour -->
+          <g
+            v-if="markerShape === 'cross'"
+            class="cg-point-marker cg-point-marker--cross"
+            :transform="`translate(${m.cx},${m.cy})`"
+          >
             <line
               :x1="-CROSS_R"
               :y1="-CROSS_R"
@@ -416,9 +447,19 @@ const ariaLabel = computed(() => {
             />
           </g>
 
-          <!-- Non-critical → filled circle -->
+          <!-- Warning → triangle (▲): out-of-standard-range caution, distinct
+               from the SAFE circle by shape, not just colour (DES-UX §3.3) -->
+          <polygon
+            v-else-if="markerShape === 'triangle'"
+            class="cg-point-marker cg-point-marker--triangle"
+            :points="trianglePoints(m.cx, m.cy)"
+            :fill="palette.pt"
+          />
+
+          <!-- Safe / neutral → filled circle -->
           <circle
             v-else
+            class="cg-point-marker cg-point-marker--circle"
             :cx="m.cx"
             :cy="m.cy"
             :r="POINT_R"

--- a/frontend/src/modules/mass-balance/components/__tests__/CGEnvelopeChart.spec.ts
+++ b/frontend/src/modules/mass-balance/components/__tests__/CGEnvelopeChart.spec.ts
@@ -1,7 +1,46 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import CGEnvelopeChart from '../CGEnvelopeChart.vue'
 import type { MathCoreResult, EnvelopePoint } from '@/modules/mass-balance/stores/mass-balance.types'
+
+// useTheme is a module-level singleton; mock it so a test can pin the active
+// theme deterministically. The chart palette differs between light and dark,
+// and the dark palette is what the glare/contrast checks below assert against.
+const themeMock = vi.hoisted(() => ({ value: 'light' as 'light' | 'dark' }))
+vi.mock('@/shared/composables/useTheme', () => ({
+  useTheme: () => ({ theme: themeMock, toggleTheme: () => {} }),
+}))
+
+// Default every test back to light so a dark-mode block cannot leak.
+afterEach(() => {
+  themeMock.value = 'light'
+})
+
+// ─── WCAG relative-luminance / contrast helpers ─────────────────────────────
+// Used to verify the chart's severity colours stay legible against the dark
+// chart backdrop (DES-UX §3.2 night ops, §3.3 colour independence).
+function srgbToLinear(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(hex: string): number {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.slice(0, 2), 16)
+  const g = parseInt(h.slice(2, 4), 16)
+  const b = parseInt(h.slice(4, 6), 16)
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b)
+}
+
+function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a)
+  const lb = relativeLuminance(b)
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** Dark chart backdrop: the chart renders inside `.prep-card` → `--color-surface-card` (#252525 dark). */
+const DARK_CHART_BACKDROP = '#252525'
 
 // ─── Test fixtures ───────────────────────────────────────────────────────────
 
@@ -511,5 +550,105 @@ describe('CGEnvelopeChart — envelope polygon opacity', () => {
     const wrapper = mountChart({ result: buildResult(), severity: 'success' })
 
     expect(envelopePolygon(wrapper).attributes('opacity')).toBe('1')
+  })
+})
+
+// ─── Colour-independent severity shape (DES-UX §3.3) ─────────────────────────
+// Each severity must be tellable apart by SHAPE, not colour alone, so the
+// state survives cockpit glare and colour-blind vision:
+//   success / neutral → circle ·  warning → triangle ·  critical → cross (×)
+describe('CGEnvelopeChart — colour-independent severity shape', () => {
+  function shapeCounts(wrapper: ReturnType<typeof mountChart>) {
+    return {
+      circles: wrapper.findAll('circle.cg-point-marker--circle').length,
+      triangles: wrapper.findAll('polygon.cg-point-marker--triangle').length,
+      crosses: wrapper.findAll('g.cg-point-marker--cross').length,
+    }
+  }
+
+  it('renders SAFE points as circles only (no triangle, no cross)', () => {
+    const counts = shapeCounts(mountChart({ result: buildResult(), severity: 'success' }))
+
+    expect(counts).toEqual({ circles: 3, triangles: 0, crosses: 0 })
+  })
+
+  it('renders WARNING points as triangles only — a distinct shape from SAFE', () => {
+    const counts = shapeCounts(mountChart({ result: buildResult(), severity: 'warning' }))
+
+    expect(counts).toEqual({ circles: 0, triangles: 3, crosses: 0 })
+  })
+
+  it('renders CRITICAL points as crosses only (no circle, no triangle)', () => {
+    const counts = shapeCounts(mountChart({ result: buildResult(), severity: 'critical' }))
+
+    expect(counts).toEqual({ circles: 0, triangles: 0, crosses: 3 })
+  })
+
+  it('renders neutral (null severity) points as circles', () => {
+    const counts = shapeCounts(mountChart({ result: buildResult(), severity: null }))
+
+    expect(counts).toEqual({ circles: 3, triangles: 0, crosses: 0 })
+  })
+
+  it('gives the WARNING triangle three vertices and still applies the warning colour', () => {
+    const wrapper = mountChart({ result: buildResult(), severity: 'warning' })
+
+    const triangle = wrapper.find('polygon.cg-point-marker--triangle')
+    const vertices = triangle.attributes('points')!.trim().split(/\s+/)
+    expect(vertices).toHaveLength(3) // a triangle, not a circle
+    // Colour is retained alongside the shape — redundant, not replaced.
+    expect(triangle.attributes('fill')).toBe('#ef6c00') // light-mode warning
+  })
+})
+
+// ─── Dark-mode contrast (DES-UX §3.2 night ops / glare legibility) ───────────
+describe('CGEnvelopeChart — dark-mode AAA contrast', () => {
+  beforeEach(() => {
+    themeMock.value = 'dark'
+  })
+
+  it('SAFE marker colour clears WCAG AAA (≥ 7:1) against the dark backdrop', () => {
+    const wrapper = mountChart({ result: buildResult(), severity: 'success' })
+
+    const fill = wrapper.find('circle.cg-point-marker--circle').attributes('fill')!
+    expect(contrastRatio(fill, DARK_CHART_BACKDROP)).toBeGreaterThanOrEqual(7)
+  })
+
+  it('WARNING marker colour clears WCAG AAA (≥ 7:1) against the dark backdrop', () => {
+    const wrapper = mountChart({ result: buildResult(), severity: 'warning' })
+
+    const fill = wrapper.find('polygon.cg-point-marker--triangle').attributes('fill')!
+    expect(contrastRatio(fill, DARK_CHART_BACKDROP)).toBeGreaterThanOrEqual(7)
+  })
+
+  it('CRITICAL marker colour clears WCAG AAA (≥ 7:1) against the dark backdrop', () => {
+    const wrapper = mountChart({ result: buildResult(), severity: 'critical' })
+
+    const stroke = wrapper.find('g.cg-point-marker--cross line').attributes('stroke')!
+    expect(contrastRatio(stroke, DARK_CHART_BACKDROP)).toBeGreaterThanOrEqual(7)
+  })
+
+  it('SAFE and CRITICAL marker colours are distinguishable, not near-identical hues', () => {
+    const safe = mountChart({ result: buildResult(), severity: 'success' })
+      .find('circle.cg-point-marker--circle')
+      .attributes('fill')!
+    const critical = mountChart({ result: buildResult(), severity: 'critical' })
+      .find('g.cg-point-marker--cross line')
+      .attributes('stroke')!
+
+    expect(safe).not.toBe(critical)
+  })
+
+  it('every severity envelope stroke stays legible (≥ 4.5:1) for glare', () => {
+    for (const severity of ['success', 'warning', 'critical'] as const) {
+      const wrapper = mountChart({ result: buildResult(), severity })
+      // Envelope polygon is the second <polygon> (arrowhead marker is first).
+      const stroke = wrapper.findAll('polygon')[1]!.attributes('stroke')!
+      expect(contrastRatio(stroke, DARK_CHART_BACKDROP)).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('contrast helper is sound (white on black resolves to 21:1)', () => {
+    expect(contrastRatio('#ffffff', '#000000')).toBeCloseTo(21, 0)
   })
 })

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -366,6 +366,13 @@ MB UI Components
       - frontend/src/modules/mass-balance/components/MassStationInput.vue
       - frontend/src/modules/mass-balance/views/MassBalanceView.vue
 
+  IMP-MB-UI-009
+    title: Colour-independent CG severity signalling — distinct marker shape per severity (circle/triangle/cross) plus dense crosshatch breach fill (UX-006)
+    req:
+      - REQ-UI-019
+    files:
+      - frontend/src/modules/mass-balance/components/CGEnvelopeChart.vue
+
   IMP-MB-UI-FLEET-002
     title: Reset Payload confirm-then-undo — in-app confirmation with discard count plus a short undo window restoring pre-reset weights (UX-004)
     req:


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

- Mass-point markers on the CG envelope chart now carry a distinct **shape per severity** — SAFE → circle, WARNING → triangle (▲), CRITICAL → cross (×) — so state is no longer colour-only (DES-UX §3.3, mitigating misread-under-glare).
- CRITICAL envelope fill switched to a **denser true crosshatch** (5px tile, two perpendicular line sets, raised opacity) for a stronger colour-independent breach signal.
- Added shape-by-severity component tests and **WCAG AAA dark-mode contrast** checks (each severity marker colour ≥ 7:1 against the `#252525` chart backdrop; envelope strokes ≥ 4.5:1).
- Documented the concrete CG-chart severity→shape mapping in `docs/ux/design_system.md` §3.3.

### Related Issues

- Closes #277

### Issue State Management (Post-Merge)
- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items
- **Requirements Implemented/Affected:** `REQ-UI-019` (CG Envelope Polygon Rendering ← `H-006`) — markers now colour-independent. New impl tag `IMP-MB-UI-009`. Design rule: DES-UX §3.3.

### Documentation Updates
- [x] **Requirements:** `N/A` (Reason: no new/changed requirement; `REQ-UI-019` already exists and stays `Approved` — this is a rendering enhancement, not first implementation).
- [x] **Architecture:** Updated `docs/ux/design_system.md` §3.3 — concrete CG-chart severity→shape mapping + dark-backdrop AAA contrast note.
- [x] **Risk Management:** `N/A` (Reason: no new hazard; existing `H-006` CG-visibility mitigation is strengthened, hazard register unchanged).
- [x] **Journeys:** `N/A` (Reason: UX-006 audit remediation — no new/changed user journey).
- [x] **Code Docs:** `N/A` (Reason: no API/README change; `CHANGELOG.md` is reserved for the release process per the implement-issue workflow).

### Safety Considerations

- [x] Checked Safety Traceability Matrix. (`IMP-MB-UI-009` → `REQ-UI-019` → `H-006`; structural trace gate passes with no new violations.)
- [x] No new hazards introduced.
- [x] Existing mitigations preserved. (Colour-independent signalling strengthens the `H-006` CG-readability mitigation.)
- [x] P1 isolation maintained (no new P2/P3 imports in core modules). (Change is confined to the P2 `mass-balance` module; `src/core/` untouched.)

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added/updated and passing locally. (`CGEnvelopeChart.spec.ts` — shape-by-severity + AAA contrast; full unit suite 1423 passing.)
- [x] **Integration Tests:** Passing. (64 passing; no integration surface changed.)
- [x] **Manual Testing:** `N/A` (Reason: not mandatory for a `develop`-targeted PR; shape distinctness and AAA contrast are verified deterministically by automated component tests — no live/hardware dependency).
- [x] **DoD:** All Definition of Done items from #277 are met and ticked.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` (Reason: no architectural decision — rendering enhancement within an existing P2 module; no dependency or structural change).
