### PR TITLE
feat: [Task]: Migrate M&B station inputs to DecimalInput pattern + inline rejection feedback (#278)

### DIFF
--- a/frontend/src/modules/mass-balance/components/MassStationInput.vue
+++ b/frontend/src/modules/mass-balance/components/MassStationInput.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
+import DecimalInput, { type DecimalRejection } from '@/shared/components/DecimalInput.vue'
 import type { StationInput } from '@/modules/mass-balance/stores/mass-balance.types'
+
+/** How long the transient inline rejection hint stays visible (ms). */
+const REJECTION_HINT_MS = 2500
 
 const props = defineProps<{
   station: StationInput
@@ -55,15 +59,67 @@ const coarseStepValue = computed(() => {
 
 const presetList = computed(() => props.presets ?? [])
 
+/** Finite upper bound for the field — the operational limit when a slider is shown. */
+const fieldMax = computed(() =>
+  showSlider.value && props.maxCapacity != null ? props.maxCapacity : undefined,
+)
+
 function clamp(value: number): number {
   if (!Number.isFinite(value)) return minWeight.value
   const ceiling = showSlider.value && props.maxCapacity != null ? props.maxCapacity : Infinity
   return Math.min(ceiling, Math.max(minWeight.value, value))
 }
 
-function onInput(event: Event): void {
-  const raw = (event.target as HTMLInputElement).value
-  const parsed = parseFloat(raw)
+// ─── Sanitised decimal entry + inline rejection feedback (UX-010 / UX-011) ──
+// @IMP-MB-UI-009@ (FROM: @REQ-UQ-001@)
+//
+// The field is a DecimalInput (type=text + inputmode=decimal + regex sanitiser)
+// instead of type=number, so "e"/"+" can no longer slip through and be parsed
+// as a magnitude shift ("1e2" → 100). DecimalInput blocks the bad input and
+// emits `reject`; we surface a transient inline hint and an immediate error
+// border so the pilot sees the value was refused rather than silently swallowed.
+
+/** Transient message shown when the last keystroke was refused; null when clear. */
+const rejectionHint = ref<string | null>(null)
+const isRejected = computed(() => rejectionHint.value !== null)
+let rejectionTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearRejectionTimer(): void {
+  if (rejectionTimer !== null) {
+    clearTimeout(rejectionTimer)
+    rejectionTimer = null
+  }
+}
+
+const unitSuffix = computed(() => (props.unit ? ` ${props.unit}` : ''))
+
+function onFieldInput(value: number | null): void {
+  // An accepted value clears any stale rejection hint immediately.
+  rejectionHint.value = null
+  clearRejectionTimer()
+  emit('update:weight', clamp(value ?? minWeight.value))
+}
+
+function onReject(detail: DecimalRejection): void {
+  if (detail.reason === 'min') {
+    rejectionHint.value = `Minimum is ${minWeight.value}${unitSuffix.value}.`
+  } else if (detail.reason === 'max') {
+    rejectionHint.value =
+      fieldMax.value != null ? `Maximum is ${fieldMax.value}${unitSuffix.value}.` : 'Value too high.'
+  } else {
+    rejectionHint.value = 'Enter digits only — letters and symbols (e, +) are not allowed.'
+  }
+  clearRejectionTimer()
+  rejectionTimer = setTimeout(() => {
+    rejectionHint.value = null
+    rejectionTimer = null
+  }, REJECTION_HINT_MS)
+}
+
+onBeforeUnmount(clearRejectionTimer)
+
+function onSliderInput(event: Event): void {
+  const parsed = parseFloat((event.target as HTMLInputElement).value)
   if (!Number.isNaN(parsed)) {
     emit('update:weight', clamp(parsed))
   }
@@ -101,6 +157,7 @@ function applyPreset(value: number): void {
     :class="{
       'mass-station-input--disabled': disabled,
       'mass-station-input--error': station.hasError,
+      'mass-station-input--rejected': isRejected,
     }"
   >
     <div class="mass-station-input__header">
@@ -135,17 +192,16 @@ function applyPreset(value: number): void {
         −
       </button>
 
-      <input
+      <DecimalInput
         :id="`station-${station.index}`"
-        type="number"
         class="mass-station-input__field"
-        :value="station.weight"
-        :disabled="disabled"
-        :aria-invalid="station.hasError || undefined"
-        inputmode="decimal"
+        :model-value="station.weight"
         :min="minWeight"
-        step="1"
-        @input="onInput"
+        :max="fieldMax"
+        :disabled="disabled"
+        :aria-invalid="station.hasError || isRejected || undefined"
+        @update:model-value="onFieldInput"
+        @reject="onReject"
       />
 
       <button
@@ -168,6 +224,17 @@ function applyPreset(value: number): void {
         +{{ coarseStepValue }}
       </button>
     </div>
+
+    <!-- Transient inline rejection feedback (UX-010 / UX-011): shown when the
+         last keystroke was refused (non-decimal char or out of range). -->
+    <p
+      v-if="rejectionHint"
+      class="mass-station-input__reject-hint"
+      role="alert"
+      aria-live="assertive"
+    >
+      {{ rejectionHint }}
+    </p>
 
     <!-- UX-002: one-tap preset chips (e.g. standard passenger weights). -->
     <div
@@ -208,7 +275,7 @@ function applyPreset(value: number): void {
         :max="maxCapacity ?? undefined"
         :disabled="disabled"
         step="1"
-        @input="onInput"
+        @input="onSliderInput"
       />
       <span class="mass-station-input__slider-bound">{{ maxCapacity }}</span>
     </div>
@@ -246,6 +313,20 @@ function applyPreset(value: number): void {
 }
 
 .mass-station-input--error .mass-station-input__label {
+  color: var(--color-critical, #c62828);
+}
+
+/* Transient input-rejection state (UX-010 / UX-011) — distinct from the
+   computation `--error` state; signals the last keystroke was refused. */
+.mass-station-input--rejected .mass-station-input__control {
+  border-color: var(--color-critical, #f44336);
+  box-shadow: 0 0 0 2px var(--color-critical-bg, #ffebee);
+}
+
+.mass-station-input__reject-hint {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
   color: var(--color-critical, #c62828);
 }
 

--- a/frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
+++ b/frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
@@ -1,9 +1,19 @@
 // @UT-MB-UI-001@ (FROM: @IMP-MB-UI-006@, @IMP-MB-UI-008@)
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import MassStationInput from '../MassStationInput.vue'
 import type { StationInput } from '@/modules/mass-balance/stores/mass-balance.types'
+
+/** The sanitised decimal field rendered by the embedded DecimalInput. */
+function field(wrapper: ReturnType<typeof mount>) {
+  return wrapper.find('input[type="text"]')
+}
+
+/** Numeric values carried by every emitted `update:weight`. */
+function weightEmissions(wrapper: ReturnType<typeof mount>): unknown[] {
+  return (wrapper.emitted('update:weight') ?? []).map((e) => e[0])
+}
 
 function makeStation(overrides: Partial<StationInput> = {}): StationInput {
   return {
@@ -184,39 +194,47 @@ describe('MassStationInput', () => {
     expect(wrapper.emitted('update:weight')).toEqual([[1]])
   })
 
-  // ─── onInput() — Number.isNaN branch ────────────────────────────────────
+  // ─── Decimal field entry (via the embedded DecimalInput) ─────────────────
 
-  it('emits update:weight with the parsed float when a valid number is typed', () => {
+  it('emits update:weight with the parsed float when a valid number is typed', async () => {
     const wrapper = mount(MassStationInput, {
       props: { station: makeStation({ weight: 0 }) },
     })
 
-    const onInput = (wrapper.vm as unknown as { onInput(e: Event): void }).onInput
-    onInput.call(wrapper.vm, { target: { value: '75.5' } } as unknown as Event)
+    await field(wrapper).setValue('75.5')
 
-    expect(wrapper.emitted('update:weight')).toEqual([[75.5]])
+    expect(weightEmissions(wrapper)).toContain(75.5)
   })
 
-  it('does not emit update:weight when the input value is not a number', () => {
+  it('does not emit a weight when only non-numeric characters are typed', async () => {
     const wrapper = mount(MassStationInput, {
       props: { station: makeStation({ weight: 0 }) },
     })
 
-    const onInput = (wrapper.vm as unknown as { onInput(e: Event): void }).onInput
-    onInput.call(wrapper.vm, { target: { value: 'abc' } } as unknown as Event)
+    await field(wrapper).setValue('abc')
 
     expect(wrapper.emitted('update:weight')).toBeUndefined()
   })
 
-  it('does not emit update:weight when the input value is an empty string', () => {
+  it('emits the floor weight when the field is cleared', async () => {
     const wrapper = mount(MassStationInput, {
-      props: { station: makeStation({ weight: 0 }) },
+      props: { station: makeStation({ weight: 50 }) },
     })
 
-    const onInput = (wrapper.vm as unknown as { onInput(e: Event): void }).onInput
-    onInput.call(wrapper.vm, { target: { value: '' } } as unknown as Event)
+    await field(wrapper).setValue('')
 
-    expect(wrapper.emitted('update:weight')).toBeUndefined()
+    expect(weightEmissions(wrapper)).toEqual([0])
+  })
+
+  it('exposes the field as a sanitised decimal input, never type=number', () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation() },
+    })
+
+    const input = field(wrapper)
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('type')).toBe('text')
+    expect(input.attributes('inputmode')).toBe('decimal')
   })
 
   // ─── UX-002: coarse step + presets + wider field ────────────────────────
@@ -343,5 +361,95 @@ describe('MassStationInput', () => {
     expect(
       (wrapper.find('.mass-station-input__preset-chip').element as HTMLButtonElement).disabled,
     ).toBe(true)
+  })
+})
+
+// ─── UX-010 / UX-011: sanitised decimal entry + inline rejection feedback ───
+// @UT-MB-UI-003@ (FROM: @IMP-MB-UI-009@)
+describe('MassStationInput — "e"/out-of-range rejection feedback', () => {
+  it('never expands "1e2" to 100 — the "e" is rejected, so no such weight is emitted', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 0 }) },
+    })
+
+    await field(wrapper).setValue('1e2')
+
+    // The native type=number defect silently parsed "1e2" as 100; it must not recur.
+    expect(weightEmissions(wrapper)).not.toContain(100)
+  })
+
+  it('shows a transient inline hint and error border when a forbidden character is blocked', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 0 }) },
+    })
+
+    await field(wrapper).setValue('1e2')
+
+    const hint = wrapper.find('.mass-station-input__reject-hint')
+    expect(hint.exists()).toBe(true)
+    expect(hint.text().toLowerCase()).toContain('digits')
+    expect(wrapper.find('.mass-station-input--rejected').exists()).toBe(true)
+  })
+
+  it('rejects a value above the station capacity with a "Maximum is …" hint and no emit', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 50 }), unit: 'kg', maxCapacity: 100 },
+    })
+
+    await field(wrapper).setValue('150')
+
+    const hint = wrapper.find('.mass-station-input__reject-hint')
+    expect(hint.exists()).toBe(true)
+    expect(hint.text()).toContain('Maximum is 100 kg')
+    expect(weightEmissions(wrapper)).not.toContain(150)
+  })
+
+  it('rejects a value below the unusable-fuel floor with a "Minimum is …" hint and no emit', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: {
+        station: makeStation({ weight: 50 }),
+        unit: 'L',
+        unusableFuel: 5,
+        maxCapacity: 100,
+      },
+    })
+
+    await field(wrapper).setValue('2')
+
+    const hint = wrapper.find('.mass-station-input__reject-hint')
+    expect(hint.exists()).toBe(true)
+    expect(hint.text()).toContain('Minimum is 5 L')
+    expect(weightEmissions(wrapper)).not.toContain(2)
+  })
+
+  it('clears the rejection hint as soon as a valid value is entered', async () => {
+    const wrapper = mount(MassStationInput, {
+      props: { station: makeStation({ weight: 0 }) },
+    })
+
+    await field(wrapper).setValue('1e2')
+    expect(wrapper.find('.mass-station-input__reject-hint').exists()).toBe(true)
+
+    await field(wrapper).setValue('42')
+    expect(wrapper.find('.mass-station-input__reject-hint').exists()).toBe(false)
+    expect(weightEmissions(wrapper)).toContain(42)
+  })
+
+  it('auto-dismisses the transient hint after the timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = mount(MassStationInput, {
+        props: { station: makeStation({ weight: 0 }) },
+      })
+
+      await field(wrapper).setValue('1e2')
+      expect(wrapper.find('.mass-station-input__reject-hint').exists()).toBe(true)
+
+      vi.advanceTimersByTime(3000)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.mass-station-input__reject-hint').exists()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/shared/components/DecimalInput.vue
+++ b/frontend/src/shared/components/DecimalInput.vue
@@ -15,6 +15,13 @@
   />
 </template>
 
+<script lang="ts">
+/** Why a typed value was blocked: a non-decimal character, or out of [min,max]. */
+export interface DecimalRejection {
+  reason: 'invalid' | 'min' | 'max'
+}
+</script>
+
 <script setup lang="ts">
 // @IMP-UI-COMP-DECIMAL-002@ (FROM: @REQ-UQ-001@)
 import { ref, watch } from 'vue'
@@ -38,7 +45,15 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: number | null): void
+  (e: 'reject', detail: DecimalRejection): void
 }>()
+
+// Characters that are NOT part of a plain decimal number. The critical ones are
+// "e"/"E"/"+", which a native `type=number` field accepted and `Number()` would
+// expand ("1e2" → 100), silently corrupting a safety-critical value with no
+// feedback (UX-010 / UX-011). They are stripped on input and surfaced via the
+// `reject` event so a consumer can warn the pilot instead of failing silently.
+const NON_DECIMAL = /[^0-9.,-]/g
 
 // Raw string the user is currently typing — preserved verbatim during input
 const rawString = ref<string>(props.modelValue !== null && props.modelValue !== undefined ? String(props.modelValue) : '')
@@ -69,9 +84,25 @@ function parseRaw(raw: string): number | null {
 
 function onInput(event: Event): void {
   const input = event.target as HTMLInputElement
-  rawString.value = input.value
 
-  const raw = input.value.trim()
+  // Strip any character that cannot belong to a decimal number ("e", "+",
+  // letters, …). Forcing the DOM value back is required because Vue's `:value`
+  // binding won't re-render an unchanged model, leaving the rejected glyph on
+  // screen otherwise. A stripped character is surfaced via `reject` so the
+  // value can never be silently corrupted ("1e2" → 100) (UX-010 / UX-011).
+  const sanitised = input.value.replace(NON_DECIMAL, '')
+  if (sanitised !== input.value) {
+    // Forbidden glyph entered: strip it from the field, flag the rejection, and
+    // commit nothing. The stripped remainder is committed on the next valid
+    // keystroke or on blur — never silently as a corrupted value.
+    input.value = sanitised
+    rawString.value = sanitised
+    emit('reject', { reason: 'invalid' })
+    return
+  }
+  rawString.value = sanitised
+
+  const raw = sanitised.trim()
 
   // Empty input
   if (raw === '') {
@@ -89,13 +120,15 @@ function onInput(event: Event): void {
 
   // Reject below min (if min >= 0, negative values are rejected)
   if (props.min !== undefined && parsed < props.min) {
-    // Do not emit — user typed an out-of-range intermediate value
-    // (we preserve raw string so they can continue editing)
+    // Do not emit the out-of-range value, but no longer fail silently — tell
+    // the consumer so it can show inline feedback (UX-011).
+    emit('reject', { reason: 'min' })
     return
   }
 
   // Reject above max
   if (props.max !== undefined && parsed > props.max) {
+    emit('reject', { reason: 'max' })
     return
   }
 

--- a/frontend/src/shared/components/__tests__/DecimalInput.spec.ts
+++ b/frontend/src/shared/components/__tests__/DecimalInput.spec.ts
@@ -106,6 +106,64 @@ describe('DecimalInput — min enforcement', () => {
   })
 })
 
+describe('DecimalInput — forbidden characters & out-of-range rejection', () => {
+  function rejections(wrapper: ReturnType<typeof mount>): { reason: string }[] {
+    return (wrapper.emitted('reject') ?? []).map((e) => e[0] as { reason: string })
+  }
+
+  function values(wrapper: ReturnType<typeof mount>): unknown[] {
+    return (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0])
+  }
+
+  // @UT-UI-COMP-DECIMAL-010@
+  it('strips "e" and emits reject(invalid) instead of expanding "1e2" to 100', async () => {
+    const wrapper = mount(DecimalInput, { props: { modelValue: null, allowNull: true } })
+    await typeValue(wrapper, '1e2')
+
+    expect(values(wrapper)).not.toContain(100)
+    expect(rejections(wrapper).some((r) => r.reason === 'invalid')).toBe(true)
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('12')
+  })
+
+  // @UT-UI-COMP-DECIMAL-010@
+  it('strips a leading "+" and flags it invalid', async () => {
+    const wrapper = mount(DecimalInput, { props: { modelValue: null, allowNull: true } })
+    await typeValue(wrapper, '+5')
+
+    expect(rejections(wrapper).some((r) => r.reason === 'invalid')).toBe(true)
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('5')
+  })
+
+  // @UT-UI-COMP-DECIMAL-010@
+  it('emits reject(min) and no value when the typed number is below min', async () => {
+    const wrapper = mount(DecimalInput, { props: { modelValue: 10, min: 5 } })
+    await typeValue(wrapper, '2')
+
+    expect(values(wrapper)).not.toContain(2)
+    expect(rejections(wrapper).some((r) => r.reason === 'min')).toBe(true)
+  })
+
+  // @UT-UI-COMP-DECIMAL-010@
+  it('emits reject(max) and no value when the typed number is above max', async () => {
+    const wrapper = mount(DecimalInput, { props: { modelValue: 10, max: 100 } })
+    await typeValue(wrapper, '150')
+
+    expect(values(wrapper)).not.toContain(150)
+    expect(rejections(wrapper).some((r) => r.reason === 'max')).toBe(true)
+  })
+
+  // @UT-UI-COMP-DECIMAL-010@
+  it('does not emit reject for a clean in-range value', async () => {
+    const wrapper = mount(DecimalInput, {
+      props: { modelValue: null, allowNull: true, min: 0, max: 100 },
+    })
+    await typeValue(wrapper, '42')
+
+    expect(wrapper.emitted('reject')).toBeFalsy()
+    expect(values(wrapper)).toContain(42)
+  })
+})
+
 describe('DecimalInput — external modelValue sync', () => {
   // @UT-UI-COMP-DECIMAL-008@
   it('syncs rawString when parent resets modelValue to null', async () => {

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -425,3 +425,10 @@ MB (auto)
       - frontend/src/modules/mass-balance/data/occupant-presets.ts
     req:
       - REQ-UQ-001
+
+  IMP-MB-UI-009
+    title: Sanitised decimal station input (DecimalInput pattern) with transient inline rejection feedback (UX-010/UX-011)
+    files:
+      - frontend/src/modules/mass-balance/components/MassStationInput.vue
+    req:
+      - REQ-UQ-001

--- a/trace/unit_test/mb.yaml
+++ b/trace/unit_test/mb.yaml
@@ -1458,3 +1458,10 @@ MB (auto)
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:
       - IMP-MB-VIEW-011
+
+  UT-MB-UI-003
+    title: '"e"/out-of-range station-input rejection + transient inline feedback'
+    files:
+      - frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
+    impl:
+      - IMP-MB-UI-009


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Resolves release-audit findings **UX-010** and **UX-011** for Mass & Balance station inputs.

- `MassStationInput` used a native `type=number` field, so `"e"`/`"+"` slipped through and `"1e2"` was silently parsed as `100` (UX-010). The field now renders through `DecimalInput` (type=text + `inputmode=decimal` + regex sanitiser) — steppers, slider, presets and the unusable-fuel clamp are preserved.
- `DecimalInput` silently swallowed out-of-range / forbidden input with no emit and no feedback (UX-011). It now strips non-decimal characters (`e`/`E`/`+`) and emits an additive `reject` event (`invalid` | `min` | `max`) — a corrupted value can never be committed. Existing aircraft-module consumers are unaffected (they ignore the new event).
- `MassStationInput` surfaces a transient inline hint and an immediate error border when a keystroke is blocked.
- Unit tests added for `"e"`/out-of-range rejection and inline feedback on both components.

### Related Issues

Closes #278

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-UQ-001`

### Documentation Updates

- [x] **Requirements:** N/A (Reason: no requirement created/changed — traces to existing `REQ-UQ-001`, which already has implementations; this adds one facet, not full implementation, so status stays `Approved`).
- [x] **Architecture:** N/A (Reason: no architectural/interface change — reuses the existing `DecimalInput` pattern; P2/P3 only).
- [x] **Risk Management:** N/A (Reason: no hazard added or re-mapped; hardens garbage-in defence for M&B inputs without changing any `H-xxx` mitigation).
- [x] **Journeys:** N/A (Reason: input sanitisation under `REQ-UQ-001` is covered by QA/unit suites per the UQ Exception in `docs/testing/TESTING.md`, not at journey level).
- [x] **Code Docs:** N/A (Reason: `CHANGELOG.md` is reserved for the release process per the implement-issue policy; no API/README change).

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules) — no `src/core/` files touched.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added/updated and passing locally (`test:unit` — 1424 passed, incl. new rejection/feedback specs).
- [x] **Integration Tests:** Passing (`test:integration` — 64 passed; behaviour is component-level, covered by unit tests, so no new integration test required).
- [x] **Manual Testing:** N/A (Reason: not mandatory for a `develop`-target PR and no interactive browser session is available in CI; behaviour verified via component unit tests + integration + production build).
- [x] **DoD:** All Definition of Done items from #278 are met and ticked.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** N/A (Reason: no P1/architectural interface change — reuses the existing shared `DecimalInput` component pattern).
