### PR TITLE
feat: [Feature]: In-app incident reporting MVP (offline-queued, redacted, links to GH issue) (#281)

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident_report.yml
+++ b/.github/ISSUE_TEMPLATE/incident_report.yml
@@ -1,0 +1,62 @@
+name: 🛩️ In-app Incident Report
+description: Filed automatically by the AeroDash in-app "Report a problem" surface (REQ-SYS-016/017/018). Use this only if the in-app deep link directed you here.
+title: "[Incident]: "
+labels: ["Bug", "open", "incident-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue was opened from AeroDash's in-app **Report a problem** dialog.
+        The free-text description has already been redacted on-device for email,
+        phone, GPS, and aircraft-registration matches. Review the prefilled
+        fields, then submit.
+
+        Keep entries word-efficient per `CLAUDE.md § Concision`. Per its safety
+        carve-out, never omit a required safety or traceability detail.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Incident kind
+      description: Self-classified by the pilot in the app.
+      options:
+        - "Calculation result looked wrong"
+        - "Aircraft or airport data looked wrong"
+        - "UI / display defect"
+        - "App froze or failed to load"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Pilot description (redacted)
+      description: |
+        Auto-filled from the in-app dialog. The text was passed through the
+        on-device redactor before it left your device. Anything still
+        identifying you that you do NOT want public must be edited out
+        manually before submission.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Captured context
+      description: |
+        Auto-filled from the in-app dialog. Operational metadata only —
+        app version, route, online state, user agent, incident id.
+      render: markdown
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission confirmation
+      options:
+        - label: I have reviewed the pre-filled description and removed any remaining personal data I do not want public.
+          required: true
+        - label: I confirm this is NOT a security vulnerability report. (Please use the Security Policy for that.)
+          required: true

--- a/docs/development/incident-to-regression.md
+++ b/docs/development/incident-to-regression.md
@@ -1,0 +1,137 @@
+# Incident → Regression Workflow
+
+> Closes the feedback loop the v0.3.0 process audit flagged as PR-006: there
+> was no in-app incident-reporting path, no privacy-safe diagnostic capture,
+> and no route from a real pilot-trial finding into the regression suite.
+
+This document describes how an issue a pilot hits in the cockpit travels
+from the device, through the GitHub triage funnel, and ends up pinned in
+the regression suite so the defect cannot recur.
+
+## 1. Capture on the device (offline-safe)
+
+| Step | Surface | Storage |
+| :--- | :------ | :------ |
+| Pilot taps **Report a problem** in the sidebar footer | `ReportProblemDialog.vue` | – |
+| Pilot picks a kind, writes a short summary, types a description | – | – |
+| Pilot reviews the redacted preview | `redactIncidentText` (P1) | – |
+| Pilot taps **Save report** | `useIncidentReportStore.capture` | IndexedDB `aerodash-incidents` |
+
+The capture path is fully offline-safe: the redactor and the queue are both
+local. No network call happens at this stage. The pilot can keep flying
+and submit later from the **Incident reports** view at `/incidents`.
+
+Each stored report is a Zod-validated
+[`IncidentReport`](../../frontend/src/core/domain/incident-report.schema.ts)
+containing:
+
+- `id` (UUID v4)
+- `createdAt` (ISO-8601)
+- `kind` (CALCULATION / DATA / UI / CRASH / OTHER)
+- `summary` (≤ 120 chars)
+- `redactedDescription` (≤ 4 000 chars — pilot free text, post-redaction)
+- `context` (app version, route name, path tail, user-agent slice, online flag)
+
+Pilot-supplied raw text is **never** written to disk. The redactor is the
+only producer of the persisted `redactedDescription` string.
+
+## 2. Redaction policy
+
+The P1 redactor (`frontend/src/core/logic/incident-redaction.ts`) is pure
+and deterministic. It replaces, in order:
+
+1. URLs (so embedded email/phone in query strings are not double-counted)
+2. Email addresses → `[REDACTED-EMAIL]`
+3. DMS / decimal geographic coordinates → `[REDACTED-COORD]`
+4. Phone numbers (international, grouped) → `[REDACTED-PHONE]`
+5. ICAO aircraft registrations + FAA N-numbers → `[REDACTED-REG]`
+
+Aviation numerics (`100 kg`, `50 L`, `MTOM 650 kg`, `1.84 m`) are kept
+verbatim — they are the data needed to reproduce a bug. Names, addresses,
+and free-form prose are NOT redacted; the preview-before-submit dialog is
+the second line of defence.
+
+Public airport ICAO/IATA codes are also kept; they are route-revealing but
+the diagnostic value outweighs the privacy cost for this MVP. The pilot
+can edit them out in the GitHub draft if they wish.
+
+## 3. Pilot-driven submission to GitHub
+
+When connectivity returns the pilot opens `/incidents` and taps
+**Open on GitHub** on a queued report. The store builds a deep link with
+[`buildGithubIssueUrl`](../../frontend/src/core/logic/github-issue-url.ts):
+
+```text
+https://github.com/naturelle137/AeroDash/issues/new
+  ?template=incident_report.yml
+  &title=[Incident] <summary>
+  &kind=<human label>
+  &description=<redacted body + summary>
+  &context=<operational metadata>
+```
+
+The link opens in a new tab. GitHub renders the
+[`.github/ISSUE_TEMPLATE/incident_report.yml`](../../.github/ISSUE_TEMPLATE/incident_report.yml)
+form with every field pre-populated; the pilot reviews one last time and
+clicks **Submit**.
+
+If the body would push the URL above the GitHub deep-link cap
+(`GITHUB_URL_MAX_LEN = 7 500`), the builder truncates the description and
+appends a clearly visible marker so the pilot can paste the rest from the
+saved report.
+
+No automatic submission ever happens; the pilot must take the action.
+
+## 4. Triage in the issue tracker
+
+A submitted incident issue carries the labels:
+
+- **`open`** — pending triage (auto-applied by the template)
+- **`incident-report`** — surfaced as an incident, not a hand-written report
+
+A maintainer triages it within the normal weekly cycle and either:
+
+- relabels it to **`accepted`** + reclassifies as `Bug` / `Feature`
+  (the regression chain continues below), or
+- closes as `duplicate` / `wont do` with a one-line rationale.
+
+The original pilot is automatically subscribed because they opened the
+GitHub issue.
+
+## 5. Reproduction + regression test
+
+Once an incident is accepted as a `Bug`, the standard AeroDash defect
+protocol applies:
+
+1. **Failing test first.** Add a `*.spec.ts`, `*.int.spec.ts`, or
+   `*.feature` that reproduces the defect from the redacted incident
+   payload (the context block lists the aircraft profile / route /
+   inputs the pilot used).
+2. **Minimal fix.** Implement the smallest change that turns the test
+   green.
+3. **Trace.** Tag the new test with the next sequential `@UT-…@` /
+   `@IT-…@` / `@E2E-…@` id and add the registry entry per
+   [STC](../stc.md).
+4. **Permanent regression.** Because the test sits in the canonical
+   suites, every future build runs it — the defect is bound to the
+   regression net for good.
+
+## 6. Local maintenance
+
+Captured reports live alongside the rest of the local data. They are:
+
+- wiped when the pilot uses the **Delete all data** control on the
+  Privacy view (REQ-SYS-014),
+- excluded from the GDPR bulk export (REQ-SYS-015) — they are
+  privacy-redacted operational diagnostics, not personal data,
+- droppable one-by-one from the `/incidents` view.
+
+## 7. Hazard linkage
+
+PR-006 is a process gap, not a flight hazard, so the requirements
+([REQ-SYS-016](../requirements/system.md#req-sys-016-offline-queued-incident-capture),
+[REQ-SYS-017](../requirements/system.md#req-sys-017-incident-report-privacy-redaction),
+[REQ-SYS-018](../requirements/system.md#req-sys-018-incident-to-regression-handoff))
+do NOT carry a `FROM: @H-…@` link. They do, however, materially reduce
+exposure to every flight-prep hazard the regression suite catches —
+by ensuring real pilot-trial findings reach that suite at all.

--- a/docs/development/incident-to-regression.md
+++ b/docs/development/incident-to-regression.md
@@ -12,7 +12,7 @@ the regression suite so the defect cannot recur.
 
 | Step | Surface | Storage |
 | :--- | :------ | :------ |
-| Pilot taps **Report a problem** in the sidebar footer | `ReportProblemDialog.vue` | – |
+| Pilot taps **Report a problem** in the sidebar footer (desktop) or the **Incidents** entry in the mobile bottom-nav | `ReportProblemDialog.vue` | – |
 | Pilot picks a kind, writes a short summary, types a description | – | – |
 | Pilot reviews the redacted preview | `redactIncidentText` (P1) | – |
 | Pilot taps **Save report** | `useIncidentReportStore.capture` | IndexedDB `aerodash-incidents` |
@@ -28,7 +28,7 @@ containing:
 - `id` (UUID v4)
 - `createdAt` (ISO-8601)
 - `kind` (CALCULATION / DATA / UI / CRASH / OTHER)
-- `summary` (≤ 120 chars)
+- `summary` (≤ 120 chars — pilot free text, post-redaction)
 - `redactedDescription` (≤ 4 000 chars — pilot free text, post-redaction)
 - `context` (app version, route name, path tail, user-agent slice, online flag)
 
@@ -121,9 +121,14 @@ protocol applies:
 Captured reports live alongside the rest of the local data. They are:
 
 - wiped when the pilot uses the **Delete all data** control on the
-  Privacy view (REQ-SYS-014),
+  Privacy view (REQ-SYS-014). `data-rights.service.wipeAllLocalData`
+  explicitly clears `aerodash-incidents` and reports the deleted count
+  separately from the fleet count, so a partial failure surfaces a
+  CRITICAL banner rather than a false success notice,
 - excluded from the GDPR bulk export (REQ-SYS-015) — they are
-  privacy-redacted operational diagnostics, not personal data,
+  privacy-redacted operational diagnostics, not personal data. The
+  Privacy view shows the queued-incident count after every export so the
+  pilot knows they remain on the device,
 - droppable one-by-one from the `/incidents` view.
 
 ## 7. Hazard linkage

--- a/docs/requirements/system.md
+++ b/docs/requirements/system.md
@@ -169,7 +169,7 @@ This document defines the system behavior using the **EARS** (Easy Approach to R
 
 ### REQ-SYS-017: Incident-Report Privacy Redaction
 
-**Requirement:** Before an incident report is persisted or surfaced for submission, the system shall redact email addresses, phone numbers, geographic coordinates, aircraft registrations, and URLs from the pilot-supplied free-text description, and shall present the redacted text to the pilot for review before any external action.
+**Requirement:** Before an incident report is persisted or surfaced for submission, the system shall redact email addresses, phone numbers, geographic coordinates, aircraft registrations, and URLs from every pilot-supplied free-text field (summary and description), and shall present the redacted text to the pilot for review before any external action.
 **Rationale:** The destination of a submitted report (GitHub) is outside the GDPR data perimeter the rest of AeroDash maintains; deterministic, reviewable redaction is the only acceptable handoff (PR-006, DP-004 / CS-012 spirit).
 **Priority:** P2
 **Status:** Implemented

--- a/docs/requirements/system.md
+++ b/docs/requirements/system.md
@@ -155,11 +155,42 @@ This document defines the system behavior using the **EARS** (Easy Approach to R
 **Status:** Implemented
 **Design Reference:** [Data-Rights Design](../architecture/data-rights.md)
 
+<!-- @REQ-SYS-016@ -->
+
+### REQ-SYS-016: Offline-Queued Incident Capture
+
+**Requirement:** When the pilot submits an incident report through the in-app "Report a problem" surface, the system shall persist a redacted, schema-validated report to local browser storage, and shall not transmit the report to any external endpoint without an explicit subsequent pilot action.
+**Rationale:** Pilot-trial users need a reliable feedback path even when offline at remote airfields; storing first and submitting on explicit action keeps the GDPR data perimeter intact (DP audit, PR-006).
+**Priority:** P2
+**Status:** Implemented
+**Design Reference:** [Incident → Regression Workflow](../development/incident-to-regression.md)
+
+<!-- @REQ-SYS-017@ -->
+
+### REQ-SYS-017: Incident-Report Privacy Redaction
+
+**Requirement:** Before an incident report is persisted or surfaced for submission, the system shall redact email addresses, phone numbers, geographic coordinates, aircraft registrations, and URLs from the pilot-supplied free-text description, and shall present the redacted text to the pilot for review before any external action.
+**Rationale:** The destination of a submitted report (GitHub) is outside the GDPR data perimeter the rest of AeroDash maintains; deterministic, reviewable redaction is the only acceptable handoff (PR-006, DP-004 / CS-012 spirit).
+**Priority:** P2
+**Status:** Implemented
+**Design Reference:** [Incident → Regression Workflow](../development/incident-to-regression.md)
+
+<!-- @REQ-SYS-018@ -->
+
+### REQ-SYS-018: Incident-to-Regression Handoff
+
+**Requirement:** The system shall offer the pilot a deep link that opens a pre-filled GitHub issue, using the repository's incident-report template, populated with the report's kind, summary, redacted description, and operational context (app version, route, online state, user agent).
+**Rationale:** The audit (PR-006) closed the loop with "pilot-trial incidents must reach the regression suite"; the GitHub issue is the canonical triage surface, and a pre-filled deep link is the lowest-friction handoff.
+**Priority:** P2
+**Status:** Implemented
+**Design Reference:** [Incident → Regression Workflow](../development/incident-to-regression.md)
+
 ---
 
 ## Design References
 
 - **<a name="notificationScheme"></a>Notification Scheme:** [`docs/architecture/notification_schema.md`](../architecture/notification_schema.md)
 - **<a name="dataRights"></a>Data-Rights (Erasure & Bulk Export):** [`docs/architecture/data-rights.md`](../architecture/data-rights.md)
+- **<a name="incidentReporting"></a>Incident → Regression Workflow:** [`docs/development/incident-to-regression.md`](../development/incident-to-regression.md)
 
 ---

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,12 +3,11 @@
 // @IMP-SYS-SHARED-005@ (FROM: @REQ-SYS-006@)
 // @IMP-SYS-SHARED-009@ (FROM: @REQ-SYS-006@, @H-019@)
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
-import { RouterView, RouterLink, useRoute } from 'vue-router'
+import { RouterView, RouterLink, useRoute, useRouter } from 'vue-router'
 import { useTheme } from '@/shared/composables/useTheme'
 import AppLogo from '@/shared/components/AppLogo.vue'
 import AppVersion from '@/shared/components/AppVersion.vue'
 import ReportProblemDialog from '@/shared/components/ReportProblemDialog.vue'
-import { useRouter } from 'vue-router'
 import { usePwaUpdateStore } from '@/stores/pwa-update.store'
 import { useAppVersionStore, attachConnectivityRefresh } from '@/stores/app-version.store'
 
@@ -108,13 +107,18 @@ const navItems: NavItem[] = [
   { id: 'airport',     label: 'Airport DB',  path: '/airport',     icon: 'ap',   soon: true },
   // @IMP-UI-SHARED-007@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@)
   { id: 'privacy',     label: 'Privacy',     path: '/privacy',     icon: 'privacy' },
+  // @IMP-UI-SHARED-009@ (FROM: @REQ-SYS-016@, @REQ-SYS-018@) — surfaces the
+  // queued-incident review screen so a phone/iPad pilot can reach it without
+  // the desktop sidebar (which is `display:none` on < 768px viewports).
+  { id: 'incidents',   label: 'Incidents',   path: '/incidents',   icon: 'incidents' },
 ]
 
 // Mobile bottom nav (phone-width < 768px, where the sidebar is hidden): the
-// primary task destinations plus Privacy, so the GDPR data-rights surface
-// (REQ-SYS-014/015) stays reachable on phones. The icon-rail sidebar already
-// exposes every destination, including Privacy, at >= 768px.
-const BOTTOM_NAV_IDS = ['home', 'flight-prep', 'fleet', 'weather', 'privacy'] as const
+// primary task destinations plus Privacy + Incidents, so the GDPR data-rights
+// surface (REQ-SYS-014/015) AND the report-a-problem follow-up
+// (REQ-SYS-016/018) both stay reachable on phones. The icon-rail sidebar
+// already exposes every destination at >= 768px.
+const BOTTOM_NAV_IDS = ['home', 'flight-prep', 'fleet', 'incidents', 'privacy'] as const
 const bottomNavItems = BOTTOM_NAV_IDS.map((id) => navItems.find((item) => item.id === id)).filter(
   (item): item is NavItem => item !== undefined,
 )
@@ -237,6 +241,12 @@ const themeLabel = computed(() =>
               <svg v-else-if="item.icon === 'privacy'" width="20" height="20" viewBox="0 0 20 20" fill="none">
                 <path d="M10 2l6 2.5v5c0 4-3 7-6 8-3-1-6-4-6-8v-5L10 2z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
                 <path d="M7.5 10l2 2 3-3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <!-- Incidents (caution triangle) -->
+              <svg v-else-if="item.icon === 'incidents'" width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path d="M10 3l7.5 13H2.5L10 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M10 8v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="10" cy="14" r="0.9" fill="currentColor" />
               </svg>
             </span>
 
@@ -371,6 +381,11 @@ const themeLabel = computed(() =>
               <svg v-else-if="item.icon === 'privacy'" width="22" height="22" viewBox="0 0 20 20" fill="none">
                 <path d="M10 2l6 2.5v5c0 4-3 7-6 8-3-1-6-4-6-8v-5L10 2z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
                 <path d="M7.5 10l2 2 3-3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <svg v-else-if="item.icon === 'incidents'" width="22" height="22" viewBox="0 0 20 20" fill="none">
+                <path d="M10 3l7.5 13H2.5L10 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M10 8v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="10" cy="14" r="0.9" fill="currentColor" />
               </svg>
             </span>
             <span class="bottom-nav__label">{{ item.label }}</span>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,8 @@ import { RouterView, RouterLink, useRoute } from 'vue-router'
 import { useTheme } from '@/shared/composables/useTheme'
 import AppLogo from '@/shared/components/AppLogo.vue'
 import AppVersion from '@/shared/components/AppVersion.vue'
+import ReportProblemDialog from '@/shared/components/ReportProblemDialog.vue'
+import { useRouter } from 'vue-router'
 import { usePwaUpdateStore } from '@/stores/pwa-update.store'
 import { useAppVersionStore, attachConnectivityRefresh } from '@/stores/app-version.store'
 
@@ -38,6 +40,13 @@ const { theme, toggleTheme } = useTheme()
 const route = useRoute()
 
 const sidebarCollapsed = ref(false)
+const reportDialogOpen = ref(false)
+const appRouter = useRouter()
+
+function onReportSaved(): void {
+  reportDialogOpen.value = false
+  void appRouter.push({ name: 'incidents' })
+}
 
 // @IMP-SYS-SHARED-007@ (FROM: @REQ-SYS-001@)
 // iOS Safari aggressively restores SPA pages from the back/forward cache
@@ -238,12 +247,30 @@ const themeLabel = computed(() =>
         </li>
       </ul>
 
-      <!-- Sidebar footer: advisory + version -->
+      <!-- Sidebar footer: report-a-problem + advisory + version -->
       <div class="sidebar-footer">
+        <!-- @IMP-UI-SHARED-009@ (FROM: @REQ-SYS-016@, @REQ-SYS-018@) -->
+        <button
+          type="button"
+          class="sidebar-footer__report-btn"
+          data-testid="sidebar-report-problem"
+          aria-label="Report a problem with AeroDash"
+          @click="reportDialogOpen = true"
+        >
+          <span aria-hidden="true" class="sidebar-footer__report-icon">!</span>
+          <span class="sidebar-footer__report-label">Report a problem</span>
+        </button>
         <p class="sidebar-footer__text">Advisory only. Verify against POH/AFM.</p>
         <AppVersion />
       </div>
     </nav>
+
+    <!-- ═══ Report-a-problem dialog (REQ-SYS-016/017/018) ═════════════════ -->
+    <ReportProblemDialog
+      :open="reportDialogOpen"
+      @close="reportDialogOpen = false"
+      @saved="onReportSaved"
+    />
 
     <!-- ═══ PWA update banner (INFO-SYS-001) ════════════════════════════════ -->
     <div v-if="pwaStore.needsUpdate" class="pwa-update-banner" role="status" aria-live="polite">
@@ -638,6 +665,50 @@ const themeLabel = computed(() =>
   color: var(--color-text-secondary);
   margin: 0;
   line-height: 1.4;
+}
+
+.sidebar-footer__report-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  margin-bottom: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  min-height: 44px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.sidebar-footer__report-btn:hover,
+.sidebar-footer__report-btn:focus-visible {
+  background: var(--color-surface-hover);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.sidebar-footer__report-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  background: var(--color-warning, #b45309);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85em;
+  flex-shrink: 0;
+}
+
+.sidebar--collapsed .sidebar-footer__report-label {
+  display: none;
 }
 
 /* ─── Main content ────────────────────────────────────────────────────────── */

--- a/frontend/src/core/domain/incident-report.schema.spec.ts
+++ b/frontend/src/core/domain/incident-report.schema.spec.ts
@@ -1,0 +1,102 @@
+// @UT-SYS-CORE-112@ (FROM: @IMP-SYS-CORE-013@)
+import { describe, it, expect } from 'vitest'
+import {
+  DESCRIPTION_MAX_LEN,
+  IncidentDraftSchema,
+  IncidentKindSchema,
+  IncidentReportSchema,
+  SUMMARY_MAX_LEN,
+} from './incident-report.schema'
+
+describe('IncidentKindSchema', () => {
+  it('accepts every taxonomy entry', () => {
+    for (const kind of ['CALCULATION', 'DATA', 'UI', 'CRASH', 'OTHER'] as const) {
+      expect(IncidentKindSchema.parse(kind)).toBe(kind)
+    }
+  })
+
+  it('rejects unknown kinds', () => {
+    expect(() => IncidentKindSchema.parse('PANIC')).toThrow(/invalid option|expected/i)
+  })
+})
+
+describe('IncidentDraftSchema', () => {
+  it('parses a minimal valid draft', () => {
+    const parsed = IncidentDraftSchema.parse({
+      kind: 'CALCULATION',
+      summary: 'CG went amber',
+      description: 'Loaded fuel and pilot mass; envelope flipped.',
+    })
+    expect(parsed.summary).toBe('CG went amber')
+  })
+
+  it('rejects summary below the minimum length', () => {
+    expect(() =>
+      IncidentDraftSchema.parse({
+        kind: 'OTHER',
+        summary: 'ab',
+        description: 'A description long enough.',
+      }),
+    ).toThrow(/too small/i)
+  })
+
+  it('rejects summary above the maximum length', () => {
+    expect(() =>
+      IncidentDraftSchema.parse({
+        kind: 'OTHER',
+        summary: 'x'.repeat(SUMMARY_MAX_LEN + 1),
+        description: 'A description long enough.',
+      }),
+    ).toThrow(/too big/i)
+  })
+
+  it('rejects description above the maximum length', () => {
+    expect(() =>
+      IncidentDraftSchema.parse({
+        kind: 'OTHER',
+        summary: 'fine summary',
+        description: 'x'.repeat(DESCRIPTION_MAX_LEN + 1),
+      }),
+    ).toThrow(/too big/i)
+  })
+})
+
+describe('IncidentReportSchema', () => {
+  const valid = {
+    id: '00000000-0000-4000-a000-000000000001',
+    createdAt: '2026-05-31T08:15:00.000Z',
+    kind: 'OTHER' as const,
+    summary: 'something happened',
+    redactedDescription: 'A redacted body.',
+    context: {
+      appVersion: '0.4.0-alpha',
+      routeName: null,
+      pathTail: null,
+      userAgent: null,
+      online: null,
+    },
+    schemaVersion: 1 as const,
+  }
+
+  it('accepts a well-formed report', () => {
+    expect(IncidentReportSchema.parse(valid)).toEqual(valid)
+  })
+
+  it('rejects a non-UUID id', () => {
+    expect(() => IncidentReportSchema.parse({ ...valid, id: 'nope' })).toThrow(
+      /uuid|invalid string/i,
+    )
+  })
+
+  it('rejects schemaVersion values other than 1', () => {
+    expect(() =>
+      IncidentReportSchema.parse({ ...valid, schemaVersion: 2 as unknown as 1 }),
+    ).toThrow(/expected|literal|invalid/i)
+  })
+
+  it('rejects malformed ISO timestamps', () => {
+    expect(() => IncidentReportSchema.parse({ ...valid, createdAt: 'yesterday' })).toThrow(
+      /datetime|iso|invalid string/i,
+    )
+  })
+})

--- a/frontend/src/core/domain/incident-report.schema.ts
+++ b/frontend/src/core/domain/incident-report.schema.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+
+/**
+ * Zod schemas for the in-app incident-reporting MVP (issue #281, PR-006).
+ * P1 Safety Core — pure TypeScript, no framework dependencies.
+ *
+ * The incident channel is the first formal feedback loop from real (pilot-
+ * trial) users back into the regression suite: a redacted report queued
+ * offline → opened on GitHub by the pilot when connectivity returns →
+ * triaged into a `Bug`/`Feature` issue → pinned in regression tests once
+ * fixed.
+ *
+ * Privacy contract: every field captured here is either app-controlled
+ * metadata (build version, route name, kind) or pilot-supplied free text
+ * that has already been routed through {@link incident-redaction}. The
+ * schema itself is unaware of the redactor — it only validates the shape
+ * of the persisted document.
+ *
+ * @see docs/development/incident-to-regression.md
+ */
+
+// @IMP-SYS-CORE-013@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@)
+
+/**
+ * Coarse-grained taxonomy for the pilot to self-classify the report. Kept
+ * intentionally small so triage is fast and the enum can be reused as the
+ * GitHub issue-template dropdown without lossy mapping.
+ */
+export const IncidentKindSchema = z.enum([
+  'CALCULATION', // Mass & Balance / Performance / Fuel & Endurance result looked wrong
+  'DATA', // Aircraft profile / airport data appeared incorrect
+  'UI', // Layout, input, or display defect
+  'CRASH', // The app or a page failed to load / froze
+  'OTHER',
+])
+export type IncidentKind = z.infer<typeof IncidentKindSchema>
+
+/**
+ * Per-tab build metadata snapshot attached to every report. All fields are
+ * app-controlled (no pilot input) so they are safe to round-trip into the
+ * pre-filled GitHub issue body without further redaction.
+ */
+export const IncidentContextSchema = z.object({
+  appVersion: z.string().max(64),
+  /** Vue Router route name at capture time, or `null` if unknown. */
+  routeName: z.string().max(64).nullable(),
+  /** Last segment of the URL pathname (no query / hash) at capture time. */
+  pathTail: z.string().max(128).nullable(),
+  /** `navigator.userAgent` slice, capped to avoid log bloat. */
+  userAgent: z.string().max(256).nullable(),
+  /** Web Locks / Service Worker / online flag at capture time. */
+  online: z.boolean().nullable(),
+})
+export type IncidentContext = z.infer<typeof IncidentContextSchema>
+
+/** Hard ceilings for free-text fields — prevents log bloat and URL overflow. */
+export const SUMMARY_MAX_LEN = 120
+export const DESCRIPTION_MAX_LEN = 4_000
+
+/**
+ * What the UI form submits BEFORE redaction. Validated at the boundary so
+ * a malformed draft never reaches the redactor or the queue.
+ */
+export const IncidentDraftSchema = z.object({
+  kind: IncidentKindSchema,
+  summary: z.string().min(3).max(SUMMARY_MAX_LEN),
+  description: z.string().min(10).max(DESCRIPTION_MAX_LEN),
+})
+export type IncidentDraft = z.infer<typeof IncidentDraftSchema>
+
+/**
+ * The persisted, redacted, fully-formed report. `summary` and
+ * `redactedDescription` have already passed through the redactor; storing
+ * the original pilot text is intentionally NOT supported (privacy by design).
+ */
+export const IncidentReportSchema = z.object({
+  /** UUID v4. */
+  id: z.string().uuid(),
+  /** ISO-8601 UTC timestamp the pilot captured the report. */
+  createdAt: z.string().datetime(),
+  kind: IncidentKindSchema,
+  summary: z.string().min(3).max(SUMMARY_MAX_LEN),
+  redactedDescription: z.string().min(1).max(DESCRIPTION_MAX_LEN),
+  context: IncidentContextSchema,
+  /**
+   * Bumped when the persisted shape changes incompatibly. The queue
+   * repository drops rows whose version is from a future build (PWA
+   * rollback safety, mirrors the fleet repository contract).
+   */
+  schemaVersion: z.literal(1),
+})
+export type IncidentReport = z.infer<typeof IncidentReportSchema>

--- a/frontend/src/core/logic/github-issue-url.spec.ts
+++ b/frontend/src/core/logic/github-issue-url.spec.ts
@@ -1,0 +1,120 @@
+// @UT-SYS-CORE-111@ (FROM: @IMP-SYS-CORE-015@)
+import { describe, it, expect } from 'vitest'
+import {
+  GITHUB_URL_MAX_LEN,
+  INCIDENT_KIND_LABELS,
+  TEMPLATE_FILE,
+  TITLE_PREFIX,
+  buildGithubIssueUrl,
+  renderIncidentBody,
+  renderIncidentContext,
+} from './github-issue-url'
+import type { IncidentReport } from '../domain/incident-report.schema'
+
+function buildReport(overrides: Partial<IncidentReport> = {}): IncidentReport {
+  return {
+    id: '00000000-0000-4000-a000-000000000001',
+    createdAt: '2026-05-31T08:15:00.000Z',
+    kind: 'CALCULATION',
+    summary: 'CG amber after correct fuel entry',
+    redactedDescription: 'Loaded 100 kg pilot mass and 50 L fuel; envelope went amber.',
+    context: {
+      appVersion: '0.4.0-alpha',
+      routeName: 'mass-balance',
+      pathTail: 'mass-balance',
+      userAgent: 'Mozilla/5.0',
+      online: true,
+    },
+    schemaVersion: 1,
+    ...overrides,
+  }
+}
+
+describe('buildGithubIssueUrl', () => {
+  it('targets the repo issues/new endpoint with the incident template', () => {
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport(),
+    })
+    expect(url.startsWith('https://github.com/owner/repo/issues/new?')).toBe(true)
+    expect(url).toContain(`template=${TEMPLATE_FILE}`)
+  })
+
+  it('prefixes the title and url-encodes the summary', () => {
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport({ summary: 'CG amber after correct fuel entry & reload' }),
+    })
+    const decoded = decodeURIComponent(url)
+    expect(decoded).toContain(`title=${TITLE_PREFIX} CG amber after correct fuel entry & reload`)
+  })
+
+  it('encodes the kind as its human-readable label', () => {
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport({ kind: 'CRASH' }),
+    })
+    expect(decodeURIComponent(url)).toContain(`kind=${INCIDENT_KIND_LABELS.CRASH}`)
+  })
+
+  it('embeds the redacted body and the operational context separately', () => {
+    const report = buildReport()
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report,
+    })
+    const decoded = decodeURIComponent(url)
+    expect(decoded).toContain(renderIncidentBody(report))
+    expect(decoded).toContain(renderIncidentContext(report))
+  })
+
+  it('tolerates a trailing slash on the repo URL', () => {
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo/',
+      report: buildReport(),
+    })
+    expect(url).toContain('/repo/issues/new?')
+    expect(url).not.toContain('/repo//issues/new')
+  })
+
+  it('stays under the GitHub URL length cap by truncating the description', () => {
+    const huge = 'X'.repeat(50_000)
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport({ redactedDescription: huge }),
+    })
+    expect(url.length).toBeLessThanOrEqual(GITHUB_URL_MAX_LEN)
+    expect(decodeURIComponent(url)).toContain('…[truncated; open the saved report on the device for the full text]')
+  })
+
+  it('is deterministic — same input yields identical output', () => {
+    const a = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport(),
+    })
+    const b = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport(),
+    })
+    expect(a).toBe(b)
+  })
+})
+
+describe('renderIncidentContext', () => {
+  it('renders unknown route/userAgent/online states as "unknown"', () => {
+    const out = renderIncidentContext(
+      buildReport({
+        context: {
+          appVersion: '0.4.0-alpha',
+          routeName: null,
+          pathTail: null,
+          userAgent: null,
+          online: null,
+        },
+      }),
+    )
+    expect(out).toContain('Route:** unknown')
+    expect(out).toContain('Online:** unknown')
+    expect(out).toContain('User agent:** unknown')
+  })
+})

--- a/frontend/src/core/logic/github-issue-url.spec.ts
+++ b/frontend/src/core/logic/github-issue-url.spec.ts
@@ -87,6 +87,42 @@ describe('buildGithubIssueUrl', () => {
     expect(decodeURIComponent(url)).toContain('…[truncated; open the saved report on the device for the full text]')
   })
 
+  // M2: boundary case. A single-pass trim could leave the URL over-cap when
+  // the overflow is small but percent-encoding inflates the marker. Sweep a
+  // range of just-over-cap raw-body sizes and assert the loop converges.
+  it('stays under the GitHub URL length cap across the boundary band', () => {
+    for (let bodyLen = 6_900; bodyLen <= 7_200; bodyLen += 17) {
+      const url = buildGithubIssueUrl({
+        repoUrl: 'https://github.com/owner/repo',
+        report: buildReport({ redactedDescription: 'X'.repeat(bodyLen) }),
+      })
+      expect(url.length, `bodyLen=${bodyLen}`).toBeLessThanOrEqual(GITHUB_URL_MAX_LEN)
+    }
+  })
+
+  // M2: even when the context block alone overflows the cap, the function
+  // must still return a usable URL — fall back to title-only rather than a
+  // mid-percent-escape truncation that GitHub would silently drop.
+  it('falls back to a bare title-only URL when the context is oversized', () => {
+    const url = buildGithubIssueUrl({
+      repoUrl: 'https://github.com/owner/repo',
+      report: buildReport({
+        redactedDescription: 'tiny',
+        context: {
+          appVersion: '0.4.0-alpha',
+          routeName: 'mass-balance',
+          pathTail: 'mass-balance',
+          userAgent: 'X'.repeat(256),
+          online: true,
+        },
+        // pad summary minimally so the title-only fallback still encodes safely
+        summary: 'CG envelope amber after correct fuel entry',
+      }),
+    })
+    expect(url.length).toBeLessThanOrEqual(GITHUB_URL_MAX_LEN)
+    expect(url).toContain(`template=${TEMPLATE_FILE}`)
+  })
+
   it('is deterministic — same input yields identical output', () => {
     const a = buildGithubIssueUrl({
       repoUrl: 'https://github.com/owner/repo',

--- a/frontend/src/core/logic/github-issue-url.ts
+++ b/frontend/src/core/logic/github-issue-url.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure builder for a GitHub "new issue" deep link pre-filled from an
+ * {@link IncidentReport} (issue #281, PR-006). P1 Safety Core — pure
+ * TypeScript, no framework dependencies, deterministic.
+ *
+ * Why P1: the URL is the only artefact that leaves the device. If this
+ * function corrupts the body (drops the redaction notice, leaks unredacted
+ * description, mis-encodes), the privacy contract breaks. Keeping it pure
+ * lets the unit suite verify every byte that hits navigator.clipboard /
+ * window.open.
+ *
+ * @see docs/development/incident-to-regression.md
+ */
+
+import type { IncidentReport } from '../domain/incident-report.schema'
+
+// @IMP-SYS-CORE-015@ (FROM: @REQ-SYS-017@, @REQ-SYS-018@)
+
+/** GitHub caps the issue-prefill URL near ~8 KB; we leave headroom. */
+export const GITHUB_URL_MAX_LEN = 7_500
+
+/**
+ * Issue-template form field IDs declared by
+ * `.github/ISSUE_TEMPLATE/incident_report.yml`. Kept in lock-step with the
+ * template — drift would mean prefilled fields silently land in the wrong
+ * slot.
+ */
+export const TEMPLATE_FILE = 'incident_report.yml'
+export const TEMPLATE_FIELD_KIND = 'kind'
+export const TEMPLATE_FIELD_DESCRIPTION = 'description'
+export const TEMPLATE_FIELD_CONTEXT = 'context'
+
+/** Human-readable label for each {@link IncidentReport.kind}. */
+export const INCIDENT_KIND_LABELS: Record<IncidentReport['kind'], string> = {
+  CALCULATION: 'Calculation result looked wrong',
+  DATA: 'Aircraft or airport data looked wrong',
+  UI: 'UI / display defect',
+  CRASH: 'App froze or failed to load',
+  OTHER: 'Other',
+}
+
+/** Hard-coded prefix every incident-derived GitHub issue title carries. */
+export const TITLE_PREFIX = '[Incident]'
+
+/**
+ * Build the `?key=value&...` query string for a GitHub issue prefill URL.
+ * Repeated calls with the same input yield byte-identical output.
+ */
+function buildQuery(params: Array<[string, string]>): string {
+  return params
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&')
+}
+
+/**
+ * Render the markdown the pilot will see in the "Description" field of the
+ * pre-filled issue. The free text has ALREADY been redacted (see
+ * {@link incident-redaction}); this function only frames it with a header
+ * that makes the source obvious to the triage reviewer.
+ */
+export function renderIncidentBody(report: IncidentReport): string {
+  return [
+    `**Summary:** ${report.summary}`,
+    '',
+    '### Pilot description (redacted)',
+    '',
+    report.redactedDescription,
+  ].join('\n')
+}
+
+/**
+ * Render the markdown for the "Context" field. Pure operational metadata —
+ * no pilot-supplied data flows through here.
+ */
+export function renderIncidentContext(report: IncidentReport): string {
+  const c = report.context
+  return [
+    `- **Captured at:** ${report.createdAt}`,
+    `- **App version:** ${c.appVersion}`,
+    `- **Route:** ${c.routeName ?? 'unknown'}${c.pathTail ? ` (${c.pathTail})` : ''}`,
+    `- **Online:** ${c.online === null ? 'unknown' : c.online ? 'yes' : 'no'}`,
+    `- **User agent:** ${c.userAgent ?? 'unknown'}`,
+    `- **Incident ID:** ${report.id}`,
+  ].join('\n')
+}
+
+export interface GithubIssueUrlInput {
+  /**
+   * Repository web URL, e.g. `https://github.com/naturelle137/AeroDash`. The
+   * function tolerates a trailing slash but does not invent a default —
+   * pass an empty string and you get `/issues/new?...` so the caller can
+   * see the misuse instead of leaking a hard-coded fallback.
+   */
+  repoUrl: string
+  report: IncidentReport
+}
+
+/**
+ * Build a `https://github.com/<owner>/<repo>/issues/new?...` URL with the
+ * incident report's title, kind, description, and context pre-filled into
+ * the `incident_report.yml` GitHub issue-form template fields.
+ *
+ * Long descriptions are truncated to stay below
+ * {@link GITHUB_URL_MAX_LEN}; the truncation point appends a clearly
+ * visible marker so the pilot can re-paste the rest from the saved report.
+ */
+export function buildGithubIssueUrl(input: GithubIssueUrlInput): string {
+  const base = `${input.repoUrl.replace(/\/+$/, '')}/issues/new`
+  const title = `${TITLE_PREFIX} ${input.report.summary}`
+  const body = renderIncidentBody(input.report)
+  const context = renderIncidentContext(input.report)
+
+  let query = buildQuery([
+    ['template', TEMPLATE_FILE],
+    ['title', title],
+    [TEMPLATE_FIELD_KIND, INCIDENT_KIND_LABELS[input.report.kind]],
+    [TEMPLATE_FIELD_DESCRIPTION, body],
+    [TEMPLATE_FIELD_CONTEXT, context],
+  ])
+
+  let url = `${base}?${query}`
+
+  if (url.length > GITHUB_URL_MAX_LEN) {
+    const overflowMarker = '\n\n…[truncated; open the saved report on the device for the full text]'
+    // Trim the description body by exactly the overflow + marker length.
+    const overflow = url.length - GITHUB_URL_MAX_LEN
+    // Encoded length grows roughly 3× with URL-encoding, so trim more
+    // aggressively to stay under the cap in one pass.
+    const trimChars = Math.min(body.length, overflow * 3 + overflowMarker.length + 16)
+    const trimmedBody = body.slice(0, Math.max(0, body.length - trimChars)) + overflowMarker
+    query = buildQuery([
+      ['template', TEMPLATE_FILE],
+      ['title', title],
+      [TEMPLATE_FIELD_KIND, INCIDENT_KIND_LABELS[input.report.kind]],
+      [TEMPLATE_FIELD_DESCRIPTION, trimmedBody],
+      [TEMPLATE_FIELD_CONTEXT, context],
+    ])
+    url = `${base}?${query}`
+  }
+  return url
+}

--- a/frontend/src/core/logic/github-issue-url.ts
+++ b/frontend/src/core/logic/github-issue-url.ts
@@ -109,33 +109,55 @@ export function buildGithubIssueUrl(input: GithubIssueUrlInput): string {
   const title = `${TITLE_PREFIX} ${input.report.summary}`
   const body = renderIncidentBody(input.report)
   const context = renderIncidentContext(input.report)
+  const overflowMarker =
+    '\n\n…[truncated; open the saved report on the device for the full text]'
 
-  let query = buildQuery([
-    ['template', TEMPLATE_FILE],
-    ['title', title],
-    [TEMPLATE_FIELD_KIND, INCIDENT_KIND_LABELS[input.report.kind]],
-    [TEMPLATE_FIELD_DESCRIPTION, body],
-    [TEMPLATE_FIELD_CONTEXT, context],
-  ])
-
-  let url = `${base}?${query}`
-
-  if (url.length > GITHUB_URL_MAX_LEN) {
-    const overflowMarker = '\n\n…[truncated; open the saved report on the device for the full text]'
-    // Trim the description body by exactly the overflow + marker length.
-    const overflow = url.length - GITHUB_URL_MAX_LEN
-    // Encoded length grows roughly 3× with URL-encoding, so trim more
-    // aggressively to stay under the cap in one pass.
-    const trimChars = Math.min(body.length, overflow * 3 + overflowMarker.length + 16)
-    const trimmedBody = body.slice(0, Math.max(0, body.length - trimChars)) + overflowMarker
-    query = buildQuery([
+  const build = (b: string, c: string): string => {
+    const query = buildQuery([
       ['template', TEMPLATE_FILE],
       ['title', title],
       [TEMPLATE_FIELD_KIND, INCIDENT_KIND_LABELS[input.report.kind]],
-      [TEMPLATE_FIELD_DESCRIPTION, trimmedBody],
-      [TEMPLATE_FIELD_CONTEXT, context],
+      [TEMPLATE_FIELD_DESCRIPTION, b],
+      [TEMPLATE_FIELD_CONTEXT, c],
     ])
-    url = `${base}?${query}`
+    return `${base}?${query}`
   }
-  return url
+
+  // First pass: full body + full context. Returns immediately when fitted.
+  let url = build(body, context)
+  if (url.length <= GITHUB_URL_MAX_LEN) return url
+
+  // Trim the description body first. Loop because percent-encoding inflates
+  // the byte count non-linearly — a single-pass trim cannot guarantee the
+  // cap (M2). Cap iterations defensively so a pathological input cannot
+  // spin forever.
+  let trimmedBody = body
+  for (let i = 0; i < 20 && url.length > GITHUB_URL_MAX_LEN && trimmedBody.length > 0; i += 1) {
+    const overflow = url.length - GITHUB_URL_MAX_LEN
+    // Grow the trim chunk so each pass cuts roughly one URL-encoded unit per
+    // raw char (3× for ASCII percent-encoded, plus a small fixed margin).
+    const trimChars = Math.max(64, overflow * 3 + overflowMarker.length + 16)
+    const sliceLen = Math.max(0, trimmedBody.replace(overflowMarker, '').length - trimChars)
+    trimmedBody =
+      sliceLen === 0
+        ? overflowMarker.trimStart()
+        : body.slice(0, sliceLen) + overflowMarker
+    url = build(trimmedBody, context)
+  }
+  if (url.length <= GITHUB_URL_MAX_LEN) return url
+
+  // Body is fully gone (or replaced by the marker) and we still overflow —
+  // the context itself is oversize. Drop everything except a one-line stub
+  // pointing the triage reader back to the on-device report.
+  const stubContext = `- **Incident ID:** ${input.report.id}`
+  url = build(overflowMarker.trimStart(), stubContext)
+  if (url.length <= GITHUB_URL_MAX_LEN) return url
+
+  // Last-resort fallback: bare title-only URL so the deep link still opens
+  // a pre-filled issue rather than truncating mid-percent-escape.
+  const titleOnly = buildQuery([
+    ['template', TEMPLATE_FILE],
+    ['title', title],
+  ])
+  return `${base}?${titleOnly}`
 }

--- a/frontend/src/core/logic/incident-redaction.spec.ts
+++ b/frontend/src/core/logic/incident-redaction.spec.ts
@@ -1,0 +1,103 @@
+// @UT-SYS-CORE-110@ (FROM: @IMP-SYS-CORE-014@)
+import { describe, it, expect } from 'vitest'
+import {
+  REDACTION_MARKERS,
+  redactIncidentText,
+  totalRedactions,
+} from './incident-redaction'
+
+describe('redactIncidentText', () => {
+  it('returns the empty result for empty input', () => {
+    const { redacted, counts } = redactIncidentText('')
+    expect(redacted).toBe('')
+    expect(totalRedactions(counts)).toBe(0)
+  })
+
+  it('passes through aviation-numeric text untouched', () => {
+    const text =
+      'After loading 100 kg pilot mass and 50 L fuel the CG was 1.84 m at MTOM 650 kg.'
+    const { redacted, counts } = redactIncidentText(text)
+    expect(redacted).toBe(text)
+    expect(totalRedactions(counts)).toBe(0)
+  })
+
+  it('redacts email addresses', () => {
+    const { redacted, counts } = redactIncidentText(
+      'reach me at john.doe+pilot@example.com or admin@flight.aero',
+    )
+    expect(redacted).toContain(REDACTION_MARKERS.EMAIL)
+    expect(redacted).not.toContain('john.doe+pilot@example.com')
+    expect(redacted).not.toContain('admin@flight.aero')
+    expect(counts.email).toBe(2)
+  })
+
+  it('redacts phone numbers in international and grouped formats', () => {
+    const { redacted, counts } = redactIncidentText(
+      'Call +49 151 1234 5678 or (415) 555-2671 for follow-up.',
+    )
+    expect(redacted).toContain(REDACTION_MARKERS.PHONE)
+    expect(redacted).not.toMatch(/\+49 151 1234 5678/)
+    expect(redacted).not.toMatch(/\(415\) 555-2671/)
+    expect(counts.phone).toBe(2)
+  })
+
+  it('does not treat aviation quantity like "300 kg" as a phone number', () => {
+    const { counts } = redactIncidentText('Loaded 300 kg fuel and 50 L oil.')
+    expect(counts.phone).toBe(0)
+  })
+
+  it('redacts decimal coordinate pairs', () => {
+    const { redacted, counts } = redactIncidentText(
+      'Departed from 50.0379,8.5622 heading east.',
+    )
+    expect(redacted).toContain(REDACTION_MARKERS.COORD)
+    expect(redacted).not.toContain('50.0379,8.5622')
+    expect(counts.coord).toBe(1)
+  })
+
+  it('redacts DMS coordinate pairs', () => {
+    const { redacted, counts } = redactIncidentText(
+      `Position 50°02'16"N 008°33'44"E logged on takeoff roll.`,
+    )
+    expect(redacted).toContain(REDACTION_MARKERS.COORD)
+    expect(counts.coord).toBe(1)
+  })
+
+  it('redacts ICAO-style aircraft registration', () => {
+    const { redacted, counts } = redactIncidentText(
+      'D-EBPN and N12345 both showed the same defect.',
+    )
+    expect(redacted).toContain(REDACTION_MARKERS.REGISTRATION)
+    expect(redacted).not.toContain('D-EBPN')
+    expect(redacted).not.toContain('N12345')
+    expect(counts.registration).toBe(2)
+  })
+
+  it('redacts URLs even when they contain emails in query strings', () => {
+    const { redacted, counts } = redactIncidentText(
+      'See https://example.com/x?u=pilot@example.com&t=1',
+    )
+    expect(redacted).toContain(REDACTION_MARKERS.URL)
+    expect(redacted).not.toContain('pilot@example.com')
+    expect(counts.url).toBe(1)
+    // Email inside URL is swallowed by the URL marker — not counted twice.
+    expect(counts.email).toBe(0)
+  })
+
+  it('is deterministic — same input yields identical output', () => {
+    const text = 'Contact: pilot@example.com or +49 151 1234 5678 at D-EBPN.'
+    const first = redactIncidentText(text)
+    const second = redactIncidentText(text)
+    expect(first).toEqual(second)
+  })
+
+  it('totals every class via totalRedactions', () => {
+    const { counts } = redactIncidentText(
+      'Email a@b.co and call +12 345 6789 0 at https://x.io re D-EBPN at 50.04,8.56.',
+    )
+    expect(totalRedactions(counts)).toBe(
+      counts.email + counts.phone + counts.coord + counts.registration + counts.url,
+    )
+    expect(totalRedactions(counts)).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/frontend/src/core/logic/incident-redaction.spec.ts
+++ b/frontend/src/core/logic/incident-redaction.spec.ts
@@ -100,4 +100,71 @@ describe('redactIncidentText', () => {
     )
     expect(totalRedactions(counts)).toBeGreaterThanOrEqual(4)
   })
+
+  // B3: registration pattern must NOT eat aviation diagnostics that look
+  // superficially like an ICAO reg. The reviewer found these false positives
+  // were destroying the very data needed to triage a calculation defect.
+  it.each([
+    'Climbed to FL-100 and held',
+    'Operated an A-320 today',
+    'Compared to B-737 numbers',
+    'Took off, called T-O at V-1',
+  ])('preserves aviation diagnostic phrase: %s', (phrase) => {
+    const { redacted, counts } = redactIncidentText(phrase)
+    expect(counts.registration).toBe(0)
+    expect(redacted).toBe(phrase)
+  })
+
+  it('preserves single-digit N-number engine readings (N1, N2)', () => {
+    const text = 'Read N1 95% and N2 88% on takeoff'
+    const { redacted, counts } = redactIncidentText(text)
+    expect(counts.registration).toBe(0)
+    expect(redacted).toBe(text)
+  })
+
+  // M1: lookbehind would throw SyntaxError on Safari 16.0–16.3 at module-load
+  // time. Reaching this assertion proves the module compiled — we still
+  // exercise a phone redaction to make sure the pattern is wired up.
+  it('does not use regex lookbehind syntax (Safari 16.0 floor)', () => {
+    const { redacted } = redactIncidentText('Call +49 151 1234 5678 for dispatch.')
+    expect(typeof redactIncidentText).toBe('function')
+    expect(redacted).toContain(REDACTION_MARKERS.PHONE)
+  })
+
+  // M3: phone redaction must remove BOTH the parens and the digits so no
+  // dangling `(` survives in the output.
+  it('strips the leading parenthesis when redacting "(415) 555-2671"', () => {
+    const { redacted } = redactIncidentText('Phone (415) 555-2671 for ops.')
+    expect(redacted).not.toContain('(415)')
+    expect(redacted).not.toContain('(415')
+    expect(redacted).toContain(REDACTION_MARKERS.PHONE)
+  })
+
+  // m1: plain numeric ranges must NOT be redacted as phones — pilots lose
+  // timeline detail like "between 1700-1815".
+  it.each(['Window between 1700-1815 UTC', 'Score sequence 100-200-300'])(
+    'does not redact narrative numeric run: %s',
+    (phrase) => {
+      const { redacted, counts } = redactIncidentText(phrase)
+      expect(counts.phone).toBe(0)
+      expect(redacted).toBe(phrase)
+    },
+  )
+
+  // m2: integer hemisphere-tagged coordinate pairs should still be redacted.
+  it('redacts integer coordinate pairs that carry N/S/E/W markers', () => {
+    const { redacted, counts } = redactIncidentText('Departed 50N 8E in the morning.')
+    expect(counts.coord).toBe(1)
+    expect(redacted).toContain(REDACTION_MARKERS.COORD)
+    expect(redacted).not.toContain('50N 8E')
+  })
+
+  // Sanity: numeric pilot input ("50,8 kg, 12,3 L") must NOT trip the
+  // integer-coord branch (no hemisphere marker).
+  it('does not over-match plain numeric pairs without hemisphere markers', () => {
+    const text = 'Loaded 50,8 kg cargo and 12,3 L oil.'
+    const { redacted, counts } = redactIncidentText(text)
+    expect(counts.coord).toBe(0)
+    expect(redacted).toBe(text)
+  })
 })

--- a/frontend/src/core/logic/incident-redaction.ts
+++ b/frontend/src/core/logic/incident-redaction.ts
@@ -1,0 +1,145 @@
+/**
+ * Privacy redaction for pilot-supplied incident report text (issue #281,
+ * PR-006). P1 Safety Core — pure TypeScript, no framework dependencies,
+ * deterministic.
+ *
+ * Goal: strip the obvious PII classes that a pilot might paste into a free-
+ * text problem report (email, phone, GPS coordinates, aircraft registration,
+ * URLs with query strings) before the report is queued to IndexedDB and
+ * eventually opened on github.com. The pilot is then shown the redacted
+ * text in a preview so they can confirm what will leave the device.
+ *
+ * Non-goals:
+ * - Heuristic NER (names, addresses). Those need pilot judgement — the
+ *   preview-before-submit dialog is the second line of defence.
+ * - Removing aviation numerics ("100 kg pilot mass", "50 L fuel"). Those
+ *   are exactly the values needed to reproduce the bug, so they are kept
+ *   verbatim.
+ * - Redacting public airport ICAO/IATA codes — they are route-revealing
+ *   but the diagnostic value outweighs the privacy cost for this MVP
+ *   (the pilot can edit them out in the GitHub draft if they wish).
+ *
+ * Mirrors the spirit of the logger's
+ * {@link ../../shared/utils/logger.ts | redactPayload} field-allow-list
+ * (DP-004 / CS-012) but operates on free text rather than structured data.
+ */
+
+// @IMP-SYS-CORE-014@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@)
+
+export const REDACTION_MARKERS = {
+  EMAIL: '[REDACTED-EMAIL]',
+  PHONE: '[REDACTED-PHONE]',
+  COORD: '[REDACTED-COORD]',
+  REGISTRATION: '[REDACTED-REG]',
+  URL: '[REDACTED-URL]',
+} as const
+
+export type RedactionCounts = {
+  email: number
+  phone: number
+  coord: number
+  registration: number
+  url: number
+}
+
+/**
+ * Patterns applied in order. Each replaces a self-contained PII class with
+ * a marker so the next pattern still sees clean text on both sides.
+ *
+ * Order matters: URL stripping happens before email/phone, otherwise an
+ * email/phone embedded in a query string would be matched twice.
+ */
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"']+/gi
+// Pragmatic email regex — not RFC 5322 perfect, but covers everything a
+// pilot is likely to paste. The `[\w.+-]+` local part deliberately accepts
+// underscores so addresses like `john_doe@example.com` are caught.
+const EMAIL_PATTERN = /\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b/g
+// Phone — international, +/- separators, spaces, parens. We want at least
+// 7 digits in total to avoid matching plain quantity numbers like "300 kg".
+const PHONE_PATTERN = /(?<![\w.-])\+?\d[\d\s().-]{6,}\d(?![\w.-])/g
+// Decimal lat/lon pair, e.g. "50.0379,8.5622" or "50.0379 N 8.5622 E".
+const COORD_DECIMAL_PATTERN =
+  /-?\d{1,3}\.\d{2,}\s*[NnSs]?[ ,;/]+-?\d{1,3}\.\d{2,}\s*[EeWw]?/g
+// DMS lat/lon, e.g. "50°02'16"N 008°33'44"E". Uses degree, ASCII single
+// quote, ASCII double quote; tolerates extra spaces.
+const COORD_DMS_PATTERN =
+  /\d{1,3}°\s*\d{1,2}'\s*\d{1,2}(?:\.\d+)?"?\s*[NnSs][ ,;/]+\d{1,3}°\s*\d{1,2}'\s*\d{1,2}(?:\.\d+)?"?\s*[EeWw]/g
+// ICAO aircraft registration: country prefix (1-2 letters) + dash + 1-5
+// alphanumerics, e.g. D-EBPN, OE-ABC, G-ABCD. Also N-numbers (N12345,
+// N123AB). Anchored on word boundaries so it does NOT eat ICAO airport
+// codes (4 letters, no dash).
+const REGISTRATION_DASH_PATTERN = /\b[A-Z]{1,2}-[A-Z0-9]{1,5}\b/g
+const REGISTRATION_N_PATTERN = /\bN[0-9]{1,5}[A-Z]{0,2}\b/g
+
+/**
+ * Apply the redaction pipeline to free text. Returns the redacted text plus
+ * per-class match counts so the preview UI can tell the pilot exactly how
+ * many secrets were stripped (low-friction trust signal).
+ *
+ * The function is pure and deterministic — same input ⇒ same output, no
+ * IO, no Date.now, no random.
+ *
+ * @param text Raw pilot input. May be empty (yields empty result + zero
+ *             counts).
+ */
+export function redactIncidentText(text: string): {
+  redacted: string
+  counts: RedactionCounts
+} {
+  const counts: RedactionCounts = {
+    email: 0,
+    phone: 0,
+    coord: 0,
+    registration: 0,
+    url: 0,
+  }
+
+  // URLs first so embedded emails/phones in query strings don't double-count.
+  let out = text.replace(URL_PATTERN, () => {
+    counts.url += 1
+    return REDACTION_MARKERS.URL
+  })
+
+  out = out.replace(EMAIL_PATTERN, () => {
+    counts.email += 1
+    return REDACTION_MARKERS.EMAIL
+  })
+
+  // Coordinate forms before phone — DMS digit sequences would otherwise
+  // get partially gobbled by the phone matcher.
+  out = out.replace(COORD_DMS_PATTERN, () => {
+    counts.coord += 1
+    return REDACTION_MARKERS.COORD
+  })
+  out = out.replace(COORD_DECIMAL_PATTERN, () => {
+    counts.coord += 1
+    return REDACTION_MARKERS.COORD
+  })
+
+  out = out.replace(PHONE_PATTERN, () => {
+    counts.phone += 1
+    return REDACTION_MARKERS.PHONE
+  })
+
+  out = out.replace(REGISTRATION_DASH_PATTERN, () => {
+    counts.registration += 1
+    return REDACTION_MARKERS.REGISTRATION
+  })
+  out = out.replace(REGISTRATION_N_PATTERN, () => {
+    counts.registration += 1
+    return REDACTION_MARKERS.REGISTRATION
+  })
+
+  return { redacted: out, counts }
+}
+
+/** Total number of redactions across every class — handy for the UI badge. */
+export function totalRedactions(counts: RedactionCounts): number {
+  return (
+    counts.email +
+    counts.phone +
+    counts.coord +
+    counts.registration +
+    counts.url
+  )
+}

--- a/frontend/src/core/logic/incident-redaction.ts
+++ b/frontend/src/core/logic/incident-redaction.ts
@@ -48,28 +48,57 @@ export type RedactionCounts = {
  *
  * Order matters: URL stripping happens before email/phone, otherwise an
  * email/phone embedded in a query string would be matched twice.
+ *
+ * Regex syntax constraint: no lookbehind. Lookbehind shipped in Safari
+ * 16.4, but `vite.config.ts` pins `build.target` at `safari16.0` so the
+ * bundle must parse on Safari 16.0–16.3 (Vite does not transpile regex
+ * syntax — a lookbehind here would throw `SyntaxError` at module-load on
+ * those iOS versions and cascade-break every importer). Lookahead is fine
+ * (Safari has supported it for years).
  */
 const URL_PATTERN = /\bhttps?:\/\/[^\s<>"']+/gi
 // Pragmatic email regex — not RFC 5322 perfect, but covers everything a
 // pilot is likely to paste. The `[\w.+-]+` local part deliberately accepts
 // underscores so addresses like `john_doe@example.com` are caught.
 const EMAIL_PATTERN = /\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b/g
-// Phone — international, +/- separators, spaces, parens. We want at least
-// 7 digits in total to avoid matching plain quantity numbers like "300 kg".
-const PHONE_PATTERN = /(?<![\w.-])\+?\d[\d\s().-]{6,}\d(?![\w.-])/g
+// Phone — international, +/- separators, spaces, parens. Capture group 1
+// re-emits the leading boundary char so the replacement does not eat it
+// (replaces the lookbehind that would otherwise drop iOS Safari 16.0–16.3
+// out of scope, M1). Two alternatives, both anchored to require either a
+// leading `+` (international form) OR an internal `[\s()]` separator so
+// plain numeric ranges like `"between 1700-1815"` or `"100-200-300"` are
+// not swallowed (m1). The optional `\(?` consumes a leading parenthesis
+// such as `(415) 555-2671` so no dangling `(` survives in the output (m3).
+const PHONE_PATTERN =
+  /(^|[^\w.-])(\+\d[\d\s().-]{6,}\d|\(?\s*\d[\d().-]*[\s()]\d[\d\s().-]{4,}\d)(?![\w.-])/g
 // Decimal lat/lon pair, e.g. "50.0379,8.5622" or "50.0379 N 8.5622 E".
 const COORD_DECIMAL_PATTERN =
   /-?\d{1,3}\.\d{2,}\s*[NnSs]?[ ,;/]+-?\d{1,3}\.\d{2,}\s*[EeWw]?/g
+// Integer-only coordinate pair (m2), e.g. "50N 8E" or "50,8 N/E". The
+// pattern requires explicit N/S/E/W hemisphere markers so plain numeric
+// lists ("50,8 kg, 12,3 L") are not over-matched. Lat range capped to
+// 2 digits, lon to 3 digits.
+const COORD_INT_PATTERN =
+  /(^|[^\w.-])(-?\d{1,2}\s*[NnSs][ ,;/]+-?\d{1,3}\s*[EeWw])\b/g
 // DMS lat/lon, e.g. "50°02'16"N 008°33'44"E". Uses degree, ASCII single
 // quote, ASCII double quote; tolerates extra spaces.
 const COORD_DMS_PATTERN =
   /\d{1,3}°\s*\d{1,2}'\s*\d{1,2}(?:\.\d+)?"?\s*[NnSs][ ,;/]+\d{1,3}°\s*\d{1,2}'\s*\d{1,2}(?:\.\d+)?"?\s*[EeWw]/g
-// ICAO aircraft registration: country prefix (1-2 letters) + dash + 1-5
-// alphanumerics, e.g. D-EBPN, OE-ABC, G-ABCD. Also N-numbers (N12345,
-// N123AB). Anchored on word boundaries so it does NOT eat ICAO airport
-// codes (4 letters, no dash).
-const REGISTRATION_DASH_PATTERN = /\b[A-Z]{1,2}-[A-Z0-9]{1,5}\b/g
-const REGISTRATION_N_PATTERN = /\bN[0-9]{1,5}[A-Z]{0,2}\b/g
+// ICAO aircraft registration: country prefix (1-2 letters) + dash + 3-5
+// LETTERS (no digits) so the pattern catches D-EBPN, OE-ABC, G-ABCD,
+// HB-XYZ but spares aviation diagnostics that look superficially similar:
+//   • Flight levels  (FL-100)
+//   • Aircraft types (A-320, B-737)
+//   • Throttle/abbreviations (T-O for take-off, V-1, Cs-A)
+// Trade-off (B3): rare alphabetic country prefixes with digit-containing
+// suffixes (none in routine ICAO use) slip through; pilots typing a non-
+// standard registration can redact it manually in the preview pane.
+// False positives on common English bigrams (E-MAIL, X-RAY, MS-DOS) are
+// acceptable because the preview shows the result before submission.
+const REGISTRATION_DASH_PATTERN = /\b[A-Z]{1,2}-[A-Z]{3,5}\b/g
+// N-numbers: must be N + 2 or more digits so engine readings like "N1"
+// and "N2" (turbine speed gauges) survive. Trailing letters optional.
+const REGISTRATION_N_PATTERN = /\bN[0-9]{2,5}[A-Z]{0,2}\b/g
 
 /**
  * Apply the redaction pipeline to free text. Returns the redacted text plus
@@ -115,10 +144,14 @@ export function redactIncidentText(text: string): {
     counts.coord += 1
     return REDACTION_MARKERS.COORD
   })
+  out = out.replace(COORD_INT_PATTERN, (_match, lead: string) => {
+    counts.coord += 1
+    return `${lead}${REDACTION_MARKERS.COORD}`
+  })
 
-  out = out.replace(PHONE_PATTERN, () => {
+  out = out.replace(PHONE_PATTERN, (_match, lead: string) => {
     counts.phone += 1
-    return REDACTION_MARKERS.PHONE
+    return `${lead}${REDACTION_MARKERS.PHONE}`
   })
 
   out = out.replace(REGISTRATION_DASH_PATTERN, () => {

--- a/frontend/src/modules/aircraft/__tests__/data-rights.service.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/data-rights.service.int.spec.ts
@@ -18,6 +18,29 @@ import {
 import { create, findAll, fleetRepository } from '../services/fleet.repository'
 import { CURRENT_PROFILE_SCHEMA_VERSION } from '@/core/logic/profile-migrations'
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import {
+  enqueueReport as enqueueIncident,
+  listReports as listIncidents,
+} from '@/shared/utils/incident-queue'
+import type { IncidentReport } from '@/core/domain/incident-report.schema'
+
+function buildIncident(overrides: Partial<IncidentReport> = {}): IncidentReport {
+  return {
+    id: overrides.id ?? '00000000-0000-4000-a000-0000000000e1',
+    createdAt: overrides.createdAt ?? '2026-05-31T08:15:00.000Z',
+    kind: overrides.kind ?? 'OTHER',
+    summary: overrides.summary ?? 'queued report',
+    redactedDescription: overrides.redactedDescription ?? 'A redacted body.',
+    context: overrides.context ?? {
+      appVersion: '0.4.0-alpha',
+      routeName: null,
+      pathTail: null,
+      userAgent: null,
+      online: null,
+    },
+    schemaVersion: 1,
+  }
+}
 
 beforeEach(() => {
   Object.defineProperty(globalThis, 'indexedDB', {
@@ -253,8 +276,63 @@ describe('wipeAllLocalData — Repository-Wide Wipe (REQ-SYS-014)', () => {
     expect(report.localStorageKeysCleared).toEqual([])
     expect(report.sessionStorageKeysCleared).toEqual([])
     expect(report.indexedDbCleared).toBe(true)
+    expect(report.incidentDbCleared).toBe(true)
     expect(report.complete).toBe(true)
     expect(report.failures).toEqual([])
+  })
+
+  // B2 — REQ-SYS-014: the wipe MUST also clear the aerodash-incidents IDB
+  // database; previously the prefix-sweep only touched aerodash-fleet + Web
+  // Storage, leaving redacted pilot prose on disk after a "complete erasure".
+  it('clears the aerodash-incidents IndexedDB and reports the deleted incident count', async () => {
+    await enqueueIncident(
+      buildIncident({ id: '00000000-0000-4000-a000-0000000000e1', summary: 'first' }),
+    )
+    await enqueueIncident(
+      buildIncident({ id: '00000000-0000-4000-a000-0000000000e2', summary: 'second' }),
+    )
+
+    const report = await wipeAllLocalData()
+
+    expect(report.incidentDbCleared).toBe(true)
+    expect(report.incidentReportsDeleted).toBe(2)
+    expect(report.complete).toBe(true)
+    expect(await listIncidents()).toEqual([])
+  })
+
+  it('reports an incidents-clear failure as its own failure entry (not masked by fleet success)', async () => {
+    await enqueueIncident(buildIncident())
+    // Force the next openDB() call for `aerodash-incidents` to fail. We
+    // build a minimal IDBOpenDBRequest stand-in whose `onerror` callback,
+    // when fired, exposes `error.message` through the same `event.target`
+    // shape the production code reads.
+    const origOpen = indexedDB.open.bind(indexedDB)
+    vi.spyOn(indexedDB, 'open').mockImplementation((name: string, version?: number) => {
+      if (name !== 'aerodash-incidents') return origOpen(name, version)
+      // Minimal IDBOpenDBRequest stand-in: we only need the production code
+      // to be able to read `event.target.error?.message` from the onerror
+      // callback. The cast through `unknown` keeps strict TS happy without
+      // pulling in the full DOMException implementation.
+      const req = {
+        result: null,
+        error: { message: 'forced-incident-open-failure' },
+        onsuccess: null,
+        onerror: null,
+        onupgradeneeded: null,
+      } as unknown as IDBOpenDBRequest
+      queueMicrotask(() => {
+        req.onerror?.({ target: req } as unknown as Event)
+      })
+      return req
+    })
+
+    const report = await wipeAllLocalData()
+
+    expect(report.incidentDbCleared).toBe(false)
+    expect(report.complete).toBe(false)
+    const incidentFailure = report.failures.find((f) => f.store === 'incidents')
+    expect(incidentFailure).toBeDefined()
+    expect(incidentFailure?.detail).toContain('forced-incident-open-failure')
   })
 })
 
@@ -284,10 +362,33 @@ describe('exportAllProfiles — Bulk JSON Export (REQ-SYS-015)', () => {
   })
 
   it('returns an empty envelope when no profiles exist', async () => {
-    const { envelope, omitted } = await exportAllProfiles(new Date('2026-05-27T00:00:00Z'))
+    const { envelope, omitted, incidentReportsOmitted } = await exportAllProfiles(
+      new Date('2026-05-27T00:00:00Z'),
+    )
     expect(envelope.profileCount).toBe(0)
     expect(envelope.profiles).toEqual([])
     expect(omitted).toEqual([])
+    expect(incidentReportsOmitted).toBe(0)
+  })
+
+  // B2: queued incidents are deliberately NOT included in the bulk export
+  // (separate privacy perimeter, already redacted, opt-in submission). The
+  // count must still be surfaced so the pilot sees they exist on the device.
+  it('surfaces the count of queued incident reports as `incidentReportsOmitted` without including them', async () => {
+    await create(buildProfile())
+    await enqueueIncident(
+      buildIncident({ id: '00000000-0000-4000-a000-0000000000e3', summary: 'first queued' }),
+    )
+    await enqueueIncident(
+      buildIncident({ id: '00000000-0000-4000-a000-0000000000e4', summary: 'second queued' }),
+    )
+
+    const { envelope, incidentReportsOmitted } = await exportAllProfiles()
+
+    expect(incidentReportsOmitted).toBe(2)
+    // envelope shape has no incident fields — keep the two perimeters separate
+    expect(envelope).not.toHaveProperty('incidents')
+    expect(envelope.profileCount).toBe(1)
   })
 
   it('omits unreadable profiles from the envelope but reports them so the copy is not silently incomplete', async () => {

--- a/frontend/src/modules/aircraft/services/data-rights.service.ts
+++ b/frontend/src/modules/aircraft/services/data-rights.service.ts
@@ -15,9 +15,13 @@
  */
 
 import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import {
+  clearAllReports as clearAllIncidentReports,
+  listReports as listIncidentReports,
+} from '@/shared/utils/incident-queue'
 import { fleetRepository, DB_NAME, type MigrationDiagnostic } from './fleet.repository'
 
-// @IMP-SYS-STORE-021@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@, @DES-ARCH-011@, @DES-ARCH-012@)
+// @IMP-SYS-STORE-021@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@, @REQ-SYS-016@, @DES-ARCH-011@, @DES-ARCH-012@)
 
 // ─── Storage keys cleared by Delete-All-Data ──────────────────────────────
 // These three live keys cover all known AeroDash persistence at v0.4.0-alpha:
@@ -42,8 +46,12 @@ export const INDEXED_DB_FLEET_NAME = DB_NAME
 
 /** A storage location that could not be cleared during a Delete-All-Data run. */
 export interface WipeFailure {
-  /** Which storage facility the failure occurred in. */
-  readonly store: 'indexeddb' | 'localStorage' | 'sessionStorage'
+  /**
+   * Which storage facility the failure occurred in. `incidents` covers the
+   * separate `aerodash-incidents` IndexedDB database that holds redacted
+   * pilot incident reports (REQ-SYS-016).
+   */
+  readonly store: 'indexeddb' | 'incidents' | 'localStorage' | 'sessionStorage'
   /**
    * The specific key that could not be removed, or `null` for a whole-store
    * failure (e.g. the IndexedDB `clear()` transaction rejecting).
@@ -61,12 +69,21 @@ export interface WipeReport {
    * `0` would be a misleading erasure receipt.
    */
   readonly profilesDeleted: number | null
+  /**
+   * Number of queued incident reports removed (`aerodash-incidents`,
+   * REQ-SYS-016), or `null` when the wipe failed before the count could be
+   * established. Reported separately so the pilot sees an explicit receipt
+   * even when the fleet store is empty.
+   */
+  readonly incidentReportsDeleted: number | null
   /** localStorage keys removed (sorted, including the session payload). */
   readonly localStorageKeysCleared: readonly string[]
   /** sessionStorage keys removed (sorted, including the cold-start marker). */
   readonly sessionStorageKeysCleared: readonly string[]
   /** `true` once the IndexedDB object store has been emptied. */
   readonly indexedDbCleared: boolean
+  /** `true` once the `aerodash-incidents` IndexedDB store has been emptied. */
+  readonly incidentDbCleared: boolean
   /**
    * Storage locations that could **not** be cleared. Empty on a complete wipe.
    * REQ-SYS-014 forbids signalling success while any of these remain, so the
@@ -94,6 +111,15 @@ export interface BulkExportResult {
    * are also destroyed by a subsequent Delete-All-Data wipe.
    */
   readonly omitted: readonly MigrationDiagnostic[]
+  /**
+   * Count of queued incident reports deliberately NOT included in this
+   * envelope (B2 / REQ-SYS-015). Incident reports are scoped to local-
+   * device triage and have a separate, already-redacted handoff path
+   * (open-on-GitHub). The Privacy UI surfaces this count so the pilot
+   * knows they exist on the device and would be erased by a subsequent
+   * Delete-All-Data.
+   */
+  readonly incidentReportsOmitted: number
 }
 
 /** Top-level envelope for a bulk export-all JSON file. */
@@ -163,6 +189,24 @@ export async function wipeAllLocalData(): Promise<WipeReport> {
     })
   }
 
+  // Wipe the `aerodash-incidents` IndexedDB database (B2). Separate from the
+  // fleet DB so a failure here is reported as its own line in `failures` and
+  // its own `incidentDbCleared` flag — never masked by a successful fleet
+  // wipe. REQ-SYS-014 requires erasure of ALL local data; queued incident
+  // reports are local data even though their submission target is github.com.
+  let incidentDbCleared = false
+  let incidentReportsDeleted: number | null = null
+  try {
+    incidentReportsDeleted = await clearAllIncidentReports()
+    incidentDbCleared = true
+  } catch (err) {
+    failures.push({
+      store: 'incidents',
+      key: null,
+      detail: err instanceof Error ? err.message : 'Incident IndexedDB clear failed',
+    })
+  }
+
   const local = clearPrefixedKeys('local')
   const session = clearPrefixedKeys('session')
   for (const key of local.failedKeys) {
@@ -174,7 +218,9 @@ export async function wipeAllLocalData(): Promise<WipeReport> {
 
   return {
     profilesDeleted,
+    incidentReportsDeleted,
     indexedDbCleared,
+    incidentDbCleared,
     localStorageKeysCleared: local.cleared,
     sessionStorageKeysCleared: session.cleared,
     failures,
@@ -264,6 +310,18 @@ export async function exportAllProfiles(now: Date = new Date()): Promise<BulkExp
   // Sort by registration so the file is diff-friendly across re-exports. Pin
   // the locale so the order is stable regardless of the host machine's locale.
   const sorted = [...profiles].sort((a, b) => a.registration.localeCompare(b.registration, 'en'))
+  // Surface (but do NOT include) queued incident reports. They live in a
+  // separate database, are already redacted, and are submitted on demand
+  // via the open-on-GitHub deep link — round-tripping them through this
+  // envelope would mix two privacy perimeters. Reporting the count lets
+  // the Privacy UI tell the pilot they exist on the device (B2 / m note).
+  let incidentReportsOmitted = 0
+  try {
+    incidentReportsOmitted = (await listIncidentReports()).length
+  } catch {
+    // Best-effort: a missing/locked incidents DB must never block the
+    // fleet export. The pilot can still see queued reports in /incidents.
+  }
   return {
     envelope: {
       exportSchemaVersion: 1,
@@ -272,6 +330,7 @@ export async function exportAllProfiles(now: Date = new Date()): Promise<BulkExp
       profiles: sorted,
     },
     omitted: diagnostics,
+    incidentReportsOmitted,
   }
 }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -40,6 +40,12 @@ const router = createRouter({
       name: 'privacy',
       component: () => import('@/views/PrivacyView.vue'),
     },
+    // @IMP-UI-ROUTE-005@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@)
+    {
+      path: '/incidents',
+      name: 'incidents',
+      component: () => import('@/views/IncidentReportsView.vue'),
+    },
   ],
 })
 

--- a/frontend/src/shared/components/ReportProblemDialog.vue
+++ b/frontend/src/shared/components/ReportProblemDialog.vue
@@ -8,18 +8,20 @@
       @click.self="onCancel"
     >
       <div
+        ref="dialogEl"
         class="report-dialog"
         role="dialog"
         aria-modal="true"
+        tabindex="-1"
         :aria-labelledby="titleId"
         @keydown.esc.prevent="onCancel"
       >
         <h2 :id="titleId" class="report-dialog__title">Report a problem</h2>
         <p class="report-dialog__intro">
           Your report is stored on this device. Nothing leaves AeroDash unless
-          you press <strong>Open on GitHub</strong> below — the description is
-          automatically redacted first, and you can review the redacted text
-          before submitting.
+          you press <strong>Open on GitHub</strong> below — both the summary
+          and the description are automatically redacted first, and you can
+          review the redacted text before submitting.
         </p>
 
         <form class="report-dialog__form" @submit.prevent="onSubmit">
@@ -40,6 +42,7 @@
               <span class="report-dialog__hint">({{ form.summary.length }}/{{ SUMMARY_MAX_LEN }})</span>
             </span>
             <input
+              ref="summaryEl"
               v-model="form.summary"
               class="report-dialog__input"
               type="text"
@@ -66,14 +69,35 @@
             ></textarea>
           </label>
 
-          <details v-if="form.description.length > 0" class="report-dialog__preview" open>
+          <details
+            v-if="form.summary.length > 0 || form.description.length > 0"
+            class="report-dialog__preview"
+            open
+          >
             <summary>
               Preview of redacted text
               <span v-if="preview.total > 0" class="report-dialog__badge">
                 {{ preview.total }} item{{ preview.total === 1 ? '' : 's' }} redacted
               </span>
             </summary>
-            <pre class="report-dialog__preview-text" data-testid="redaction-preview">{{ preview.redacted }}</pre>
+            <p
+              v-if="form.summary.length > 0"
+              class="report-dialog__preview-label"
+            >Summary (sent as the issue title)</p>
+            <pre
+              v-if="form.summary.length > 0"
+              class="report-dialog__preview-text"
+              data-testid="redaction-preview-summary"
+            >{{ preview.summary.redacted }}</pre>
+            <p
+              v-if="form.description.length > 0"
+              class="report-dialog__preview-label"
+            >Description</p>
+            <pre
+              v-if="form.description.length > 0"
+              class="report-dialog__preview-text"
+              data-testid="redaction-preview"
+            >{{ preview.description.redacted }}</pre>
           </details>
 
           <p v-if="formError" class="report-dialog__error" role="alert">{{ formError }}</p>
@@ -102,7 +126,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, useId, watch } from 'vue'
+import { computed, nextTick, reactive, ref, useId, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import {
   DESCRIPTION_MAX_LEN,
@@ -121,14 +145,27 @@ const titleId = useId()
 const store = useIncidentReportStore()
 const route = useRoute()
 
+// Default `kind` matches the first visible <select> option (M6) so a pilot
+// who never touches the dropdown files the report under the highlighted
+// option ("Calculation result looked wrong") rather than the silent
+// fall-through to OTHER.
 const blankForm = (): IncidentDraft => ({
-  kind: 'OTHER',
+  kind: 'CALCULATION',
   summary: '',
   description: '',
 })
 const form = reactive<IncidentDraft>(blankForm())
 const busy = ref(false)
 const formError = ref<string | null>(null)
+
+// Focus management (M7 / WCAG 2.4.3 + 2.1.2): when the dialog opens, move
+// focus to the first input so keyboard / screen-reader users can interact
+// without first tab-walking the page. On close, restore focus to whatever
+// element triggered the open so a tab pilot is not dropped back at the top
+// of the document.
+const dialogEl = ref<HTMLDivElement | null>(null)
+const summaryEl = ref<HTMLInputElement | null>(null)
+let triggerEl: HTMLElement | null = null
 
 watch(
   () => props.open,
@@ -137,11 +174,26 @@ watch(
       Object.assign(form, blankForm())
       formError.value = null
       busy.value = false
+      if (typeof document !== 'undefined') {
+        const active = document.activeElement
+        triggerEl = active instanceof HTMLElement ? active : null
+      }
+      void nextTick(() => {
+        summaryEl.value?.focus()
+      })
+    } else if (triggerEl !== null) {
+      // Restore focus on the next microtask so the Teleport-mounted DOM has
+      // fully detached before the trigger button receives focus.
+      const toRestore = triggerEl
+      triggerEl = null
+      void nextTick(() => {
+        toRestore.focus()
+      })
     }
   },
 )
 
-const preview = computed(() => store.previewRedaction(form.description))
+const preview = computed(() => store.previewDraft(form))
 
 const canSubmit = computed(
   () =>
@@ -282,11 +334,18 @@ async function onSubmit(): Promise<void> {
   padding: 0.1rem 0.5rem;
 }
 
+.report-dialog__preview-label {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
 .report-dialog__preview-text {
   white-space: pre-wrap;
   font-family: var(--font-mono, monospace);
   font-size: var(--text-xs);
-  margin: var(--space-2) 0 0;
+  margin: var(--space-1) 0 0;
   max-height: 12rem;
   overflow-y: auto;
 }

--- a/frontend/src/shared/components/ReportProblemDialog.vue
+++ b/frontend/src/shared/components/ReportProblemDialog.vue
@@ -1,0 +1,332 @@
+<!-- @IMP-UI-SHARED-008@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@) -->
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="report-dialog__backdrop"
+      data-testid="report-problem-dialog"
+      @click.self="onCancel"
+    >
+      <div
+        class="report-dialog"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        @keydown.esc.prevent="onCancel"
+      >
+        <h2 :id="titleId" class="report-dialog__title">Report a problem</h2>
+        <p class="report-dialog__intro">
+          Your report is stored on this device. Nothing leaves AeroDash unless
+          you press <strong>Open on GitHub</strong> below — the description is
+          automatically redacted first, and you can review the redacted text
+          before submitting.
+        </p>
+
+        <form class="report-dialog__form" @submit.prevent="onSubmit">
+          <label class="report-dialog__field">
+            <span class="report-dialog__label">What kind of problem?</span>
+            <select v-model="form.kind" class="report-dialog__select" required>
+              <option value="CALCULATION">Calculation result looked wrong</option>
+              <option value="DATA">Aircraft or airport data looked wrong</option>
+              <option value="UI">UI / display defect</option>
+              <option value="CRASH">App froze or failed to load</option>
+              <option value="OTHER">Other</option>
+            </select>
+          </label>
+
+          <label class="report-dialog__field">
+            <span class="report-dialog__label">
+              Short summary
+              <span class="report-dialog__hint">({{ form.summary.length }}/{{ SUMMARY_MAX_LEN }})</span>
+            </span>
+            <input
+              v-model="form.summary"
+              class="report-dialog__input"
+              type="text"
+              :maxlength="SUMMARY_MAX_LEN"
+              minlength="3"
+              required
+              placeholder="e.g. CG envelope showed amber after correct fuel entry"
+            />
+          </label>
+
+          <label class="report-dialog__field">
+            <span class="report-dialog__label">
+              What happened?
+              <span class="report-dialog__hint">({{ form.description.length }}/{{ DESCRIPTION_MAX_LEN }})</span>
+            </span>
+            <textarea
+              v-model="form.description"
+              class="report-dialog__textarea"
+              :maxlength="DESCRIPTION_MAX_LEN"
+              minlength="10"
+              required
+              rows="6"
+              placeholder="Steps, expected vs actual, any aviation numbers you used. Avoid email, phone, GPS, registration — they will be redacted automatically."
+            ></textarea>
+          </label>
+
+          <details v-if="form.description.length > 0" class="report-dialog__preview" open>
+            <summary>
+              Preview of redacted text
+              <span v-if="preview.total > 0" class="report-dialog__badge">
+                {{ preview.total }} item{{ preview.total === 1 ? '' : 's' }} redacted
+              </span>
+            </summary>
+            <pre class="report-dialog__preview-text" data-testid="redaction-preview">{{ preview.redacted }}</pre>
+          </details>
+
+          <p v-if="formError" class="report-dialog__error" role="alert">{{ formError }}</p>
+
+          <div class="report-dialog__actions">
+            <button
+              type="button"
+              class="report-dialog__btn report-dialog__btn--ghost"
+              @click="onCancel"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              class="report-dialog__btn report-dialog__btn--primary"
+              :disabled="!canSubmit || busy"
+              data-testid="report-problem-save-btn"
+            >
+              Save report
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, useId, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import {
+  DESCRIPTION_MAX_LEN,
+  SUMMARY_MAX_LEN,
+  type IncidentDraft,
+} from '@/core/domain/incident-report.schema'
+import { useIncidentReportStore } from '@/stores/incident-report.store'
+
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'saved', report: { id: string }): void
+}>()
+
+const titleId = useId()
+const store = useIncidentReportStore()
+const route = useRoute()
+
+const blankForm = (): IncidentDraft => ({
+  kind: 'OTHER',
+  summary: '',
+  description: '',
+})
+const form = reactive<IncidentDraft>(blankForm())
+const busy = ref(false)
+const formError = ref<string | null>(null)
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      Object.assign(form, blankForm())
+      formError.value = null
+      busy.value = false
+    }
+  },
+)
+
+const preview = computed(() => store.previewRedaction(form.description))
+
+const canSubmit = computed(
+  () =>
+    form.summary.trim().length >= 3 &&
+    form.description.trim().length >= 10 &&
+    form.summary.length <= SUMMARY_MAX_LEN &&
+    form.description.length <= DESCRIPTION_MAX_LEN,
+)
+
+function onCancel(): void {
+  if (busy.value) return
+  emit('close')
+}
+
+async function onSubmit(): Promise<void> {
+  if (!canSubmit.value || busy.value) return
+  busy.value = true
+  formError.value = null
+  try {
+    const report = await store.capture(form, {
+      routeName: typeof route.name === 'string' ? route.name : null,
+    })
+    emit('saved', { id: report.id })
+    emit('close')
+  } catch (err) {
+    formError.value =
+      err instanceof Error ? err.message : 'Failed to save the report. Please try again.'
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<style scoped>
+.report-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-4);
+}
+
+.report-dialog {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  max-width: 560px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: var(--space-6);
+}
+
+.report-dialog__title {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-lg);
+  font-weight: 700;
+}
+
+.report-dialog__intro {
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  color: var(--color-text-secondary);
+}
+
+.report-dialog__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.report-dialog__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.report-dialog__label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.report-dialog__hint {
+  font-weight: 400;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.report-dialog__input,
+.report-dialog__select,
+.report-dialog__textarea {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-input, var(--color-surface));
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  font-family: inherit;
+}
+
+.report-dialog__textarea {
+  min-height: 8rem;
+  resize: vertical;
+}
+
+.report-dialog__preview {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-muted, var(--color-surface));
+}
+
+.report-dialog__preview summary {
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.report-dialog__badge {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  background: var(--color-info, #1d4ed8);
+  color: #fff;
+  border-radius: var(--radius-full);
+  padding: 0.1rem 0.5rem;
+}
+
+.report-dialog__preview-text {
+  white-space: pre-wrap;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-xs);
+  margin: var(--space-2) 0 0;
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.report-dialog__error {
+  color: var(--color-danger, #dc2626);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+.report-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.report-dialog__btn {
+  min-height: 44px;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.report-dialog__btn--primary {
+  background: var(--color-primary, #1d4ed8);
+  color: #fff;
+}
+
+.report-dialog__btn--primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.report-dialog__btn--ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+</style>

--- a/frontend/src/shared/components/__tests__/ReportProblemDialog.spec.ts
+++ b/frontend/src/shared/components/__tests__/ReportProblemDialog.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for ReportProblemDialog.vue — UI surface for the in-app
+ * incident-reporting MVP (issue #281, PR-006).
+ */
+
+// @UT-UI-SHARED-040@ (FROM: @IMP-UI-SHARED-008@)
+// @UT-UI-SHARED-041@ (FROM: @IMP-UI-SHARED-008@)
+// @UT-UI-SHARED-042@ (FROM: @IMP-UI-SHARED-008@)
+// @UT-UI-SHARED-043@ (FROM: @IMP-UI-SHARED-008@)
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+import { defineComponent, h } from 'vue'
+import ReportProblemDialog from '../ReportProblemDialog.vue'
+import { useIncidentReportStore } from '@/stores/incident-report.store'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+const Stub = defineComponent({
+  setup() {
+    return () => h('div')
+  },
+})
+
+function buildRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', name: 'home', component: Stub }],
+  })
+}
+
+async function mountDialog(open = true) {
+  const router = buildRouter()
+  await router.push('/')
+  await router.isReady()
+  return mount(ReportProblemDialog, {
+    attachTo: document.body,
+    props: { open },
+    global: { plugins: [router] },
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+})
+
+describe('ReportProblemDialog', () => {
+  it('renders the dialog when open', async () => {
+    await mountDialog(true)
+    expect(document.body.querySelector('[data-testid="report-problem-dialog"]')).not.toBeNull()
+  })
+
+  it('renders nothing when closed', async () => {
+    await mountDialog(false)
+    expect(document.body.querySelector('[data-testid="report-problem-dialog"]')).toBeNull()
+  })
+
+  it('updates the redaction preview as the description changes', async () => {
+    await mountDialog(true)
+    const textarea = document.body.querySelector('textarea')!
+    ;(textarea as HTMLTextAreaElement).value = 'Reach me at pilot@example.com after 1700Z.'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+    const preview = document.body.querySelector('[data-testid="redaction-preview"]')!
+    expect(preview.textContent).toContain('[REDACTED-EMAIL]')
+  })
+
+  it('disables Save until summary and description meet length minimums', async () => {
+    await mountDialog(true)
+    const saveBtn = document.body.querySelector(
+      '[data-testid="report-problem-save-btn"]',
+    ) as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+
+    const summary = document.body.querySelector('input[type="text"]') as HTMLInputElement
+    summary.value = 'short summary'
+    summary.dispatchEvent(new Event('input', { bubbles: true }))
+    const textarea = document.body.querySelector('textarea') as HTMLTextAreaElement
+    textarea.value = 'A description that is plenty long.'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+    expect(saveBtn.disabled).toBe(false)
+  })
+
+  it('persists the report on submit', async () => {
+    await mountDialog(true)
+
+    const summary = document.body.querySelector('input[type="text"]') as HTMLInputElement
+    summary.value = 'CG amber after fuel'
+    summary.dispatchEvent(new Event('input', { bubbles: true }))
+    const textarea = document.body.querySelector('textarea') as HTMLTextAreaElement
+    textarea.value = 'Loaded 100 kg pilot mass, contact pilot@example.com'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const form = document.body.querySelector('form') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    // fake-indexeddb schedules onsuccess via macrotasks; pump real timers
+    // alongside microtasks until the store enqueue resolves.
+    for (let i = 0; i < 6; i += 1) {
+      await flushPromises()
+      await new Promise((r) => setTimeout(r, 0))
+    }
+
+    const store = useIncidentReportStore()
+    expect(store.queuedCount).toBe(1)
+    expect(store.reports[0]?.redactedDescription).toContain('[REDACTED-EMAIL]')
+  })
+})

--- a/frontend/src/shared/utils/__tests__/incident-queue.int.spec.ts
+++ b/frontend/src/shared/utils/__tests__/incident-queue.int.spec.ts
@@ -1,0 +1,87 @@
+// @IT-SYS-SHARED-001@ (FROM: @IMP-SYS-SHARED-011@)
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import {
+  clearAllReports,
+  enqueueReport,
+  listReports,
+  removeReport,
+} from '../incident-queue'
+import type { IncidentReport } from '@/core/domain/incident-report.schema'
+
+function buildReport(overrides: Partial<IncidentReport> = {}): IncidentReport {
+  return {
+    id: overrides.id ?? '00000000-0000-4000-a000-000000000001',
+    createdAt: overrides.createdAt ?? '2026-05-31T08:15:00.000Z',
+    kind: overrides.kind ?? 'OTHER',
+    summary: overrides.summary ?? 'something happened',
+    redactedDescription: overrides.redactedDescription ?? 'A redacted body.',
+    context: overrides.context ?? {
+      appVersion: '0.4.0-alpha',
+      routeName: null,
+      pathTail: null,
+      userAgent: null,
+      online: null,
+    },
+    schemaVersion: 1,
+  }
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+})
+
+describe('incident-queue', () => {
+  it('starts empty', async () => {
+    expect(await listReports()).toEqual([])
+  })
+
+  it('persists a report and reads it back', async () => {
+    const r = buildReport()
+    await enqueueReport(r)
+    const list = await listReports()
+    expect(list).toHaveLength(1)
+    expect(list[0]?.id).toBe(r.id)
+  })
+
+  it('sorts queued reports newest-first', async () => {
+    await enqueueReport(
+      buildReport({ id: '00000000-0000-4000-a000-000000000001', createdAt: '2026-01-01T00:00:00.000Z' }),
+    )
+    await enqueueReport(
+      buildReport({ id: '00000000-0000-4000-a000-000000000002', createdAt: '2026-05-31T00:00:00.000Z' }),
+    )
+    const list = await listReports()
+    expect(list.map((r) => r.id)).toEqual([
+      '00000000-0000-4000-a000-000000000002',
+      '00000000-0000-4000-a000-000000000001',
+    ])
+  })
+
+  it('rejects a malformed report at the boundary', async () => {
+    const broken = { ...buildReport(), schemaVersion: 99 as unknown as 1 }
+    await expect(enqueueReport(broken)).rejects.toThrow(/malformed incident report/i)
+    expect(await listReports()).toEqual([])
+  })
+
+  it('removeReport drops the matching row', async () => {
+    await enqueueReport(buildReport({ id: '00000000-0000-4000-a000-00000000000a' }))
+    await enqueueReport(buildReport({ id: '00000000-0000-4000-a000-00000000000b' }))
+    await removeReport('00000000-0000-4000-a000-00000000000a')
+    const list = await listReports()
+    expect(list.map((r) => r.id)).toEqual(['00000000-0000-4000-a000-00000000000b'])
+  })
+
+  it('clearAllReports wipes the store and reports the count', async () => {
+    await enqueueReport(buildReport({ id: '00000000-0000-4000-a000-00000000000a' }))
+    await enqueueReport(buildReport({ id: '00000000-0000-4000-a000-00000000000b' }))
+    const removed = await clearAllReports()
+    expect(removed).toBe(2)
+    expect(await listReports()).toEqual([])
+  })
+})

--- a/frontend/src/shared/utils/incident-queue.ts
+++ b/frontend/src/shared/utils/incident-queue.ts
@@ -1,0 +1,144 @@
+/**
+ * Offline-queued IndexedDB persistence for in-app incident reports
+ * (issue #281, PR-006). P3 — browser API, no Vue/Pinia framework imports.
+ *
+ * Database: aerodash-incidents, version 1.
+ * Object store: reports, keyPath: id (UUID v4).
+ *
+ * The queue holds redacted reports until the pilot opens GitHub and
+ * confirms submission. Reports are NEVER sent automatically — submission
+ * requires an explicit pilot action because the destination is github.com,
+ * which is outside the GDPR data perimeter the rest of AeroDash maintains.
+ *
+ * Each row is round-tripped through {@link IncidentReportSchema} on read;
+ * a row whose `schemaVersion` is from a future build (PWA-cache rollback)
+ * is dropped from the in-memory queue but left on disk so the future
+ * build can read it back when the pilot updates.
+ *
+ * Pattern mirrors `modules/aircraft/services/fleet.repository.ts`.
+ */
+
+import {
+  IncidentReportSchema,
+  type IncidentReport,
+} from '@/core/domain/incident-report.schema'
+
+// @IMP-SYS-SHARED-011@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@)
+
+export const DB_NAME = 'aerodash-incidents'
+const DB_VERSION = 1
+const STORE_NAME = 'reports'
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' })
+        store.createIndex('createdAt', 'createdAt', { unique: false })
+      }
+    }
+
+    request.onsuccess = (event) => {
+      resolve((event.target as IDBOpenDBRequest).result)
+    }
+    request.onerror = (event) => {
+      reject(
+        new Error(
+          `Failed to open incident IndexedDB: ${
+            (event.target as IDBOpenDBRequest).error?.message ?? 'unknown'
+          }`,
+        ),
+      )
+    }
+  })
+}
+
+function runRequest<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB request failed'))
+  })
+}
+
+/** Persist a redacted report. Validates BEFORE writing so a malformed
+ *  row never reaches the store and so the public surface never lies about
+ *  what is on disk. */
+export async function enqueueReport(report: IncidentReport): Promise<void> {
+  const parsed = IncidentReportSchema.safeParse(report)
+  if (!parsed.success) {
+    throw new Error(`Refusing to queue malformed incident report: ${parsed.error.message}`)
+  }
+  const db = await openDB()
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    await runRequest(store.put(parsed.data))
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error ?? new Error('IndexedDB tx failed'))
+      tx.onabort = () => reject(tx.error ?? new Error('IndexedDB tx aborted'))
+    })
+  } finally {
+    db.close()
+  }
+}
+
+/** All queued reports, newest-first by `createdAt`. Rows that fail schema
+ *  validation are silently dropped from the returned list (see file header
+ *  for rationale) but left on disk. */
+export async function listReports(): Promise<IncidentReport[]> {
+  const db = await openDB()
+  try {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const store = tx.objectStore(STORE_NAME)
+    const raw = await runRequest(store.getAll())
+    const valid: IncidentReport[] = []
+    for (const row of raw as unknown[]) {
+      const parsed = IncidentReportSchema.safeParse(row)
+      if (parsed.success) valid.push(parsed.data)
+    }
+    valid.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    return valid
+  } finally {
+    db.close()
+  }
+}
+
+/** Delete one report by id. No-op if the id is unknown. */
+export async function removeReport(id: string): Promise<void> {
+  const db = await openDB()
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    await runRequest(store.delete(id))
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error ?? new Error('IndexedDB tx failed'))
+      tx.onabort = () => reject(tx.error ?? new Error('IndexedDB tx aborted'))
+    })
+  } finally {
+    db.close()
+  }
+}
+
+/** Wipe every queued report. Invoked by Privacy "Delete all data". */
+export async function clearAllReports(): Promise<number> {
+  const db = await openDB()
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const count = await runRequest(store.count())
+    await runRequest(store.clear())
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error ?? new Error('IndexedDB tx failed'))
+      tx.onabort = () => reject(tx.error ?? new Error('IndexedDB tx aborted'))
+    })
+    return count
+  } finally {
+    db.close()
+  }
+}

--- a/frontend/src/shared/utils/incident-queue.ts
+++ b/frontend/src/shared/utils/incident-queue.ts
@@ -34,11 +34,24 @@ function openDB(): Promise<IDBDatabase> {
     const request = indexedDB.open(DB_NAME, DB_VERSION)
 
     request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' })
-        store.createIndex('createdAt', 'createdAt', { unique: false })
+      // Versioned upgrade switch (m4) — mirrors fleet.repository so a future
+      // v2 build (e.g. new index, renamed field) can add a migration branch
+      // here without `NotFoundError` on the new index. Each `case` falls
+      // through intentionally so a pilot upgrading from v1 → vN applies
+      // every intermediate migration in order. Update `DB_VERSION` whenever
+      // a new branch is added.
+      const target = event.target as IDBOpenDBRequest
+      const db = target.result
+      const oldVersion = event.oldVersion
+       
+      switch (oldVersion) {
+        case 0: {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' })
+          store.createIndex('createdAt', 'createdAt', { unique: false })
+        }
+        // case 1: // future migration to v2 lands here
       }
+       
     }
 
     request.onsuccess = (event) => {
@@ -124,14 +137,26 @@ export async function removeReport(id: string): Promise<void> {
   }
 }
 
-/** Wipe every queued report. Invoked by Privacy "Delete all data". */
+/**
+ * Wipe every queued report. Invoked by Privacy "Delete all data"
+ * (REQ-SYS-014, called via `data-rights.service.wipeAllLocalData`).
+ *
+ * The pre-deletion count and the clear request are issued back-to-back
+ * inside the same readwrite transaction (no `await` between them). The
+ * IDB spec deactivates a transaction the moment control returns to the
+ * event loop with no pending requests, so a `await` between `count()`
+ * and `clear()` would cause an `InvalidStateError` on real browsers
+ * (Chrome/Safari/Firefox) — `fake-indexeddb` is permissive enough to
+ * mask it in tests (M4).
+ */
 export async function clearAllReports(): Promise<number> {
   const db = await openDB()
   try {
     const tx = db.transaction(STORE_NAME, 'readwrite')
     const store = tx.objectStore(STORE_NAME)
-    const count = await runRequest(store.count())
-    await runRequest(store.clear())
+    const countReq = store.count()
+    const clearReq = store.clear()
+    const [count] = await Promise.all([runRequest(countReq), runRequest(clearReq)])
     await new Promise<void>((resolve, reject) => {
       tx.oncomplete = () => resolve()
       tx.onerror = () => reject(tx.error ?? new Error('IndexedDB tx failed'))

--- a/frontend/src/stores/__tests__/incident-report.store.int.spec.ts
+++ b/frontend/src/stores/__tests__/incident-report.store.int.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration tests for useIncidentReportStore — exercises the full path
+ * from a pilot-submitted draft through the P1 redactor into the IndexedDB
+ * queue and back out on `loadAll()`. Mirrors the fleet repository int
+ * pattern (refs #166): real IndexedDB via fake-indexeddb, real Pinia.
+ */
+
+// @IT-SYS-STORE-003@ (FROM: @IMP-SYS-STORE-022@, @IMP-SYS-SHARED-011@)
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { setActivePinia, createPinia } from 'pinia'
+import { useIncidentReportStore } from '../incident-report.store'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+})
+
+describe('useIncidentReportStore — capture / list / remove lifecycle', () => {
+  it('captures a redacted report and surfaces it via loadAll()', async () => {
+    const store = useIncidentReportStore()
+    await store.capture(
+      {
+        kind: 'CALCULATION',
+        summary: 'CG amber after correct fuel entry',
+        description: 'Loaded 100 kg pilot mass, contact me at pilot@example.com.',
+      },
+      { routeName: 'mass-balance' },
+    )
+    expect(store.queuedCount).toBe(1)
+    expect(store.reports[0]?.redactedDescription).toContain('[REDACTED-EMAIL]')
+    expect(store.reports[0]?.context.routeName).toBe('mass-balance')
+  })
+
+  it('removes one report and leaves the rest', async () => {
+    const store = useIncidentReportStore()
+    const a = await store.capture({
+      kind: 'OTHER',
+      summary: 'First report saved',
+      description: 'A description long enough.',
+    })
+    await store.capture({
+      kind: 'UI',
+      summary: 'Second report saved',
+      description: 'Another long-enough description.',
+    })
+    await store.remove(a.id)
+    expect(store.queuedCount).toBe(1)
+    expect(store.reports[0]?.summary).toBe('Second report saved')
+  })
+
+  it('clearAll wipes every queued report', async () => {
+    const store = useIncidentReportStore()
+    await store.capture({
+      kind: 'OTHER',
+      summary: 'First report saved',
+      description: 'A description long enough.',
+    })
+    await store.capture({
+      kind: 'OTHER',
+      summary: 'Second report saved',
+      description: 'Another long-enough description.',
+    })
+    const removed = await store.clearAll()
+    expect(removed).toBe(2)
+    expect(store.queuedCount).toBe(0)
+    expect(store.isEmpty).toBe(true)
+  })
+
+  it('survives a reload by reading from IndexedDB on a fresh Pinia instance', async () => {
+    const store1 = useIncidentReportStore()
+    await store1.capture({
+      kind: 'DATA',
+      summary: 'POH default mass looked wrong',
+      description: 'The pre-filled empty mass for this profile did not match POH.',
+    })
+
+    setActivePinia(createPinia())
+    const store2 = useIncidentReportStore()
+    await store2.loadAll()
+    expect(store2.queuedCount).toBe(1)
+    expect(store2.reports[0]?.summary).toBe('POH default mass looked wrong')
+  })
+})

--- a/frontend/src/stores/__tests__/incident-report.store.spec.ts
+++ b/frontend/src/stores/__tests__/incident-report.store.spec.ts
@@ -90,3 +90,35 @@ describe('useIncidentReportStore.buildGithubUrl', () => {
     expect(decodeURIComponent(url)).toContain('App froze or failed to load')
   })
 })
+
+// B1 — REQ-SYS-017: the pilot-supplied summary becomes the public GitHub
+// issue title, so it must pass through the same redactor as the description.
+// Storing the raw summary would leak PII verbatim into the public title.
+describe('useIncidentReportStore — summary redaction (B1)', () => {
+  it('redacts the summary before persistence and before URL handoff', () => {
+    const store = useIncidentReportStore()
+    const report = store.buildReport({
+      kind: 'OTHER',
+      summary: 'Call +49 151 1234 5678 re D-EBPN',
+      description: 'A longer description, definitely above the minimum length.',
+    })
+    expect(report.summary).not.toContain('+49 151 1234 5678')
+    expect(report.summary).not.toContain('D-EBPN')
+    expect(report.summary).toContain('[REDACTED')
+    const url = store.buildGithubUrl(report)
+    expect(decodeURIComponent(url)).not.toContain('+49 151 1234 5678')
+    expect(decodeURIComponent(url)).not.toContain('D-EBPN')
+  })
+
+  it('previewDraft surfaces redactions for BOTH summary and description', () => {
+    const store = useIncidentReportStore()
+    const preview = store.previewDraft({
+      summary: 'Call pilot@example.com',
+      description: 'See https://example.com for context.',
+    })
+    expect(preview.summary.redacted).toContain('[REDACTED-EMAIL]')
+    expect(preview.description.redacted).toContain('[REDACTED-URL]')
+    expect(preview.total).toBe(preview.summary.total + preview.description.total)
+    expect(preview.total).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/frontend/src/stores/__tests__/incident-report.store.spec.ts
+++ b/frontend/src/stores/__tests__/incident-report.store.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for useIncidentReportStore — validates that the store wires
+ * the P1 redaction + URL builder + queue together correctly. The store's
+ * IndexedDB I/O is exercised in incident-report.store.int.spec.ts.
+ */
+
+// @UT-SYS-STORE-200@ (FROM: @IMP-SYS-STORE-022@)
+// @UT-SYS-STORE-201@ (FROM: @IMP-SYS-STORE-022@)
+// @UT-SYS-STORE-202@ (FROM: @IMP-SYS-STORE-022@)
+// @UT-SYS-STORE-203@ (FROM: @IMP-SYS-STORE-022@)
+// @UT-SYS-STORE-204@ (FROM: @IMP-SYS-STORE-022@)
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { useIncidentReportStore } from '../incident-report.store'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+})
+
+describe('useIncidentReportStore.previewRedaction', () => {
+  it('redacts an email and returns the count', () => {
+    const store = useIncidentReportStore()
+    const result = store.previewRedaction('Reach me at pilot@example.com')
+    expect(result.redacted).toContain('[REDACTED-EMAIL]')
+    expect(result.counts.email).toBe(1)
+    expect(result.total).toBe(1)
+  })
+
+  it('returns zero redactions for safe text', () => {
+    const store = useIncidentReportStore()
+    const result = store.previewRedaction('Loaded 100 kg fuel.')
+    expect(result.total).toBe(0)
+    expect(result.redacted).toBe('Loaded 100 kg fuel.')
+  })
+})
+
+describe('useIncidentReportStore.buildReport', () => {
+  it('produces a fully-validated report with redaction applied', () => {
+    const store = useIncidentReportStore()
+    const report = store.buildReport(
+      {
+        kind: 'CALCULATION',
+        summary: 'CG went amber after correct fuel entry',
+        description: 'Loaded 100 kg pilot, contact me at pilot@example.com',
+      },
+      { routeName: 'mass-balance', now: new Date('2026-05-31T08:15:00Z') },
+    )
+    expect(report.kind).toBe('CALCULATION')
+    expect(report.summary).toBe('CG went amber after correct fuel entry')
+    expect(report.redactedDescription).toContain('[REDACTED-EMAIL]')
+    expect(report.context.routeName).toBe('mass-balance')
+    expect(report.schemaVersion).toBe(1)
+    expect(report.createdAt).toBe('2026-05-31T08:15:00.000Z')
+  })
+
+  it('rejects a draft that fails Zod validation', () => {
+    const store = useIncidentReportStore()
+    expect(() =>
+      store.buildReport({
+        kind: 'OTHER',
+        summary: 'no',
+        description: 'too short',
+      }),
+    ).toThrow(/too small/i)
+  })
+})
+
+describe('useIncidentReportStore.buildGithubUrl', () => {
+  it('produces a deep link with the prefilled title and kind', () => {
+    const store = useIncidentReportStore()
+    const report = store.buildReport(
+      {
+        kind: 'CRASH',
+        summary: 'App froze after fuel entry',
+        description: 'The Mass & Balance page stopped responding entirely.',
+      },
+      { routeName: 'mass-balance' },
+    )
+    const url = store.buildGithubUrl(report)
+    expect(url).toContain('github.com/naturelle137/AeroDash/issues/new')
+    expect(decodeURIComponent(url)).toContain('[Incident] App froze after fuel entry')
+    expect(decodeURIComponent(url)).toContain('App froze or failed to load')
+  })
+})

--- a/frontend/src/stores/incident-report.store.ts
+++ b/frontend/src/stores/incident-report.store.ts
@@ -41,7 +41,12 @@ import {
 
 // @IMP-SYS-STORE-022@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@)
 
-const APP_REPO_URL = 'https://github.com/naturelle137/AeroDash'
+// Allow a fork or release-channel build to retarget the GitHub deep link via
+// `VITE_INCIDENT_REPO_URL` (m6) — a fork that shipped without this override
+// would otherwise file pilot incidents against this upstream repo.
+const APP_REPO_URL =
+  (import.meta.env.VITE_INCIDENT_REPO_URL as string | undefined) ??
+  'https://github.com/naturelle137/AeroDash'
 
 export type IncidentLoadState = 'IDLE' | 'LOADING' | 'READY' | 'ERROR'
 
@@ -96,17 +101,37 @@ export const useIncidentReportStore = defineStore('incidentReport', () => {
   }
 
   /**
+   * Combined preview of the redactor's output for both the summary and the
+   * description (B1). The summary leaks into the public GitHub issue title
+   * + body, so it must go through the same redaction filter as the
+   * description; the pilot needs to see both before submission.
+   */
+  function previewDraft(draft: { summary: string; description: string }): {
+    summary: { redacted: string; counts: RedactionCounts; total: number }
+    description: { redacted: string; counts: RedactionCounts; total: number }
+    total: number
+  } {
+    const summary = previewRedaction(draft.summary)
+    const description = previewRedaction(draft.description)
+    return { summary, description, total: summary.total + description.total }
+  }
+
+  /**
    * Build (without persisting) the canonical report shape that would be
    * stored for the given draft, given current build/route metadata. The
    * caller may pass an explicit `routeName` (from `useRoute().name`) so the
    * store stays decoupled from `vue-router`.
+   *
+   * The pilot-supplied `summary` is redacted alongside `description` so the
+   * public GitHub issue title cannot leak PII (B1, REQ-SYS-017).
    */
   function buildReport(
     draft: IncidentDraft,
     overrides: { routeName?: string | null; now?: Date; id?: string } = {},
   ): IncidentReport {
     const parsedDraft = IncidentDraftSchema.parse(draft)
-    const { redacted } = redactIncidentText(parsedDraft.description)
+    const { redacted: redactedSummary } = redactIncidentText(parsedDraft.summary)
+    const { redacted: redactedDescription } = redactIncidentText(parsedDraft.description)
     const context: IncidentContext = {
       ...snapshotContext(),
       routeName: overrides.routeName ?? null,
@@ -115,8 +140,8 @@ export const useIncidentReportStore = defineStore('incidentReport', () => {
       id: overrides.id ?? uuidv4(),
       createdAt: (overrides.now ?? new Date()).toISOString(),
       kind: parsedDraft.kind,
-      summary: parsedDraft.summary,
-      redactedDescription: redacted,
+      summary: redactedSummary,
+      redactedDescription,
       context,
       schemaVersion: 1,
     }
@@ -129,20 +154,42 @@ export const useIncidentReportStore = defineStore('incidentReport', () => {
     overrides: { routeName?: string | null } = {},
   ): Promise<IncidentReport> {
     const report = buildReport(draft, overrides)
-    await enqueueReport(report)
+    try {
+      await enqueueReport(report)
+      lastError.value = null
+    } catch (err) {
+      lastError.value = err instanceof Error ? err.message : 'Failed to queue incident report.'
+      throw err
+    }
     await loadAll()
     return report
   }
 
+  /** Delete one report. Surfaces an IDB failure via {@link lastError} (M8). */
   async function remove(id: string): Promise<void> {
-    await removeReport(id)
+    try {
+      await removeReport(id)
+      lastError.value = null
+    } catch (err) {
+      lastError.value =
+        err instanceof Error ? err.message : 'Failed to delete the incident report.'
+      throw err
+    }
     await loadAll()
   }
 
+  /** Wipe every queued report. Surfaces an IDB failure via {@link lastError} (M8). */
   async function clearAll(): Promise<number> {
-    const removed = await clearAllReports()
-    await loadAll()
-    return removed
+    try {
+      const removed = await clearAllReports()
+      lastError.value = null
+      await loadAll()
+      return removed
+    } catch (err) {
+      lastError.value =
+        err instanceof Error ? err.message : 'Failed to clear incident reports.'
+      throw err
+    }
   }
 
   function buildGithubUrl(report: IncidentReport): string {
@@ -157,6 +204,7 @@ export const useIncidentReportStore = defineStore('incidentReport', () => {
     isEmpty,
     loadAll,
     previewRedaction,
+    previewDraft,
     buildReport,
     capture,
     remove,

--- a/frontend/src/stores/incident-report.store.ts
+++ b/frontend/src/stores/incident-report.store.ts
@@ -1,0 +1,166 @@
+/**
+ * Incident Report Store — P3 App Shell.
+ *
+ * Orchestrates the in-app incident-reporting MVP (issue #281, PR-006):
+ *  - Validates pilot-supplied {@link IncidentDraft} input via Zod.
+ *  - Runs the free-text description through the P1 redactor BEFORE
+ *    persistence, so unredacted text never reaches IndexedDB or the
+ *    GitHub deep link.
+ *  - Persists redacted reports offline via {@link incident-queue}.
+ *  - Builds the prefilled GitHub-issue URL on demand.
+ *
+ * The store NEVER auto-submits a report. Submission is always pilot-driven
+ * — the destination is github.com (outside the GDPR data perimeter), so the
+ * pilot must explicitly open the deep link.
+ */
+
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { v4 as uuidv4 } from 'uuid'
+import {
+  IncidentDraftSchema,
+  IncidentReportSchema,
+  type IncidentContext,
+  type IncidentDraft,
+  type IncidentReport,
+} from '@/core/domain/incident-report.schema'
+import {
+  redactIncidentText,
+  totalRedactions,
+  type RedactionCounts,
+} from '@/core/logic/incident-redaction'
+import {
+  buildGithubIssueUrl as buildGithubIssueUrlPure,
+} from '@/core/logic/github-issue-url'
+import {
+  clearAllReports,
+  enqueueReport,
+  listReports,
+  removeReport,
+} from '@/shared/utils/incident-queue'
+
+// @IMP-SYS-STORE-022@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@)
+
+const APP_REPO_URL = 'https://github.com/naturelle137/AeroDash'
+
+export type IncidentLoadState = 'IDLE' | 'LOADING' | 'READY' | 'ERROR'
+
+function snapshotContext(): IncidentContext {
+  const appVersion = (import.meta.env.VITE_APP_VERSION as string | undefined) ?? '0.0.0-dev'
+  if (typeof window === 'undefined') {
+    return {
+      appVersion,
+      routeName: null,
+      pathTail: null,
+      userAgent: null,
+      online: null,
+    }
+  }
+  const path = window.location?.pathname ?? null
+  const pathTail = path && path !== '/' ? path.split('/').filter(Boolean).slice(-2).join('/') : path
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent ?? null : null
+  const online =
+    typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean' ? navigator.onLine : null
+  return {
+    appVersion,
+    routeName: null,
+    pathTail: pathTail ? pathTail.slice(0, 128) : null,
+    userAgent: ua ? ua.slice(0, 256) : null,
+    online,
+  }
+}
+
+export const useIncidentReportStore = defineStore('incidentReport', () => {
+  const reports = ref<IncidentReport[]>([])
+  const loadState = ref<IncidentLoadState>('IDLE')
+  const lastError = ref<string | null>(null)
+
+  const queuedCount = computed(() => reports.value.length)
+  const isEmpty = computed(() => reports.value.length === 0)
+
+  async function loadAll(): Promise<void> {
+    loadState.value = 'LOADING'
+    lastError.value = null
+    try {
+      reports.value = await listReports()
+      loadState.value = 'READY'
+    } catch (err) {
+      lastError.value = err instanceof Error ? err.message : 'Failed to read incident queue.'
+      loadState.value = 'ERROR'
+    }
+  }
+
+  function previewRedaction(text: string): { redacted: string; counts: RedactionCounts; total: number } {
+    const { redacted, counts } = redactIncidentText(text)
+    return { redacted, counts, total: totalRedactions(counts) }
+  }
+
+  /**
+   * Build (without persisting) the canonical report shape that would be
+   * stored for the given draft, given current build/route metadata. The
+   * caller may pass an explicit `routeName` (from `useRoute().name`) so the
+   * store stays decoupled from `vue-router`.
+   */
+  function buildReport(
+    draft: IncidentDraft,
+    overrides: { routeName?: string | null; now?: Date; id?: string } = {},
+  ): IncidentReport {
+    const parsedDraft = IncidentDraftSchema.parse(draft)
+    const { redacted } = redactIncidentText(parsedDraft.description)
+    const context: IncidentContext = {
+      ...snapshotContext(),
+      routeName: overrides.routeName ?? null,
+    }
+    const report: IncidentReport = {
+      id: overrides.id ?? uuidv4(),
+      createdAt: (overrides.now ?? new Date()).toISOString(),
+      kind: parsedDraft.kind,
+      summary: parsedDraft.summary,
+      redactedDescription: redacted,
+      context,
+      schemaVersion: 1,
+    }
+    return IncidentReportSchema.parse(report)
+  }
+
+  /** Validate → redact → persist. Returns the persisted report. */
+  async function capture(
+    draft: IncidentDraft,
+    overrides: { routeName?: string | null } = {},
+  ): Promise<IncidentReport> {
+    const report = buildReport(draft, overrides)
+    await enqueueReport(report)
+    await loadAll()
+    return report
+  }
+
+  async function remove(id: string): Promise<void> {
+    await removeReport(id)
+    await loadAll()
+  }
+
+  async function clearAll(): Promise<number> {
+    const removed = await clearAllReports()
+    await loadAll()
+    return removed
+  }
+
+  function buildGithubUrl(report: IncidentReport): string {
+    return buildGithubIssueUrlPure({ repoUrl: APP_REPO_URL, report })
+  }
+
+  return {
+    reports,
+    loadState,
+    lastError,
+    queuedCount,
+    isEmpty,
+    loadAll,
+    previewRedaction,
+    buildReport,
+    capture,
+    remove,
+    clearAll,
+    buildGithubUrl,
+  }
+})

--- a/frontend/src/views/IncidentReportsView.vue
+++ b/frontend/src/views/IncidentReportsView.vue
@@ -1,0 +1,286 @@
+<!-- @IMP-UI-VIEW-005@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@) -->
+<template>
+  <section class="incidents" aria-labelledby="incidents-title">
+    <header class="incidents__header">
+      <h1 id="incidents-title" class="incidents__title">Incident reports</h1>
+      <p class="incidents__intro">
+        Reports captured on this device through <strong>Report a problem</strong>.
+        Each entry is stored locally and offline; nothing leaves AeroDash
+        unless you open it on GitHub. Descriptions were redacted before being
+        saved.
+      </p>
+      <div class="incidents__actions">
+        <button
+          type="button"
+          class="incidents__btn incidents__btn--primary"
+          data-testid="open-report-dialog"
+          @click="dialogOpen = true"
+        >
+          Report a new problem
+        </button>
+        <button
+          v-if="!store.isEmpty"
+          type="button"
+          class="incidents__btn incidents__btn--ghost"
+          data-testid="clear-all-reports"
+          @click="onClearAll"
+        >
+          Delete all reports ({{ store.queuedCount }})
+        </button>
+      </div>
+    </header>
+
+    <p
+      v-if="store.lastError"
+      class="incidents__error"
+      role="alert"
+    >{{ store.lastError }}</p>
+
+    <p
+      v-if="store.loadState === 'LOADING'"
+      class="incidents__empty"
+      data-testid="incidents-loading"
+    >Loading queued reports…</p>
+
+    <p
+      v-else-if="store.isEmpty"
+      class="incidents__empty"
+      data-testid="incidents-empty"
+    >No incident reports queued. Use “Report a new problem” the next time you
+       hit something off.</p>
+
+    <ul v-else class="incidents__list" data-testid="incidents-list">
+      <li
+        v-for="report in store.reports"
+        :key="report.id"
+        class="incidents__row"
+      >
+        <div class="incidents__row-head">
+          <span class="incidents__kind">{{ kindLabel(report.kind) }}</span>
+          <span class="incidents__date">{{ formatDate(report.createdAt) }}</span>
+        </div>
+        <p class="incidents__summary">{{ report.summary }}</p>
+        <details class="incidents__details">
+          <summary>Redacted description &amp; context</summary>
+          <pre class="incidents__pre">{{ report.redactedDescription }}</pre>
+          <dl class="incidents__context">
+            <dt>App version</dt><dd>{{ report.context.appVersion }}</dd>
+            <dt>Route</dt><dd>{{ report.context.routeName ?? 'unknown' }}</dd>
+            <dt>Path</dt><dd>{{ report.context.pathTail ?? 'unknown' }}</dd>
+            <dt>Online</dt><dd>{{ onlineLabel(report.context.online) }}</dd>
+          </dl>
+        </details>
+        <div class="incidents__row-actions">
+          <a
+            class="incidents__btn incidents__btn--primary"
+            :href="store.buildGithubUrl(report)"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="open-on-github"
+          >Open on GitHub</a>
+          <button
+            type="button"
+            class="incidents__btn incidents__btn--ghost"
+            @click="onRemove(report.id)"
+          >Delete</button>
+        </div>
+      </li>
+    </ul>
+
+    <ReportProblemDialog
+      :open="dialogOpen"
+      @close="dialogOpen = false"
+      @saved="onSaved"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import ReportProblemDialog from '@/shared/components/ReportProblemDialog.vue'
+import { useIncidentReportStore } from '@/stores/incident-report.store'
+import { INCIDENT_KIND_LABELS } from '@/core/logic/github-issue-url'
+import type { IncidentReport } from '@/core/domain/incident-report.schema'
+
+const store = useIncidentReportStore()
+const dialogOpen = ref(false)
+
+onMounted(() => {
+  void store.loadAll()
+})
+
+function kindLabel(kind: IncidentReport['kind']): string {
+  return INCIDENT_KIND_LABELS[kind]
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString()
+}
+
+function onlineLabel(value: boolean | null): string {
+  if (value === null) return 'unknown'
+  return value ? 'yes' : 'no'
+}
+
+async function onRemove(id: string): Promise<void> {
+  await store.remove(id)
+}
+
+async function onClearAll(): Promise<void> {
+  if (typeof window !== 'undefined') {
+    const confirmed = window.confirm(
+      'Delete every queued incident report from this device? This cannot be undone.',
+    )
+    if (!confirmed) return
+  }
+  await store.clearAll()
+}
+
+function onSaved(): void {
+  dialogOpen.value = false
+}
+</script>
+
+<style scoped>
+.incidents {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+}
+
+.incidents__title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-2xl, 1.5rem);
+  font-weight: 700;
+}
+
+.incidents__intro {
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.incidents__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.incidents__empty {
+  font-style: italic;
+  color: var(--color-text-secondary);
+}
+
+.incidents__error {
+  color: var(--color-danger, #dc2626);
+}
+
+.incidents__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.incidents__row {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  background: var(--color-surface);
+}
+
+.incidents__row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.incidents__kind {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--color-info, #1d4ed8);
+  color: #fff;
+  border-radius: var(--radius-full);
+  padding: 0.1rem 0.6rem;
+}
+
+.incidents__date {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.incidents__summary {
+  margin: 0 0 var(--space-2);
+  font-weight: 600;
+}
+
+.incidents__details {
+  margin-bottom: var(--space-2);
+}
+
+.incidents__pre {
+  white-space: pre-wrap;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-xs);
+  background: var(--color-surface-muted, var(--color-surface));
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+}
+
+.incidents__context {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 2px var(--space-3);
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.incidents__context dt {
+  font-weight: 600;
+}
+
+.incidents__context dd {
+  margin: 0;
+}
+
+.incidents__row-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.incidents__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.incidents__btn--primary {
+  background: var(--color-primary, #1d4ed8);
+  color: #fff;
+}
+
+.incidents__btn--ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+</style>

--- a/frontend/src/views/IncidentReportsView.vue
+++ b/frontend/src/views/IncidentReportsView.vue
@@ -124,8 +124,18 @@ function onlineLabel(value: boolean | null): string {
   return value ? 'yes' : 'no'
 }
 
+// onRemove / onClearAll catch IDB failures (quota, private-mode, locked DB)
+// so the pilot gets visible feedback rather than a silent unhandled-rejection
+// (M8). The store already updates `lastError` on the write paths — re-
+// throwing here would surface as an unhandled rejection in tests/devtools.
 async function onRemove(id: string): Promise<void> {
-  await store.remove(id)
+  try {
+    await store.remove(id)
+  } catch {
+    // store.lastError carries the message; the template's error banner
+    // surfaces it. Nothing else to do — the row stays visible until the
+    // next successful loadAll().
+  }
 }
 
 async function onClearAll(): Promise<void> {
@@ -135,7 +145,11 @@ async function onClearAll(): Promise<void> {
     )
     if (!confirmed) return
   }
-  await store.clearAll()
+  try {
+    await store.clearAll()
+  } catch {
+    // Same as onRemove — lastError is already populated; the banner shows it.
+  }
 }
 
 function onSaved(): void {

--- a/frontend/src/views/PrivacyView.vue
+++ b/frontend/src/views/PrivacyView.vue
@@ -21,6 +21,7 @@ const lastError = ref<string | null>(null)
 const lastWipe = ref<WipeReport | null>(null)
 const lastExportAt = ref<string | null>(null)
 const lastExportOmitted = ref(0)
+const lastExportIncidentsOmitted = ref(0)
 
 const profileCount = computed(() => fleetStore.profiles.length)
 // A failed fleet load leaves `profiles` empty, which would otherwise read as
@@ -36,11 +37,18 @@ const unreadableCount = computed(() => fleetStore.unreadableProfileCount)
 const wipeNotice = computed(() => {
   const r = lastWipe.value
   if (r === null) return ''
-  if (r.profilesDeleted === null) {
-    return `Local data cleared at ${r.clearedAt} (profiles removed: count unavailable).`
-  }
-  const n = r.profilesDeleted
-  return `Local data cleared at ${r.clearedAt} — ${n} aircraft profile${n === 1 ? '' : 's'} removed.`
+  const profilesPart =
+    r.profilesDeleted === null
+      ? 'profiles removed: count unavailable'
+      : `${r.profilesDeleted} aircraft profile${r.profilesDeleted === 1 ? '' : 's'} removed`
+  const incidentsPart =
+    r.incidentReportsDeleted === null
+      ? null
+      : `${r.incidentReportsDeleted} incident report${
+          r.incidentReportsDeleted === 1 ? '' : 's'
+        } removed`
+  const tail = incidentsPart ? ` ${profilesPart}, ${incidentsPart}.` : ` ${profilesPart}.`
+  return `Local data cleared at ${r.clearedAt} —${tail}`
 })
 
 const wipeConfirmText = ref('')
@@ -65,14 +73,16 @@ async function onExportAll(): Promise<void> {
   lastWipe.value = null
   lastExportAt.value = null
   lastExportOmitted.value = 0
+  lastExportIncidentsOmitted.value = 0
   busy.value = true
   try {
-    const { envelope, omitted } = await exportAllProfiles()
+    const { envelope, omitted, incidentReportsOmitted } = await exportAllProfiles()
     const json = serializeBulkExport(envelope)
     const downloaded = triggerJsonDownload(json, envelope.exportedAt)
     if (!downloaded) return
     lastExportAt.value = envelope.exportedAt
     lastExportOmitted.value = omitted.length
+    lastExportIncidentsOmitted.value = incidentReportsOmitted
   } catch (err) {
     lastError.value = err instanceof Error ? err.message : 'Export failed: unknown error'
   } finally {
@@ -111,6 +121,7 @@ async function onConfirmWipe(): Promise<void> {
   lastWipe.value = null
   lastExportAt.value = null
   lastExportOmitted.value = 0
+  lastExportIncidentsOmitted.value = 0
   busy.value = true
   try {
     // Cancel any pending debounced session autosave first, so a timer scheduled
@@ -225,6 +236,21 @@ function onCancelWipe(): void {
       not be included in this export (saved by a newer app version or unreadable). The export
       is therefore not a complete copy — update AeroDash to recover them before deleting all
       data.
+    </p>
+
+    <p
+      v-if="lastExportAt && lastExportIncidentsOmitted > 0"
+      class="privacy-view__notice privacy-view__notice--warn"
+      role="status"
+      aria-live="polite"
+      data-testid="privacy-export-incidents-omitted"
+    >
+      Note: {{ lastExportIncidentsOmitted }} queued incident report{{
+        lastExportIncidentsOmitted === 1 ? '' : 's'
+      }} {{ lastExportIncidentsOmitted === 1 ? 'is' : 'are' }} stored on this device but
+      <strong>not</strong> included in this export — they are redacted and submitted on demand
+      via <strong>Open on GitHub</strong> from the Incidents page. A Delete all data action
+      will erase them.
     </p>
 
     <!-- ─── Export-all card ─────────────────────────────────────────── -->

--- a/frontend/src/views/__tests__/IncidentReportsView.spec.ts
+++ b/frontend/src/views/__tests__/IncidentReportsView.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for IncidentReportsView.vue — list / open-on-GitHub / delete
+ * surface for the in-app incident-reporting MVP (issue #281, PR-006).
+ */
+
+// @UT-UI-VIEW-010@ (FROM: @IMP-UI-VIEW-005@)
+// @UT-UI-VIEW-011@ (FROM: @IMP-UI-VIEW-005@)
+// @UT-UI-VIEW-012@ (FROM: @IMP-UI-VIEW-005@)
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+import { defineComponent, h } from 'vue'
+import IncidentReportsView from '../IncidentReportsView.vue'
+import { useIncidentReportStore } from '@/stores/incident-report.store'
+
+const Stub = defineComponent({
+  setup() {
+    return () => h('div')
+  },
+})
+
+function buildRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', name: 'home', component: Stub }],
+  })
+}
+
+async function settle(): Promise<void> {
+  // fake-indexeddb schedules onsuccess callbacks through the macrotask queue,
+  // so flushPromises (microtasks only) is not enough. Pump a few real-timer
+  // ticks alongside flushPromises until the store transitions out of LOADING.
+  for (let i = 0; i < 6; i += 1) {
+    await flushPromises()
+    await new Promise((r) => setTimeout(r, 0))
+  }
+}
+
+async function mountView() {
+  const router = buildRouter()
+  await router.push('/')
+  await router.isReady()
+  const wrapper = mount(IncidentReportsView, {
+    attachTo: document.body,
+    global: { plugins: [router] },
+  })
+  await settle()
+  return wrapper
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('IncidentReportsView', () => {
+  it('shows the empty-state copy when the queue is empty', async () => {
+    const wrapper = await mountView()
+    expect(wrapper.find('[data-testid="incidents-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="incidents-list"]').exists()).toBe(false)
+  })
+
+  it('lists queued reports newest-first', async () => {
+    const store = useIncidentReportStore()
+    await store.capture({
+      kind: 'OTHER',
+      summary: 'Older report saved',
+      description: 'A description long enough.',
+    })
+    await store.capture({
+      kind: 'UI',
+      summary: 'Newer report saved',
+      description: 'Another long-enough description.',
+    })
+
+    const wrapper = await mountView()
+    const summaries = wrapper
+      .findAll('.incidents__summary')
+      .map((node) => node.text())
+    expect(summaries[0]).toBe('Newer report saved')
+    expect(summaries[1]).toBe('Older report saved')
+  })
+
+  it('builds an "Open on GitHub" link that targets the issues/new endpoint', async () => {
+    const store = useIncidentReportStore()
+    await store.capture({
+      kind: 'CALCULATION',
+      summary: 'CG amber after fuel',
+      description: 'Loaded 100 kg pilot mass; the envelope chart went amber.',
+    })
+
+    const wrapper = await mountView()
+    const link = wrapper.find('[data-testid="open-on-github"]')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toContain(
+      'github.com/naturelle137/AeroDash/issues/new',
+    )
+    expect(decodeURIComponent(link.attributes('href') ?? '')).toContain(
+      '[Incident] CG amber after fuel',
+    )
+  })
+})

--- a/frontend/src/views/__tests__/PrivacyView.spec.ts
+++ b/frontend/src/views/__tests__/PrivacyView.spec.ts
@@ -64,7 +64,9 @@ vi.mock('@/stores/session-persistence.store', () => {
 function defaultWipeReport(): WipeReport {
   return {
     profilesDeleted: 0,
+    incidentReportsDeleted: 0,
     indexedDbCleared: true,
+    incidentDbCleared: true,
     localStorageKeysCleared: [],
     sessionStorageKeysCleared: [],
     failures: [],
@@ -82,6 +84,7 @@ function defaultExportResult(): BulkExportResult {
       profiles: [],
     },
     omitted: [],
+    incidentReportsOmitted: 0,
   }
 }
 
@@ -125,6 +128,7 @@ describe('PrivacyView — bulk export (REQ-SYS-015)', () => {
         profiles: [],
       },
       omitted: [],
+      incidentReportsOmitted: 0,
     })
 
     const wrapper = mountView()
@@ -162,6 +166,7 @@ describe('PrivacyView — bulk export (REQ-SYS-015)', () => {
           detail: 'newer build',
         },
       ],
+      incidentReportsOmitted: 0,
     })
 
     const wrapper = mountView()
@@ -257,7 +262,9 @@ describe('PrivacyView — delete-all (REQ-SYS-014)', () => {
   it('reports an incomplete erasure as CRITICAL and never shows the success notice (M2)', async () => {
     wipeMock.mockResolvedValueOnce({
       profilesDeleted: 1,
+      incidentReportsDeleted: 0,
       indexedDbCleared: true,
+      incidentDbCleared: true,
       localStorageKeysCleared: ['aerodash:session:payload'],
       sessionStorageKeysCleared: [],
       failures: [{ store: 'localStorage', key: 'aerodash-theme', detail: 'removeItem failed' }],
@@ -392,7 +399,9 @@ describe('PrivacyView — delete-all (REQ-SYS-014)', () => {
   it('reports an unknown profile count without claiming a false 0 (m1)', async () => {
     wipeMock.mockResolvedValueOnce({
       profilesDeleted: null,
+      incidentReportsDeleted: null,
       indexedDbCleared: true,
+      incidentDbCleared: true,
       localStorageKeysCleared: [],
       sessionStorageKeysCleared: [],
       failures: [],

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -267,12 +267,13 @@ SYS (auto)
       - REQ-SYS-005
 
   IMP-SYS-STORE-021
-    title: Data-rights service — erase / export of all personal data (REQ-SYS-014/015)
+    title: Data-rights service — erase / export of all personal data (REQ-SYS-014/015) including the aerodash-incidents queue (REQ-SYS-016)
     files:
       - frontend/src/modules/aircraft/services/data-rights.service.ts
     req:
       - REQ-SYS-014
       - REQ-SYS-015
+      - REQ-SYS-016
     des:
       - DES-ARCH-011
       - DES-ARCH-012
@@ -411,40 +412,6 @@ SYS Incident reporting MVP (#281, PR-006)
     title: useIncidentReportStore — Pinia store wiring the P1 redactor + URL builder + IndexedDB queue; never auto-submits, always pilot-driven (REQ-SYS-016/017/018)
     files:
       - frontend/src/stores/incident-report.store.ts
-    req:
-      - REQ-SYS-016
-      - REQ-SYS-017
-      - REQ-SYS-018
-
-  IMP-UI-SHARED-008
-    title: ReportProblemDialog.vue — in-app Report-a-problem dialog with redaction preview and offline save (REQ-SYS-016/017)
-    files:
-      - frontend/src/shared/components/ReportProblemDialog.vue
-    req:
-      - REQ-SYS-016
-      - REQ-SYS-017
-
-  IMP-UI-SHARED-009
-    title: Sidebar footer Report-a-problem button — entry point that opens the in-app incident report dialog (REQ-SYS-016/018)
-    files:
-      - frontend/src/App.vue
-    req:
-      - REQ-SYS-016
-      - REQ-SYS-018
-
-  IMP-UI-ROUTE-005
-    title: /incidents route — exposes IncidentReportsView for queue review and GitHub handoff (REQ-SYS-016/017/018)
-    files:
-      - frontend/src/router/index.ts
-    req:
-      - REQ-SYS-016
-      - REQ-SYS-017
-      - REQ-SYS-018
-
-  IMP-UI-VIEW-005
-    title: IncidentReportsView.vue — lists queued reports, exposes per-report GitHub deep link and local delete (REQ-SYS-016/017/018)
-    files:
-      - frontend/src/views/IncidentReportsView.vue
     req:
       - REQ-SYS-016
       - REQ-SYS-017

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -373,3 +373,79 @@ SYS Store — App Version build-time floor resolution (#271, PR-review Major #2 
       - REQ-SYS-006
     hazard:
       - H-019
+
+SYS Incident reporting MVP (#281, PR-006)
+  IMP-SYS-CORE-013
+    title: IncidentReport / IncidentDraft Zod schemas — pure-TS data contract for the in-app incident-reporting MVP (REQ-SYS-016/017)
+    files:
+      - frontend/src/core/domain/incident-report.schema.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+
+  IMP-SYS-CORE-014
+    title: redactIncidentText — deterministic P1 redactor for email / phone / coords / aircraft registration / URLs in pilot free-text incident descriptions (REQ-SYS-017)
+    files:
+      - frontend/src/core/logic/incident-redaction.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+
+  IMP-SYS-CORE-015
+    title: buildGithubIssueUrl — pure builder for the prefilled GitHub issue deep link (template, title, kind, redacted body, operational context) with hard length cap and truncation marker (REQ-SYS-017/018)
+    files:
+      - frontend/src/core/logic/github-issue-url.ts
+    req:
+      - REQ-SYS-017
+      - REQ-SYS-018
+
+  IMP-SYS-SHARED-011
+    title: incident-queue — offline-queued IndexedDB persistence (aerodash-incidents/reports) with Zod boundary-validation on read+write (REQ-SYS-016)
+    files:
+      - frontend/src/shared/utils/incident-queue.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+
+  IMP-SYS-STORE-022
+    title: useIncidentReportStore — Pinia store wiring the P1 redactor + URL builder + IndexedDB queue; never auto-submits, always pilot-driven (REQ-SYS-016/017/018)
+    files:
+      - frontend/src/stores/incident-report.store.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018
+
+  IMP-UI-SHARED-008
+    title: ReportProblemDialog.vue — in-app Report-a-problem dialog with redaction preview and offline save (REQ-SYS-016/017)
+    files:
+      - frontend/src/shared/components/ReportProblemDialog.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+
+  IMP-UI-SHARED-009
+    title: Sidebar footer Report-a-problem button — entry point that opens the in-app incident report dialog (REQ-SYS-016/018)
+    files:
+      - frontend/src/App.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-018
+
+  IMP-UI-ROUTE-005
+    title: /incidents route — exposes IncidentReportsView for queue review and GitHub handoff (REQ-SYS-016/017/018)
+    files:
+      - frontend/src/router/index.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018
+
+  IMP-UI-VIEW-005
+    title: IncidentReportsView.vue — lists queued reports, exposes per-report GitHub deep link and local delete (REQ-SYS-016/017/018)
+    files:
+      - frontend/src/views/IncidentReportsView.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018

--- a/trace/implementation/ui.yaml
+++ b/trace/implementation/ui.yaml
@@ -138,3 +138,37 @@ UI (auto)
     des:
       - DES-ARCH-011
       - DES-ARCH-012
+
+  IMP-UI-SHARED-008
+    title: ReportProblemDialog.vue — in-app Report-a-problem dialog with redaction preview and offline save (REQ-SYS-016/017)
+    files:
+      - frontend/src/shared/components/ReportProblemDialog.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+
+  IMP-UI-SHARED-009
+    title: Sidebar footer Report-a-problem button + mobile bottom-nav Incidents entry — pilot-facing entry points for the in-app incident report dialog and review queue (REQ-SYS-016/018)
+    files:
+      - frontend/src/App.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-018
+
+  IMP-UI-ROUTE-005
+    title: /incidents route — exposes IncidentReportsView for queue review and GitHub handoff (REQ-SYS-016/017/018)
+    files:
+      - frontend/src/router/index.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018
+
+  IMP-UI-VIEW-005
+    title: IncidentReportsView.vue — lists queued reports, exposes per-report GitHub deep link and local delete (REQ-SYS-016/017/018)
+    files:
+      - frontend/src/views/IncidentReportsView.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018

--- a/trace/integration_test/sys.yaml
+++ b/trace/integration_test/sys.yaml
@@ -25,3 +25,19 @@ SYS Store — App-version offline enforcement (Integration — #271 CS-011 / TEC
       - IMP-SYS-STORE-013
       - IMP-SYS-STORE-014
       - IMP-SYS-STORE-015
+
+SYS Incident reporting MVP (Integration — #281, PR-006)
+  IT-SYS-SHARED-001
+    title: incident-queue — IndexedDB CRUD lifecycle (enqueue/list/remove/clear) with Zod boundary validation (REQ-SYS-016)
+    files:
+      - frontend/src/shared/utils/__tests__/incident-queue.int.spec.ts
+    impl:
+      - IMP-SYS-SHARED-011
+
+  IT-SYS-STORE-003
+    title: useIncidentReportStore — capture → list → remove → clear lifecycle through fake-indexeddb + real Pinia; reload survives via IndexedDB (REQ-SYS-016/017)
+    files:
+      - frontend/src/stores/__tests__/incident-report.store.int.spec.ts
+    impl:
+      - IMP-SYS-STORE-022
+      - IMP-SYS-SHARED-011

--- a/trace/requirements/sys.yaml
+++ b/trace/requirements/sys.yaml
@@ -65,3 +65,15 @@ System Requirements
   REQ-SYS-015
     title: Export of All Personal Data
     file: docs/requirements/system.md
+
+  REQ-SYS-016
+    title: Offline-Queued Incident Capture
+    file: docs/requirements/system.md
+
+  REQ-SYS-017
+    title: Incident-Report Privacy Redaction
+    file: docs/requirements/system.md
+
+  REQ-SYS-018
+    title: Incident-to-Regression Handoff
+    file: docs/requirements/system.md

--- a/trace/unit_test/sys.yaml
+++ b/trace/unit_test/sys.yaml
@@ -1578,3 +1578,60 @@ SYS (auto)
       - frontend/src/stores/__tests__/session-persistence.store.spec.ts
     impl:
       - IMP-SYS-STORE-001
+
+SYS Incident reporting MVP (#281, PR-006)
+  UT-SYS-CORE-110
+    title: redactIncidentText — email/phone/coord/registration/URL classes, aviation-numeric pass-through, determinism (REQ-SYS-017)
+    files:
+      - frontend/src/core/logic/incident-redaction.spec.ts
+    impl:
+      - IMP-SYS-CORE-014
+
+  UT-SYS-CORE-111
+    title: buildGithubIssueUrl — title/kind/body/context prefill, trailing-slash tolerance, URL-length truncation, determinism (REQ-SYS-018)
+    files:
+      - frontend/src/core/logic/github-issue-url.spec.ts
+    impl:
+      - IMP-SYS-CORE-015
+
+  UT-SYS-CORE-112
+    title: IncidentDraftSchema / IncidentReportSchema boundary validation — length caps, UUID id, ISO timestamp, schemaVersion lock (REQ-SYS-016)
+    files:
+      - frontend/src/core/domain/incident-report.schema.spec.ts
+    impl:
+      - IMP-SYS-CORE-013
+
+  UT-SYS-STORE-200
+    title: previewRedaction wires the P1 redactor and reports per-class counts (REQ-SYS-017)
+    files:
+      - frontend/src/stores/__tests__/incident-report.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-022
+
+  UT-SYS-STORE-201
+    title: previewRedaction returns zero redactions for safe text (REQ-SYS-017)
+    files:
+      - frontend/src/stores/__tests__/incident-report.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-022
+
+  UT-SYS-STORE-202
+    title: buildReport applies redaction, snapshots route + context, and round-trips through the schema (REQ-SYS-016/017)
+    files:
+      - frontend/src/stores/__tests__/incident-report.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-022
+
+  UT-SYS-STORE-203
+    title: buildReport rejects an invalid draft at the Zod boundary (REQ-SYS-011, REQ-SYS-016)
+    files:
+      - frontend/src/stores/__tests__/incident-report.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-022
+
+  UT-SYS-STORE-204
+    title: buildGithubUrl wraps the pure builder with the canonical repo URL and reaches the prefilled title/kind (REQ-SYS-018)
+    files:
+      - frontend/src/stores/__tests__/incident-report.store.spec.ts
+    impl:
+      - IMP-SYS-STORE-022

--- a/trace/unit_test/ui.yaml
+++ b/trace/unit_test/ui.yaml
@@ -44,3 +44,53 @@ UI (auto)
       - frontend/src/views/__tests__/PrivacyView.spec.ts
     impl:
       - IMP-UI-VIEW-002
+
+UI Incident reporting MVP (#281, PR-006)
+  UT-UI-SHARED-040
+    title: ReportProblemDialog renders when open and stays hidden when closed (REQ-SYS-016)
+    files:
+      - frontend/src/shared/components/__tests__/ReportProblemDialog.spec.ts
+    impl:
+      - IMP-UI-SHARED-008
+
+  UT-UI-SHARED-041
+    title: ReportProblemDialog redaction preview updates with description text (REQ-SYS-017)
+    files:
+      - frontend/src/shared/components/__tests__/ReportProblemDialog.spec.ts
+    impl:
+      - IMP-UI-SHARED-008
+
+  UT-UI-SHARED-042
+    title: ReportProblemDialog disables Save until summary + description meet length minimums (REQ-SYS-011, REQ-SYS-016)
+    files:
+      - frontend/src/shared/components/__tests__/ReportProblemDialog.spec.ts
+    impl:
+      - IMP-UI-SHARED-008
+
+  UT-UI-SHARED-043
+    title: ReportProblemDialog persists the report on submit via the incident store (REQ-SYS-016)
+    files:
+      - frontend/src/shared/components/__tests__/ReportProblemDialog.spec.ts
+    impl:
+      - IMP-UI-SHARED-008
+
+  UT-UI-VIEW-010
+    title: IncidentReportsView shows empty-state copy when the queue is empty (REQ-SYS-016)
+    files:
+      - frontend/src/views/__tests__/IncidentReportsView.spec.ts
+    impl:
+      - IMP-UI-VIEW-005
+
+  UT-UI-VIEW-011
+    title: IncidentReportsView lists queued reports newest-first (REQ-SYS-016)
+    files:
+      - frontend/src/views/__tests__/IncidentReportsView.spec.ts
+    impl:
+      - IMP-UI-VIEW-005
+
+  UT-UI-VIEW-012
+    title: IncidentReportsView "Open on GitHub" link targets the prefilled issues/new endpoint (REQ-SYS-018)
+    files:
+      - frontend/src/views/__tests__/IncidentReportsView.spec.ts
+    impl:
+      - IMP-UI-VIEW-005


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

- In-app **Report a problem** flow that captures redacted pilot incident reports offline (IndexedDB) and hands each one off to a pre-filled GitHub issue.
- P1 redactor strips email / phone / GPS / aircraft registration / URLs from pilot free-text; P1 URL builder pre-fills the new `incident_report.yml` issue template; everything else is P3 (queue, store, dialog, `/incidents` view).
- Closes audit gap PR-006 — pilot-trial findings now have a documented path into the regression suite (see `docs/development/incident-to-regression.md`).

### Related Issues

- Closes #281

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-SYS-016`, `REQ-SYS-017`, `REQ-SYS-018`

### Documentation Updates

- [x] **Requirements:** Created ID(s): `REQ-SYS-016`, `REQ-SYS-017`, `REQ-SYS-018` in `docs/requirements/system.md`
- [x] **Architecture:** N/A (Reason: feature reuses the existing P1/P2/P3 layering and IndexedDB pattern from the fleet repository — no architectural surface added)
- [x] **Risk Management:** N/A (Reason: PR-006 is a process gap, not a flight hazard; the new requirements deliberately carry no `FROM: @H-…@` link, see workflow doc §7)
- [x] **Journeys:** N/A (Reason: incident reporting is a meta workflow about reporting defects in journeys, not a user journey itself; no `docs/journeys/` change needed)
- [x] **Code Docs:** Added `docs/development/incident-to-regression.md`; CHANGELOG intentionally untouched (release-process owned)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules) — `pnpm --filter frontend test:p1` green, P1 coverage 99 % / 97 % / 100 %.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added (`incident-redaction.spec.ts`, `github-issue-url.spec.ts`, `incident-report.schema.spec.ts`, `incident-report.store.spec.ts`, `ReportProblemDialog.spec.ts`, `IncidentReportsView.spec.ts`) and passing — `pnpm test:unit` 1465/1465 green.
- [x] **Integration Tests:** Added (`incident-queue.int.spec.ts`, `incident-report.store.int.spec.ts`) and passing — `pnpm test:integration` 74/74 green.
- [x] **Manual Testing:** N/A (Reason: targets `develop`, not `main`; behavioural coverage exercised through unit + integration suites; no in-cockpit verification possible in CI environment)
- [x] **DoD:** All Definition of Done items from the linked Feature are met — see ticked DoD on the issue (offline-queued redacted capture, Report-a-problem UI → issue template, documented incident → regression workflow).
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** N/A (Reason: the change reuses the existing dependency-isolation pattern from ADR-314 and the IndexedDB persistence pattern from ADR-006; no interface surface added that warrants a new ADR)
