### PR TITLE
feat: in-app contribution hub (prefilled bug/feature issues + security advisory link) (#395)

### DIFF
--- a/docs/architecture/adr/012-in-app-contribution-intake.md
+++ b/docs/architecture/adr/012-in-app-contribution-intake.md
@@ -1,0 +1,159 @@
+# ADR-012: In-App Contribution Intake — Prefill-and-Confirm for Issues, Link-Only for Security Advisories
+
+* **Status:** Accepted
+* **Date:** 2026-05-31
+
+## Context
+
+AeroDash has three first-class intake channels in GitHub: the
+[`bug_report.yml`](../../../.github/ISSUE_TEMPLATE/bug_report.yml) issue
+template, the
+[`feature_request.yml`](../../../.github/ISSUE_TEMPLATE/feature_request.yml)
+issue template, and the repository's private
+[Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories)
+form. The app itself currently exposes none of them — a pilot who wants to
+report a defect or propose a feature has to leave AeroDash, find the GitHub
+repository, identify the correct template, and write a structured report
+unaided. The target user is a non-developer general-aviation pilot; the
+expected outcome is that very few real findings ever reach the regression
+suite.
+
+A first attempt at closing this gap (PR #392, issue #281) introduced a
+fourth, parallel `incident_report.yml` template plus an in-app, IndexedDB-
+queued incident store with a P1 redactor. The project owner rejected both
+choices: GitHub already has the right channels, a fourth one fragments
+intake, and a parallel app-side store has no purpose if the artefact is
+ultimately submitted to GitHub. This ADR records the replacement direction
+before any code is written.
+
+The new feature is tracked under issue #395 (supersedes #281).
+
+## Considered Options
+
+* **A — In-app link-only.** Three plain-language buttons in the app open
+  the corresponding GitHub page in a new tab with the template
+  preselected: pilot enters all data on GitHub. Simplest to build,
+  zero coupling to GitHub's form schema, weakest UX for non-developers
+  (they still face a long structured form with no guidance and need to
+  navigate the GitHub UI cold).
+
+* **B — In-app guided form with prefilled handoff.** The app walks the
+  pilot through a friendly step-by-step form whose fields map to the
+  existing GitHub template fields. On submit, the app builds a fully
+  prefilled GitHub "new issue" URL (template selected, `title`, and
+  per-field body block) and opens it in a new tab. The pilot reviews and
+  clicks **Submit** on GitHub. The "have you searched the backlog?"
+  question is omitted in the app — the pilot cannot verify that without
+  leaving the app, so asking it would only confuse. Requires a small P1
+  URL builder (pure TS, easy to test) but no backend, no tokens, no
+  persistence.
+
+* **C — Full background submission.** The app captures every field and
+  submits the issue to GitHub silently. Requires either a stored
+  Personal Access Token (browser-side credential — a security risk in a
+  PWA we explicitly do not want) or a backend service to relay the
+  submission. AeroDash is offline-first and intentionally has no
+  backend; introducing one for issue intake contradicts the architecture
+  baseline and adds an operational surface that is not justified by
+  this feature's benefit.
+
+A separate constraint applies to security advisories: GitHub's
+advisory creation form
+(`/security/advisories/new`) does **not** accept URL pre-fill, so
+Option B is technically impossible for that channel — any in-app form
+would discard the user's input on handoff. Option C is also out (same
+reason as above, plus advisories carry private-vulnerability data that
+must reach GitHub's private workflow without intermediaries). Only
+Option A is available.
+
+## Decision
+
+Adopt a **two-channel split** that picks the highest-UX feasible option
+per intake type:
+
+* **Bug reports** → Option B (in-app guided form → prefilled GitHub
+  issue → confirm on GitHub).
+* **Feature requests** → Option B (same pattern, different template and
+  fields).
+* **Security vulnerabilities** → Option A (in-app explainer + button that
+  opens `/security/advisories/new` in a new tab).
+
+The implementation must reuse the **existing** GitHub templates
+unchanged. No new issue template is created. The prefill URL is built by
+a single pure-TypeScript function in `src/core/` (a P1 module) so that
+the mapping between the form field set and the GitHub query string is
+unit-testable in isolation from the Vue layer. The UI and any field
+collection live in P3 (`src/shared/components/`, `src/views/`).
+
+A small **contribution-promotion card** ships next to the three
+buttons, stating that contribution is not only code — issue reporting,
+feature ideas, improvement suggestions, and documentation are all
+valued — and linking to the public GitHub repository. The design and
+copy are specified in `docs/ux/contribution.md` and recorded as
+`DES-UX-013` / `DES-ARCH-014`. Three new system requirements (`REQ-SYS-016`
+through `REQ-SYS-018`) capture the binding behaviour.
+
+## Consequences
+
+### Positive
+
+* **No new intake channel.** The existing `bug_report.yml` and
+  `feature_request.yml` templates remain the single source of truth for
+  what an issue needs to contain; the app cannot drift from them.
+* **Pilots stay close to plain language inside the app**, then meet a
+  prefilled (not blank) GitHub form. The cognitive gap is small enough
+  that a non-developer can finish the submission unaided.
+* **No backend, no tokens, no in-app store of pilot reports.** The PWA
+  architecture (offline-first, client-only) is preserved verbatim.
+* **The P1 URL builder is pure, deterministic, and trivially testable.**
+  90 % P1 coverage is achievable with unit tests alone; no DOM or fixture
+  fabrication is required.
+* **Security advisories never travel through a relay.** The link-only
+  path keeps vulnerability data in GitHub's private workflow.
+
+### Negative
+
+* **Two integration styles to maintain.** Bug/feature use prefill;
+  security uses link-only. The asymmetry has to be explained once in the
+  UX (a tooltip on the security card states why it differs).
+* **Prefill URLs are tightly coupled to the GitHub template schema.** If
+  a template field is renamed in `bug_report.yml` or
+  `feature_request.yml`, the prefill silently drops that field on the
+  GitHub side. Mitigation: the URL builder is unit-tested against the
+  template field IDs, and a lint check (future) can warn if a template
+  field ID is removed without the builder being updated. For now the
+  coupling is documented in the builder file's tag header and in
+  `docs/ux/contribution.md`.
+* **The pilot must have a GitHub account** to complete either flow.
+  This is a project-wide constraint (no in-app auth), not new to this
+  feature.
+* **No offline submission.** A pilot drafting a report on the ramp
+  without connectivity sees the GitHub tab fail to load on handoff.
+  Mitigation: the in-app form gates the "Open GitHub" button on
+  connectivity (`navigator.onLine`) and surfaces a "save for later"
+  message asking the pilot to retry when online; we deliberately do not
+  persist the draft in IndexedDB (would re-introduce the rejected store
+  from PR #392). This trade-off is acceptable: incident reporting is
+  not a flight-critical workflow, and the airframe-side workflow (Mass &
+  Balance, Performance) remains fully offline.
+
+## Compliance
+
+This decision does not introduce new safety hazards. The contribution
+hub is a pilot-initiated, non-flight-critical workflow and does not
+feed any Go/No-Go advisory. The three new requirements
+(`REQ-SYS-016`, `REQ-SYS-017`, `REQ-SYS-018`) carry no `FROM: @H-…@`
+link by design.
+
+The link-only path for security advisories preserves GitHub's
+[coordinated-disclosure private workflow](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories);
+sensitive vulnerability detail does not transit any AeroDash code.
+
+Privacy posture (GDPR Art. 25 — privacy by default): no pilot free-text
+is stored client-side and no telemetry is emitted on form interaction.
+Browser-side handoff to GitHub is initiated only by an explicit click on
+"Open GitHub to submit".
+
+This ADR supersedes the implementation direction recorded in (closed)
+PR #392; the `incident_report.yml` template and the in-app incident
+queue are out of scope and will not be reintroduced.

--- a/docs/journeys/04_system_usability.md
+++ b/docs/journeys/04_system_usability.md
@@ -48,3 +48,27 @@ Focus: UI resilience and environmental factors.
 | **Export Attempt**     | Generates a PDF briefing pack.                                                                          | "Now let me print this for real."                                                             | The system generates the export without any `[UNVERIFIED]` markers on the destination airport. No unverified data warning or export block appears.        |
 
 **Outcome:** The pilot actively takes responsibility for the accuracy of externally-sourced data. The verification workflow ensures that auto-downloaded values are never silently trusted — the pilot must either verify individually or batch-accept the data before the system treats it as reliable.
+
+<!-- @UJ-D-003@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@) -->
+
+## <a name="UJ-D-003"></a>UJ-D-003: Reporting a Defect, Suggesting a Feature, or Raising a Security Concern
+
+**Persona:** Pilot (non-developer)
+
+**Context:** During flight prep, the pilot notices that the Mass & Balance view displays an unexpected CG value after switching aircraft profiles. Later, on a different session, the pilot has an idea for a feature: showing wind correction directly on the runway diagram. On a third session, the pilot suspects an input field accepts a value that could be used to bypass a safety warning.
+
+**Goal:** Wants to share each finding with the AeroDash team without leaving the app cold-handed, without learning a structured bug-report format from scratch, and without putting potentially-sensitive vulnerability detail into a public issue.
+
+**Journey:**
+
+| Phase | User Action | Thoughts / Feelings | Observable System Reaction |
+| :--- | :--- | :--- | :--- |
+| **Enter hub** | Opens the contribution hub from the sidebar footer link "Help / contribute". | "Where do I send this? I've never used GitHub." | The `/contribute` view loads with three labelled buttons — *Report a defect*, *Request a feature*, *Report a security vulnerability* — each with a one-sentence description and an info tooltip. |
+| **Pick category — defect** | Hovers the `(i)` tooltip on "Report a defect" to confirm it fits, then clicks the button. | "Yes — a wrong number shown by the app. That matches 'defect'." | The view replaces the three-button grid with the guided defect form. The first field, "Title", has the cursor. |
+| **Fill the defect form** | Types a short title, fills in the description, reproduction steps, picks "Major" severity, leaves the safety hazard reference blank, and accepts the auto-detected environment string. | "It's basically asking me what happened and how to reproduce it. The environment is already filled in — nice." | Each required field reveals its inline help text above the input. The "Open GitHub to submit" button stays disabled until all required fields are filled. The "Advanced (optional)" disclosure conceals the rarely-needed hazard reference field. |
+| **Hand off to GitHub** | Clicks "Open GitHub to submit ↗". | "Let's see what happens." | A new browser tab opens at GitHub's "new issue" page. The bug template is preselected. Title and all body fields are prefilled with what the pilot entered, under per-field headings. The pilot ticks the two GitHub confirmation checkboxes ("checked the backlog", "this is not a security report") and clicks **Submit**. |
+| **Return to category — feature (later session)** | Returns to `/contribute`, hovers the tooltip on "Request a feature", clicks the button. | "Wind correction on the runway diagram would be useful." | The guided feature form replaces the category buttons. The DoD field pre-fills with "- [ ] " so the pilot just continues typing. |
+| **Pick category — security (third session)** | Clicks "Report a security vulnerability". Reads the explanation. | "This shouldn't be public — good that the app says so." | The view replaces the category grid with a single card explaining that security reports are private, with a primary button "Open the private security form on GitHub ↗". No in-app input fields are shown. The pilot clicks the button and a new tab opens at GitHub's private advisory form. |
+| **See contribution promotion** | Notices the "How else can you help?" panel below the buttons. | "Oh — I can also just report what worked badly, or fix a typo in the docs. That sounds doable." | The panel lists four ways to contribute and links to the public issue list and the GitHub repository, each opening in a new tab. |
+
+**Outcome:** The pilot reports the defect with the existing GitHub bug template, prefilled and ready to submit. The feature suggestion lands in the correct GitHub template too. The suspected vulnerability goes through GitHub's private advisory workflow and never touches the public issue tracker. None of the three reports required learning a new format — the app translated plain-language prompts into the structured GitHub fields on handoff.

--- a/docs/requirements/system.md
+++ b/docs/requirements/system.md
@@ -155,6 +155,36 @@ This document defines the system behavior using the **EARS** (Easy Approach to R
 **Status:** Implemented
 **Design Reference:** [Data-Rights Design](../architecture/data-rights.md)
 
+<!-- @REQ-SYS-016@ -->
+
+### REQ-SYS-016: In-App Contribution Intake — Three-Channel Entry
+
+**Requirement:** The system shall expose an in-app contribution surface that lets the user pick one of exactly three intake channels — *defect report*, *feature request*, or *security vulnerability report* — and shall present each channel with a one-sentence plain-language description plus an info tooltip explaining when to use that channel.
+**Rationale:** AeroDash's target user is a non-developer pilot. Without an in-app intake, defects and improvement ideas observed in real flight prep do not reach the regression suite. Funnelling the user through one of three first-class channels (mirroring the existing GitHub intake structure) keeps reports correctly classified at the source.
+**Priority:** P3
+**Status:** Implemented
+**Design Reference:** [Contribution Hub Design](../ux/contribution.md), [ADR-012](../architecture/adr/012-in-app-contribution-intake.md)
+
+<!-- @REQ-SYS-017@ -->
+
+### REQ-SYS-017: Prefilled GitHub Issue Handoff for Defects and Feature Requests
+
+**Requirement:** When the user submits the in-app defect or feature form, the system shall open the corresponding GitHub "new issue" page in a new browser tab with the matching GitHub issue template preselected and every entered field prefilled into the GitHub form's title and body. The system shall not store or persist the entered values after the GitHub tab is opened, and shall not transmit the values anywhere other than the GitHub URL the user has explicitly chosen to open.
+**Rationale:** Reuses the existing `bug_report.yml` and `feature_request.yml` templates as the single source of truth for what an issue needs to contain. The user still confirms the submission on GitHub, preserving their authority over the final report; the app does not act as a submission relay.
+**Priority:** P3
+**Status:** Implemented
+**Design Reference:** [Contribution Hub Design](../ux/contribution.md), [ADR-012](../architecture/adr/012-in-app-contribution-intake.md)
+
+<!-- @REQ-SYS-018@ -->
+
+### REQ-SYS-018: Security Advisory Link-Only Handoff
+
+**Requirement:** When the user selects the security vulnerability channel, the system shall display a short explanation that security reports are handled privately on GitHub and shall provide a button that opens the repository's private security advisory creation form in a new browser tab. The system shall not collect security-report content in any in-app field.
+**Rationale:** GitHub's security-advisory creation form does not accept URL pre-fill; any in-app field collection would discard the user's input on handoff. Routing the user directly to GitHub's private workflow also keeps sensitive vulnerability detail off the public issue tracker and out of any AeroDash storage.
+**Priority:** P3
+**Status:** Implemented
+**Design Reference:** [Contribution Hub Design](../ux/contribution.md), [ADR-012](../architecture/adr/012-in-app-contribution-intake.md)
+
 ---
 
 ## Design References

--- a/docs/ux/contribution.md
+++ b/docs/ux/contribution.md
@@ -1,0 +1,273 @@
+# AeroDash Contribution Hub — UX & Handoff Design
+
+This document specifies the in-app contribution hub: how a pilot reaches the
+intake surface, what they see at each step, what fields they fill in, and
+how the app hands the result off to GitHub. The decision for the chosen
+handoff style is recorded in [`ADR-012`](../architecture/adr/012-in-app-contribution-intake.md).
+
+See also: [`docs/requirements/system.md`](../requirements/system.md) for
+`REQ-SYS-016 / 017 / 018`, and
+[`docs/journeys/04_system_usability.md`](../journeys/04_system_usability.md)
+for `UJ-D-NNN` journeys covered.
+
+---
+
+## 1. Entry Points
+
+<!-- @DES-UX-013@ (FROM: @REQ-SYS-016@) -->
+
+The contribution hub is reachable from three locations:
+
+| Location | Element | Label | Visibility |
+| --- | --- | --- | --- |
+| `App.vue` sidebar footer (above the version) | `<RouterLink to="/contribute">` | "Help / contribute" + speech-bubble icon | Always; hidden when sidebar collapsed (icon-only) |
+| `HomeView.vue` bottom of page | `<RouterLink to="/contribute">` inside a "Help improve AeroDash" panel | "Open contribution hub →" | Always when route `/` is rendered |
+| `PrivacyView.vue` end of page (below the wipe card) | `<RouterLink to="/contribute">` plain link | "Report a problem or suggest an improvement →" | Always when route `/privacy` is rendered |
+
+The hub itself is a single route `/contribute` rendering
+`ContributeView.vue`. No deep links are used; the category selection
+lives in component state.
+
+---
+
+## 2. Category Intake (Three-Button Entry)
+
+<!-- @DES-UX-014@ (FROM: @REQ-SYS-016@) -->
+
+On first paint the hub shows a heading, one explanatory paragraph, and
+three large buttons stacked vertically (mobile) or in a 3-column grid
+(≥768 px). The buttons sit above the contribution-promotion section
+(§5).
+
+Each button has: icon, label, one-sentence plain-language description,
+and an info tooltip (icon `(i)` with `aria-describedby`).
+
+| ID | Label | One-sentence description | Tooltip body |
+| --- | --- | --- | --- |
+| `defect` | "Report a defect" | "Something doesn't work the way it should." | "Use this when AeroDash shows a wrong number, a button does nothing, the app crashes, or something looks broken. We use these reports to fix problems." |
+| `feature` | "Request a feature" | "Suggest something new or an improvement." | "Use this when you have an idea for something AeroDash could do but currently doesn't — a new calculation, a new layout, support for a new aircraft, an extra option." |
+| `security` | "Report a security vulnerability" | "You've found a way the app could be abused." | "Use this when you think someone could misuse AeroDash to harm a pilot, steal data, or bypass a safety check. Security reports are handled privately on GitHub — they are not visible in the public issue list." |
+
+Selecting `defect` or `feature` transitions to the guided form (§3 /
+§4). Selecting `security` reveals the security card (§5) instead. The
+user can step back to the category screen from any sub-screen via a
+"Back" button in the top-left of the active panel.
+
+---
+
+## 3. Defect Guided Form
+
+<!-- @DES-UX-015@ (FROM: @REQ-SYS-017@) -->
+
+The form is a single scrollable column with four field groups followed
+by the submit row. It maps 1:1 to the existing
+[`bug_report.yml`](../../.github/ISSUE_TEMPLATE/bug_report.yml) template;
+no field is invented. Fields and the GitHub template ID they target:
+
+| Step | Field | GitHub template ID | Type | Required | Help text shown above the field |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Title | (URL `title=`) | single-line text | yes | "A short summary — what went wrong, in one line." |
+| 2 | Bug Description | `description` | multi-line text (4 rows) | yes | "What happened? Be as detailed as you can." Placeholder: "When calculating x, the moment arm was y." |
+| 3 | Steps to Reproduce | `reproduction` | multi-line text (5 rows) | yes | "How can someone else make the same thing happen?" Placeholder mirrors the GitHub template's numbered list. |
+| 4 | Severity & safety relevance | `severity` | dropdown | yes | "How badly did this affect you?" Options copied verbatim from the GitHub template. |
+| 5 | Safety hazard reference | `hazard_ref` | single-line text | no | "Skip if unsure — leave blank." Hidden behind an "Advanced (optional)" disclosure. |
+| 6 | Environment | `environment` | multi-line text (3 rows) | yes | "Browser, OS, device. We auto-fill what we can detect; please add anything missing." Initial value: a string built by `buildEnvironmentLine()` (P3 helper) from `navigator.userAgent` + viewport width × height + `theme`. |
+
+The two confirmation checkboxes from the GitHub template ("I have
+checked if this issue has already been reported." / "I confirm this is
+NOT a security vulnerability report.") are **not** rendered in the app.
+The user cannot truthfully attest to a backlog search from the app
+itself, and the security-vs-bug split is already handled by the
+category screen (§2). Both confirmations remain visible on the GitHub
+side after handoff; the user ticks them there.
+
+The submit row contains, left-to-right: "Back" (returns to §2),
+"Open GitHub to submit ↗" (primary). The primary button is disabled
+when any required field is empty, when the title exceeds 200 chars
+(GitHub URL limit guard, see §7), or when `navigator.onLine === false`
+(an inline note explains "You need a connection to open GitHub — try
+again when online.").
+
+---
+
+## 4. Feature Guided Form
+
+<!-- @DES-UX-016@ (FROM: @REQ-SYS-017@) -->
+
+Same layout pattern as §3. Maps 1:1 to
+[`feature_request.yml`](../../.github/ISSUE_TEMPLATE/feature_request.yml):
+
+| Step | Field | GitHub template ID | Type | Required | Help text shown above the field |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Title | (URL `title=`) | single-line text | yes | "A short summary of the idea, in one line." |
+| 2 | Problem statement / use case | `problem` | multi-line text (4 rows) | yes | "What are you trying to do? Try the form: 'As a pilot, I want to … so that …'." |
+| 3 | Proposed solution | `solution` | multi-line text (4 rows) | yes | "How could AeroDash help? Describe your ideal version." |
+| 4 | Related requirement (advanced) | `req_id` | single-line text | no | "Skip if unsure. Format: REQ-SYS-XXX." Hidden behind "Advanced (optional)" disclosure. |
+| 5 | Potential safety impact | `safety_impact` | multi-line text (3 rows) | no | "Could this feature affect a Go/No-Go decision? Skip if you don't know." |
+| 6 | Definition of Done / checklist | `dod` | multi-line text (4 rows) | yes | "What would need to be done for this to be 'finished'? A short checklist is fine." Pre-fills with `"- [ ] "` so the user only types. |
+
+Confirmation checkboxes are again not rendered in the app for the same
+reason as §3.
+
+---
+
+## 5. Security Advisory Card
+
+<!-- @DES-UX-017@ (FROM: @REQ-SYS-018@) -->
+
+Selecting `security` (§2) reveals a single card with no form fields. The
+card contains:
+
+1. A short paragraph: "Security reports are private. They go to a
+   form on GitHub that only the maintainers can read — they are not
+   visible in the public issue list."
+2. A one-line bullet list of what *not* to put in a public bug report:
+   "Don't post exploit details in a normal bug report; use this path
+   instead."
+3. A primary button "Open the private security form on GitHub ↗" with
+   `rel="noopener noreferrer"` and `target="_blank"`, opening
+   `https://github.com/naturelle137/AeroDash/security/advisories/new`.
+4. A "Back" button returning to §2.
+
+There is no in-app field collection — see ADR-012 for the rationale. The
+button is enabled regardless of connectivity (the new tab will fail to
+load offline, but blocking would hide the link entirely from a pilot
+who needs the URL for later).
+
+---
+
+## 6. Contribution Promotion Section
+
+<!-- @DES-UX-018@ (FROM: @REQ-SYS-016@) -->
+
+Below the category buttons (§2), permanently visible, sits a
+non-modal panel titled "How else can you help?" containing:
+
+- A one-paragraph statement: "AeroDash is built in the open. Contribution
+  isn't only writing code — telling us what didn't work, suggesting what
+  could work better, improving the wording in the manual, or sharing a
+  real-world flight-prep edge case all directly improve the next
+  version."
+- A 4-row bullet list: "Report a defect you noticed", "Suggest a
+  feature", "Improve the documentation", "Share a real-world edge
+  case in a discussion".
+- A row of two link-style buttons: "Browse open issues ↗"
+  (`https://github.com/naturelle137/AeroDash/issues`) and "Open the
+  GitHub repository ↗"
+  (`https://github.com/naturelle137/AeroDash`). Both open in a new tab
+  with `rel="noopener noreferrer"`.
+
+The panel uses the standard `.card` surface (matches
+`PrivacyView.vue`), not a coloured callout — it is informational, not
+an alert.
+
+---
+
+## 7. P1 URL Builder — Public Contract
+
+<!-- @DES-ARCH-014@ (FROM: @REQ-SYS-017@) -->
+
+The mapping from in-app form state to a prefilled GitHub URL lives in a
+single pure-TypeScript module:
+
+```text
+frontend/src/core/logic/github-issue-url.ts
+```
+
+It exports two named functions:
+
+```ts
+buildBugReportUrl(input: BugReportInput): string
+buildFeatureRequestUrl(input: FeatureRequestInput): string
+```
+
+Both:
+
+- Always target `https://github.com/naturelle137/AeroDash/issues/new`.
+- Always include `template=bug_report.yml` or `template=feature_request.yml`
+  in the query string (this is how GitHub selects the form schema).
+- Pass the form title via `title=` (URL-encoded). All other fields are
+  prefilled using GitHub's structured-form syntax: one query parameter
+  per field, keyed by the **exact `id` of the matching GitHub template
+  field** (`description`, `reproduction`, `severity`, `hazard_ref`,
+  `environment` for bugs; `problem`, `solution`, `req_id`,
+  `safety_impact`, `dod` for features). For the `severity` dropdown the
+  value is the **exact option label** from
+  [`bug_report.yml`](../../.github/ISSUE_TEMPLATE/bug_report.yml) (e.g.
+  `"Major: Core functionality impaired, no workaround"`), URL-encoded.
+- Empty optional fields are omitted from the query string entirely (no
+  empty `&foo=` segments).
+- Compute the final URL length up-front. If `length > 7500` (GitHub's
+  practical limit; documented in the source file), the builder trims
+  the longest text field by removing characters from the tail and
+  replacing them with a literal trailing marker
+  `… (truncated)`. If after trimming all text fields the URL still
+  exceeds 7500 chars, the builder falls back to title-only (only
+  `title=` + `template=`, all other fields dropped). Both fallback
+  paths are independently unit-testable.
+
+`BugReportInput` and `FeatureRequestInput` are exported types whose
+property names match the GitHub field IDs in §3 and §4 (`description`,
+`reproduction`, `severity`, `hazard_ref`, `environment` for bugs;
+`problem`, `solution`, `req_id`, `safety_impact`, `dod` for features),
+plus `title: string`. Optional fields are typed `string | undefined`;
+required fields are typed `string` and must be non-empty (the builder
+throws `Error("github-issue-url: required field …")` if a required
+field is empty, since the form layer already gates on this and reaching
+the builder with an empty required field is a bug).
+
+The builder is P1: it imports only from other `src/core/` modules and
+the standard library. It does not import `vue`, `pinia`, or anything
+under `src/modules/ src/shared/ src/stores/`.
+
+---
+
+## 8. State, Accessibility, and Layout Behaviour
+
+<!-- @DES-UX-019@ (FROM: @REQ-SYS-016@) -->
+
+- The `/contribute` view uses the standard
+  [Interaction State Taxonomy](design_system.md#2-interaction-state-taxonomy)
+  states `INITIAL` (no category chosen) and `UNCONFIGURED` (required
+  fields not yet filled). It never enters `VERIFIED_SAFE`,
+  `WARNING`, or `ERROR_CRITICAL` — no safety math runs here.
+- The category buttons (§2) have `role="button"`, a 44 × 44 px
+  minimum touch target, and visible focus ring per
+  [`design_system.md §3`](design_system.md#3-accessibility-a11y-standards).
+- Tooltips use `aria-describedby` pointing at a visually-hidden
+  `<span>` containing the full tooltip body, so screen readers
+  receive the long explanation even though only the `(i)` icon is
+  rendered.
+- Each form field has an associated `<label>`, an inline `aria-describedby`
+  to its help text, and `aria-required="true"` when required.
+- The "Open GitHub to submit ↗" primary button announces its target
+  via the trailing `↗` glyph and an `aria-label` suffix "(opens
+  github.com in a new tab)".
+- Layout follows
+  [`design_system.md §1.2`](design_system.md#12-layout-responsiveness):
+  single column ≤ 768 px, 3-column grid for §2 buttons ≥ 768 px, the
+  guided forms remain single column at all widths to preserve linear
+  reading order.
+- The view fits inside the standard `App.vue` shell — no full-screen
+  takeover, no modal backdrop.
+
+---
+
+## 9. Out of Scope
+
+<!-- @DES-UX-020@ (FROM: @REQ-SYS-016@) -->
+
+- Offline drafting and persistence of contribution drafts (no IndexedDB
+  store, no Pinia persistence). A draft is component-local state only
+  and is discarded on navigation away from `/contribute`.
+- Free-text redaction (no P1 redactor). The user reviews and edits the
+  prefilled content on the GitHub side before submission.
+- New issue templates. Both `bug_report.yml` and `feature_request.yml`
+  remain unchanged; no `incident_report.yml` or any fourth template is
+  introduced.
+- In-app authentication, token storage, or background issue submission.
+  The flow is "prefill and confirm on GitHub" for bug / feature, and
+  "link-only" for security — see [`ADR-012`](../architecture/adr/012-in-app-contribution-intake.md).
+- Live status of submitted issues. The app does not poll GitHub for
+  responses; the pilot tracks responses in GitHub itself or via the
+  notification settings on their GitHub account.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -238,8 +238,28 @@ const themeLabel = computed(() =>
         </li>
       </ul>
 
-      <!-- Sidebar footer: advisory + version -->
+      <!-- Sidebar footer: contribute link + advisory + version -->
       <div class="sidebar-footer">
+        <!-- @IMP-UI-SHARED-015@ (FROM: @REQ-SYS-016@, @DES-UX-013@) -->
+        <RouterLink
+          to="/contribute"
+          class="sidebar-contribute"
+          title="Help / contribute"
+          aria-label="Open the contribution hub"
+          data-testid="sidebar-contribute-link"
+        >
+          <span class="sidebar-contribute__icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+              <path
+                d="M4 5h12a2 2 0 012 2v6a2 2 0 01-2 2h-6l-4 3v-3H4a2 2 0 01-2-2V7a2 2 0 012-2z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="sidebar-contribute__label">Help / contribute</span>
+        </RouterLink>
         <p class="sidebar-footer__text">Advisory only. Verify against POH/AFM.</p>
         <AppVersion />
       </div>
@@ -622,7 +642,8 @@ const themeLabel = computed(() =>
 /* Collapsed sidebar: hide labels + badges */
 .sidebar--collapsed .sidebar-nav__label,
 .sidebar--collapsed .soon-badge,
-.sidebar--collapsed .sidebar-footer__text {
+.sidebar--collapsed .sidebar-footer__text,
+.sidebar--collapsed .sidebar-contribute__label {
   display: none;
 }
 
@@ -631,6 +652,9 @@ const themeLabel = computed(() =>
 .sidebar-footer {
   padding: var(--space-4) var(--space-3);
   border-top: 1px solid var(--color-divider);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
 .sidebar-footer__text {
@@ -638,6 +662,45 @@ const themeLabel = computed(() =>
   color: var(--color-text-secondary);
   margin: 0;
   line-height: 1.4;
+}
+
+.sidebar-contribute {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  min-height: 36px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.sidebar-contribute:hover,
+.sidebar-contribute:focus-visible {
+  background: var(--color-surface-hover);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.sidebar-contribute:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.sidebar-contribute__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+.sidebar-contribute__label {
+  flex: 1;
 }
 
 /* ─── Main content ────────────────────────────────────────────────────────── */

--- a/frontend/src/core/logic/github-issue-url.spec.ts
+++ b/frontend/src/core/logic/github-issue-url.spec.ts
@@ -92,7 +92,7 @@ describe('buildBugReportUrl', () => {
     const q = parseQuery(url)
     expect(q.get('template')).toBe(BUG_REPORT_TEMPLATE)
     expect(q.get('title')).toBe(validBug.title)
-    expect(q.get('description') ?? '').toMatch(/… \(truncated\)$/)
+    expect(q.get('description') ?? '').toMatch(/\.\.\. \(truncated\)$/)
   })
 
   it('falls back to title-only when no body field can fit alongside an oversize title', () => {

--- a/frontend/src/core/logic/github-issue-url.spec.ts
+++ b/frontend/src/core/logic/github-issue-url.spec.ts
@@ -1,0 +1,179 @@
+// @UT-SYS-CORE-102@ (FROM: @IMP-SYS-CORE-013@)
+import { describe, it, expect } from 'vitest'
+import {
+  buildBugReportUrl,
+  buildFeatureRequestUrl,
+  BUG_REPORT_TEMPLATE,
+  FEATURE_REQUEST_TEMPLATE,
+  GITHUB_NEW_ISSUE_URL,
+  GITHUB_SECURITY_ADVISORY_URL,
+  GITHUB_REPO_URL,
+  GITHUB_ISSUES_URL,
+  BUG_SEVERITY_VALUES,
+  type BugReportInput,
+  type FeatureRequestInput,
+} from './github-issue-url'
+
+function parseQuery(url: string): URLSearchParams {
+  const q = url.split('?')[1] ?? ''
+  return new URLSearchParams(q)
+}
+
+const validBug: BugReportInput = {
+  title: 'CG indicator stays green after MTOM breach',
+  description: 'After loading 4 PAX the indicator stays green even though the total mass is above MTOM.',
+  reproduction:
+    '1. Open Mass & Balance.\n2. Pick the C172 test profile.\n3. Set front row to 90 kg each.\n4. Set rear row to 90 kg each.\n5. Add full fuel.',
+  severity: 'CRITICAL: Incorrect calculations/data (Safety Hazard!)',
+  environment: 'iPad Air, Safari 17, iPadOS 17.4',
+}
+
+const validFeature: FeatureRequestInput = {
+  title: 'Wind correction on runway diagram',
+  problem: 'As a pilot, I want to see crosswind on the runway diagram so that I can pick a runway visually.',
+  solution: 'Render a wind arrow overlay on the runway diagram, scaled by speed.',
+  dod: '- [ ] Arrow renders when wind is known\n- [ ] Arrow hidden when wind unknown',
+}
+
+describe('buildBugReportUrl', () => {
+  it('builds a URL that targets the bug_report template at the new-issue endpoint', () => {
+    const url = buildBugReportUrl(validBug)
+    expect(url.startsWith(`${GITHUB_NEW_ISSUE_URL}?`)).toBe(true)
+    const q = parseQuery(url)
+    expect(q.get('template')).toBe(BUG_REPORT_TEMPLATE)
+  })
+
+  it('prefills title and every required text field under its GitHub template id', () => {
+    const url = buildBugReportUrl(validBug)
+    const q = parseQuery(url)
+    expect(q.get('title')).toBe(validBug.title)
+    expect(q.get('description')).toBe(validBug.description)
+    expect(q.get('reproduction')).toBe(validBug.reproduction)
+    expect(q.get('severity')).toBe(validBug.severity)
+    expect(q.get('environment')).toBe(validBug.environment)
+  })
+
+  it('omits hazard_ref when absent or empty', () => {
+    const url = buildBugReportUrl(validBug)
+    expect(parseQuery(url).has('hazard_ref')).toBe(false)
+
+    const withBlank = buildBugReportUrl({ ...validBug, hazard_ref: '   ' })
+    expect(parseQuery(withBlank).has('hazard_ref')).toBe(false)
+  })
+
+  it('includes hazard_ref when provided non-empty', () => {
+    const url = buildBugReportUrl({ ...validBug, hazard_ref: 'H-014' })
+    expect(parseQuery(url).get('hazard_ref')).toBe('H-014')
+  })
+
+  it.each(BUG_SEVERITY_VALUES.map((v) => [v]))(
+    'accepts the exact severity option label %s',
+    (severity) => {
+      const url = buildBugReportUrl({ ...validBug, severity })
+      expect(parseQuery(url).get('severity')).toBe(severity)
+    },
+  )
+
+  it.each([
+    ['title', { ...validBug, title: '' }],
+    ['title (whitespace)', { ...validBug, title: '   ' }],
+    ['description', { ...validBug, description: '' }],
+    ['reproduction', { ...validBug, reproduction: '' }],
+    ['severity', { ...validBug, severity: '' as unknown as BugReportInput['severity'] }],
+    ['environment', { ...validBug, environment: '' }],
+  ])('throws when required field %s is empty', (_label, input) => {
+    expect(() => buildBugReportUrl(input)).toThrow(/required field/)
+  })
+
+  it('truncates the longest field with a marker when the URL exceeds the GitHub limit', () => {
+    const huge = 'A'.repeat(12000)
+    const url = buildBugReportUrl({ ...validBug, description: huge })
+    expect(url.length).toBeLessThanOrEqual(7500)
+    const q = parseQuery(url)
+    expect(q.get('template')).toBe(BUG_REPORT_TEMPLATE)
+    expect(q.get('title')).toBe(validBug.title)
+    expect(q.get('description') ?? '').toMatch(/… \(truncated\)$/)
+  })
+
+  it('falls back to title-only when no body field can fit alongside an oversize title', () => {
+    // The trim loop strips body fields one at a time. When the title alone
+    // already pushes the URL over the GitHub limit, even after every body
+    // field has been shrunk or dropped the URL is still over budget — the
+    // loop then exits via the title-only fallback (only template + title
+    // survive). The fallback URL may itself exceed the limit (best-effort
+    // hand-off — the form layer is supposed to cap title length upstream),
+    // so we don't assert URL length here; the contract under test is "no
+    // body-field query params on this code path".
+    const monsterTitle = 'A'.repeat(7600)
+    const url = buildBugReportUrl({ ...validBug, title: monsterTitle })
+    const q = parseQuery(url)
+    expect(q.get('template')).toBe(BUG_REPORT_TEMPLATE)
+    expect(q.get('title')).toBe(monsterTitle)
+    expect(q.has('description')).toBe(false)
+    expect(q.has('reproduction')).toBe(false)
+    expect(q.has('severity')).toBe(false)
+    expect(q.has('environment')).toBe(false)
+    expect(q.has('hazard_ref')).toBe(false)
+  })
+})
+
+describe('buildFeatureRequestUrl', () => {
+  it('targets the feature_request template at the new-issue endpoint', () => {
+    const url = buildFeatureRequestUrl(validFeature)
+    expect(url.startsWith(`${GITHUB_NEW_ISSUE_URL}?`)).toBe(true)
+    expect(parseQuery(url).get('template')).toBe(FEATURE_REQUEST_TEMPLATE)
+  })
+
+  it('prefills title and every required field under its GitHub template id', () => {
+    const url = buildFeatureRequestUrl(validFeature)
+    const q = parseQuery(url)
+    expect(q.get('title')).toBe(validFeature.title)
+    expect(q.get('problem')).toBe(validFeature.problem)
+    expect(q.get('solution')).toBe(validFeature.solution)
+    expect(q.get('dod')).toBe(validFeature.dod)
+  })
+
+  it('omits req_id and safety_impact when absent or empty', () => {
+    const url = buildFeatureRequestUrl(validFeature)
+    const q = parseQuery(url)
+    expect(q.has('req_id')).toBe(false)
+    expect(q.has('safety_impact')).toBe(false)
+  })
+
+  it('includes req_id and safety_impact when provided', () => {
+    const url = buildFeatureRequestUrl({
+      ...validFeature,
+      req_id: 'REQ-PF-001',
+      safety_impact: 'Could affect runway selection.',
+    })
+    const q = parseQuery(url)
+    expect(q.get('req_id')).toBe('REQ-PF-001')
+    expect(q.get('safety_impact')).toBe('Could affect runway selection.')
+  })
+
+  it.each([
+    ['title', { ...validFeature, title: '' }],
+    ['problem', { ...validFeature, problem: '' }],
+    ['solution', { ...validFeature, solution: '' }],
+    ['dod', { ...validFeature, dod: '' }],
+  ])('throws when required field %s is empty', (_label, input) => {
+    expect(() => buildFeatureRequestUrl(input)).toThrow(/required field/)
+  })
+
+  it('respects the URL length cap with a long DoD list', () => {
+    const long = '- [ ] item\n'.repeat(2000)
+    const url = buildFeatureRequestUrl({ ...validFeature, dod: long })
+    expect(url.length).toBeLessThanOrEqual(7500)
+    expect(parseQuery(url).get('template')).toBe(FEATURE_REQUEST_TEMPLATE)
+  })
+})
+
+describe('exported endpoints', () => {
+  it('points security advisories at the private advisory form on the repo', () => {
+    expect(GITHUB_SECURITY_ADVISORY_URL).toBe(`${GITHUB_REPO_URL}/security/advisories/new`)
+  })
+
+  it('points the public issue list at /issues', () => {
+    expect(GITHUB_ISSUES_URL).toBe(`${GITHUB_REPO_URL}/issues`)
+  })
+})

--- a/frontend/src/core/logic/github-issue-url.ts
+++ b/frontend/src/core/logic/github-issue-url.ts
@@ -1,0 +1,149 @@
+// @IMP-SYS-CORE-013@ (FROM: @REQ-SYS-017@, @REQ-SYS-018@, @DES-ARCH-014@)
+//
+// Pure P1 builder for prefilled GitHub "new issue" URLs that target the
+// existing bug_report.yml and feature_request.yml templates. Field IDs and
+// the severity dropdown labels MUST match
+// .github/ISSUE_TEMPLATE/bug_report.yml and feature_request.yml verbatim;
+// if a template is changed, the input types here must be updated in the
+// same commit or the prefill silently drops fields on the GitHub side.
+
+export const GITHUB_REPO_OWNER = 'naturelle137'
+export const GITHUB_REPO_NAME = 'AeroDash'
+export const GITHUB_REPO_URL = `https://github.com/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}`
+export const GITHUB_NEW_ISSUE_URL = `${GITHUB_REPO_URL}/issues/new`
+export const GITHUB_ISSUES_URL = `${GITHUB_REPO_URL}/issues`
+export const GITHUB_SECURITY_ADVISORY_URL = `${GITHUB_REPO_URL}/security/advisories/new`
+
+export const BUG_REPORT_TEMPLATE = 'bug_report.yml'
+export const FEATURE_REQUEST_TEMPLATE = 'feature_request.yml'
+
+export const BUG_SEVERITY_VALUES = [
+  'Minor: Cosmetic or minor workaround available',
+  'Major: Core functionality impaired, no workaround',
+  'CRITICAL: Incorrect calculations/data (Safety Hazard!)',
+  'Blocker: App does not start / Crash',
+] as const
+
+export type BugSeverity = (typeof BUG_SEVERITY_VALUES)[number]
+
+export interface BugReportInput {
+  title: string
+  description: string
+  reproduction: string
+  severity: BugSeverity
+  hazard_ref?: string
+  environment: string
+}
+
+export interface FeatureRequestInput {
+  title: string
+  problem: string
+  solution: string
+  req_id?: string
+  safety_impact?: string
+  dod: string
+}
+
+const GITHUB_URL_MAX_LEN = 7500
+const TRUNCATION_MARKER = '… (truncated)'
+
+interface TextField {
+  key: string
+  value: string
+}
+
+function requireField(name: string, value: string): void {
+  if (value.trim() === '') {
+    throw new Error(`github-issue-url: required field "${name}" is empty`)
+  }
+}
+
+function pushOptional(fields: TextField[], key: string, value: string | undefined): void {
+  if (value === undefined) return
+  const trimmed = value.trim()
+  if (trimmed === '') return
+  fields.push({ key, value: trimmed })
+}
+
+function buildUrl(template: string, title: string, textFields: readonly TextField[]): string {
+  const params = new URLSearchParams()
+  params.set('template', template)
+  params.set('title', title)
+  for (const f of textFields) {
+    params.set(f.key, f.value)
+  }
+  return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`
+}
+
+function titleOnlyFallback(template: string, title: string): string {
+  const params = new URLSearchParams()
+  params.set('template', template)
+  params.set('title', title)
+  return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`
+}
+
+function trimAndBuild(template: string, title: string, fields: TextField[]): string {
+  const working: TextField[] = fields.map((f) => ({ ...f }))
+
+  while (true) {
+    const url = buildUrl(template, title, working)
+    if (url.length <= GITHUB_URL_MAX_LEN) return url
+
+    let longestIdx = -1
+    let longestLen = TRUNCATION_MARKER.length
+    for (let i = 0; i < working.length; i++) {
+      const candidate = working[i]
+      if (candidate !== undefined && candidate.value.length > longestLen) {
+        longestIdx = i
+        longestLen = candidate.value.length
+      }
+    }
+    if (longestIdx === -1) break
+
+    const f = working[longestIdx]
+    if (f === undefined) break
+    const newLen = Math.floor(f.value.length * 0.8)
+    if (newLen <= TRUNCATION_MARKER.length) {
+      working.splice(longestIdx, 1)
+    } else {
+      f.value = `${f.value.slice(0, newLen - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`
+    }
+  }
+
+  return titleOnlyFallback(template, title)
+}
+
+export function buildBugReportUrl(input: BugReportInput): string {
+  requireField('title', input.title)
+  requireField('description', input.description)
+  requireField('reproduction', input.reproduction)
+  requireField('severity', input.severity)
+  requireField('environment', input.environment)
+
+  const fields: TextField[] = [
+    { key: 'description', value: input.description.trim() },
+    { key: 'reproduction', value: input.reproduction.trim() },
+    { key: 'severity', value: input.severity.trim() },
+    { key: 'environment', value: input.environment.trim() },
+  ]
+  pushOptional(fields, 'hazard_ref', input.hazard_ref)
+
+  return trimAndBuild(BUG_REPORT_TEMPLATE, input.title.trim(), fields)
+}
+
+export function buildFeatureRequestUrl(input: FeatureRequestInput): string {
+  requireField('title', input.title)
+  requireField('problem', input.problem)
+  requireField('solution', input.solution)
+  requireField('dod', input.dod)
+
+  const fields: TextField[] = [
+    { key: 'problem', value: input.problem.trim() },
+    { key: 'solution', value: input.solution.trim() },
+    { key: 'dod', value: input.dod.trim() },
+  ]
+  pushOptional(fields, 'req_id', input.req_id)
+  pushOptional(fields, 'safety_impact', input.safety_impact)
+
+  return trimAndBuild(FEATURE_REQUEST_TEMPLATE, input.title.trim(), fields)
+}

--- a/frontend/src/core/logic/github-issue-url.ts
+++ b/frontend/src/core/logic/github-issue-url.ts
@@ -45,7 +45,9 @@ export interface FeatureRequestInput {
 }
 
 const GITHUB_URL_MAX_LEN = 7500
-const TRUNCATION_MARKER = '… (truncated)'
+// ASCII marker so `.length` matches the percent-encoded URL cost — a non-ASCII
+// ellipsis (`…` → `%E2%80%A6`) would make the trim loop over-budget.
+const TRUNCATION_MARKER = '... (truncated)'
 
 interface TextField {
   key: string

--- a/frontend/src/modules/mass-balance/components/MassStationInput.vue
+++ b/frontend/src/modules/mass-balance/components/MassStationInput.vue
@@ -71,7 +71,7 @@ function clamp(value: number): number {
 }
 
 // ─── Sanitised decimal entry + inline rejection feedback (UX-010 / UX-011) ──
-// @IMP-MB-UI-009@ (FROM: @REQ-UQ-001@)
+// @IMP-MB-UI-010@ (FROM: @REQ-UQ-001@)
 //
 // The field is a DecimalInput (type=text + inputmode=decimal + regex sanitiser)
 // instead of type=number, so "e"/"+" can no longer slip through and be parsed

--- a/frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
+++ b/frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
@@ -365,7 +365,7 @@ describe('MassStationInput', () => {
 })
 
 // ─── UX-010 / UX-011: sanitised decimal entry + inline rejection feedback ───
-// @UT-MB-UI-003@ (FROM: @IMP-MB-UI-009@)
+// @UT-MB-UI-003@ (FROM: @IMP-MB-UI-010@)
 describe('MassStationInput — "e"/out-of-range rejection feedback', () => {
   it('never expands "1e2" to 100 — the "e" is rejected, so no such weight is emitted', async () => {
     const wrapper = mount(MassStationInput, {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -40,6 +40,12 @@ const router = createRouter({
       name: 'privacy',
       component: () => import('@/views/PrivacyView.vue'),
     },
+    // @IMP-UI-ROUTE-005@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@)
+    {
+      path: '/contribute',
+      name: 'contribute',
+      component: () => import('@/views/ContributeView.vue'),
+    },
   ],
 })
 

--- a/frontend/src/shared/components/ContributeBugForm.vue
+++ b/frontend/src/shared/components/ContributeBugForm.vue
@@ -27,9 +27,20 @@ const environment = ref('')
 const showAdvanced = ref(false)
 const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
 const submitting = ref(false)
+// Short grace period so a deliberate retry (e.g. after a blocked popup) is
+// possible while still swallowing the classic tablet double-tap.
+const SUBMIT_GUARD_MS = 1500
+let submitGuardTimer: ReturnType<typeof setTimeout> | null = null
 
 function updateOnline(): void {
   isOnline.value = navigator.onLine
+}
+
+function clearSubmitGuardTimer(): void {
+  if (submitGuardTimer !== null) {
+    clearTimeout(submitGuardTimer)
+    submitGuardTimer = null
+  }
 }
 
 onMounted(() => {
@@ -45,6 +56,7 @@ onBeforeUnmount(() => {
     window.removeEventListener('online', updateOnline)
     window.removeEventListener('offline', updateOnline)
   }
+  clearSubmitGuardTimer()
 })
 
 const titleTooLong = computed(() => title.value.trim().length > TITLE_MAX)
@@ -65,7 +77,15 @@ const canSubmit = computed(() => {
 function onSubmit(): void {
   if (!canSubmit.value || severity.value === '') return
   // Double-submit guard: prevents a double-tap from opening two GitHub tabs.
+  // Auto-resets after SUBMIT_GUARD_MS so a deliberate retry (e.g. popup
+  // blocked, pilot wants to amend and resend) is possible without forcing
+  // a destructive Back-and-restart cycle.
   submitting.value = true
+  clearSubmitGuardTimer()
+  submitGuardTimer = setTimeout(() => {
+    submitting.value = false
+    submitGuardTimer = null
+  }, SUBMIT_GUARD_MS)
   emit('submit', {
     title: title.value.trim(),
     description: description.value.trim(),

--- a/frontend/src/shared/components/ContributeBugForm.vue
+++ b/frontend/src/shared/components/ContributeBugForm.vue
@@ -1,0 +1,308 @@
+<script setup lang="ts">
+// @IMP-UI-SHARED-011@ (FROM: @REQ-SYS-017@, @DES-UX-015@)
+import { computed, onMounted, ref } from 'vue'
+import {
+  BUG_SEVERITY_VALUES,
+  type BugReportInput,
+  type BugSeverity,
+} from '@/core/logic/github-issue-url'
+import {
+  buildContributionEnvironment,
+  detectEnvironmentSources,
+} from '@/shared/utils/contribution-environment'
+
+const TITLE_MAX = 200
+
+const emit = defineEmits<{
+  back: []
+  submit: [input: BugReportInput]
+}>()
+
+const title = ref('')
+const description = ref('')
+const reproduction = ref('')
+const severity = ref<BugSeverity | ''>('')
+const hazardRef = ref('')
+const environment = ref('')
+const showAdvanced = ref(false)
+const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
+
+onMounted(() => {
+  environment.value = buildContributionEnvironment(detectEnvironmentSources())
+  if (typeof window !== 'undefined') {
+    window.addEventListener('online', updateOnline)
+    window.addEventListener('offline', updateOnline)
+  }
+})
+
+function updateOnline(): void {
+  isOnline.value = navigator.onLine
+}
+
+const titleTooLong = computed(() => title.value.trim().length > TITLE_MAX)
+
+const canSubmit = computed(() => {
+  return (
+    title.value.trim() !== '' &&
+    !titleTooLong.value &&
+    description.value.trim() !== '' &&
+    reproduction.value.trim() !== '' &&
+    severity.value !== '' &&
+    environment.value.trim() !== '' &&
+    isOnline.value
+  )
+})
+
+function onSubmit(): void {
+  if (!canSubmit.value || severity.value === '') return
+  emit('submit', {
+    title: title.value.trim(),
+    description: description.value.trim(),
+    reproduction: reproduction.value.trim(),
+    severity: severity.value,
+    environment: environment.value.trim(),
+    hazard_ref: hazardRef.value.trim() === '' ? undefined : hazardRef.value.trim(),
+  })
+}
+</script>
+
+<template>
+  <form class="contribute-form" data-testid="bug-form" @submit.prevent="onSubmit">
+    <p class="contribute-form__intro">
+      Tell us what happened. We'll move you to GitHub in the next step — you
+      can edit anything before submitting there.
+    </p>
+
+    <label class="field">
+      <span class="field__label">Title</span>
+      <span class="field__help">A short summary — what went wrong, in one line.</span>
+      <input
+        v-model="title"
+        type="text"
+        data-testid="bug-title"
+        :aria-required="true"
+        :aria-invalid="titleTooLong"
+        :maxlength="TITLE_MAX + 50"
+      />
+      <span v-if="titleTooLong" class="field__error" role="alert">
+        Title must be {{ TITLE_MAX }} characters or fewer.
+      </span>
+    </label>
+
+    <label class="field">
+      <span class="field__label">Bug description</span>
+      <span class="field__help">What happened? Be as detailed as you can.</span>
+      <textarea
+        v-model="description"
+        data-testid="bug-description"
+        rows="4"
+        :aria-required="true"
+        placeholder="When calculating x, the moment arm was y."
+      />
+    </label>
+
+    <label class="field">
+      <span class="field__label">Steps to reproduce</span>
+      <span class="field__help">How can someone else make the same thing happen?</span>
+      <textarea
+        v-model="reproduction"
+        data-testid="bug-reproduction"
+        rows="5"
+        :aria-required="true"
+        :placeholder="'1. Go to page ...\n2. Enter ...\n3. Select ...\n4. Click on ...'"
+      />
+    </label>
+
+    <label class="field">
+      <span class="field__label">Severity &amp; safety relevance</span>
+      <span class="field__help">How badly did this affect you?</span>
+      <select
+        v-model="severity"
+        data-testid="bug-severity"
+        :aria-required="true"
+      >
+        <option value="" disabled>Choose…</option>
+        <option v-for="s in BUG_SEVERITY_VALUES" :key="s" :value="s">{{ s }}</option>
+      </select>
+    </label>
+
+    <label class="field">
+      <span class="field__label">Environment</span>
+      <span class="field__help">
+        Browser, OS, device. We auto-fill what we can detect; please add anything missing.
+      </span>
+      <textarea
+        v-model="environment"
+        data-testid="bug-environment"
+        rows="3"
+        :aria-required="true"
+      />
+    </label>
+
+    <details class="field-disclosure" :open="showAdvanced" @toggle="(e) => (showAdvanced = (e.target as HTMLDetailsElement).open)">
+      <summary>Advanced (optional)</summary>
+      <label class="field">
+        <span class="field__label">Safety hazard reference</span>
+        <span class="field__help">Skip if unsure — leave blank. Format: H-XXX.</span>
+        <input
+          v-model="hazardRef"
+          type="text"
+          data-testid="bug-hazard-ref"
+          placeholder="H-XXX"
+        />
+      </label>
+    </details>
+
+    <p
+      v-if="!isOnline"
+      class="contribute-form__offline-note"
+      role="status"
+      data-testid="bug-offline-note"
+    >
+      You need a connection to open GitHub — try again when online.
+    </p>
+
+    <div class="contribute-form__actions">
+      <button
+        type="button"
+        class="btn"
+        data-testid="bug-back"
+        @click="emit('back')"
+      >
+        ← Back
+      </button>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        data-testid="bug-submit"
+        :disabled="!canSubmit"
+        :aria-label="canSubmit ? 'Open GitHub to submit (opens github.com in a new tab)' : 'Fill all required fields to enable submission'"
+      >
+        Open GitHub to submit ↗
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.contribute-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-surface-card, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+}
+
+.contribute-form__intro {
+  margin: 0;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field__help {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.field input,
+.field textarea,
+.field select {
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #111827);
+  font-family: inherit;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.field input:focus-visible,
+.field textarea:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid var(--color-focus, #3b82f6);
+  outline-offset: 1px;
+}
+
+.field__error {
+  color: var(--color-critical, #b91c1c);
+  font-size: 0.85rem;
+}
+
+.field-disclosure {
+  border: 1px dashed var(--color-border, #d1d5db);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}
+
+.field-disclosure summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.field-disclosure .field {
+  margin-top: 0.75rem;
+}
+
+.contribute-form__offline-note {
+  margin: 0;
+  padding: 0.6rem 0.8rem;
+  border-radius: 6px;
+  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning, #92400e);
+  border: 1px solid var(--color-warning, #f59e0b);
+  font-size: 0.9rem;
+}
+
+.contribute-form__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn {
+  min-height: 44px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #111827);
+  cursor: pointer;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #ffffff);
+}
+</style>

--- a/frontend/src/shared/components/ContributeBugForm.vue
+++ b/frontend/src/shared/components/ContributeBugForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // @IMP-UI-SHARED-011@ (FROM: @REQ-SYS-018@, @DES-UX-015@)
-import { computed, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   BUG_SEVERITY_VALUES,
   type BugReportInput,
@@ -26,6 +26,11 @@ const hazardRef = ref('')
 const environment = ref('')
 const showAdvanced = ref(false)
 const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
+const submitting = ref(false)
+
+function updateOnline(): void {
+  isOnline.value = navigator.onLine
+}
 
 onMounted(() => {
   environment.value = buildContributionEnvironment(detectEnvironmentSources())
@@ -35,14 +40,18 @@ onMounted(() => {
   }
 })
 
-function updateOnline(): void {
-  isOnline.value = navigator.onLine
-}
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('online', updateOnline)
+    window.removeEventListener('offline', updateOnline)
+  }
+})
 
 const titleTooLong = computed(() => title.value.trim().length > TITLE_MAX)
 
 const canSubmit = computed(() => {
   return (
+    !submitting.value &&
     title.value.trim() !== '' &&
     !titleTooLong.value &&
     description.value.trim() !== '' &&
@@ -55,6 +64,8 @@ const canSubmit = computed(() => {
 
 function onSubmit(): void {
   if (!canSubmit.value || severity.value === '') return
+  // Double-submit guard: prevents a double-tap from opening two GitHub tabs.
+  submitting.value = true
   emit('submit', {
     title: title.value.trim(),
     description: description.value.trim(),

--- a/frontend/src/shared/components/ContributeCategoryGrid.vue
+++ b/frontend/src/shared/components/ContributeCategoryGrid.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+// @IMP-UI-SHARED-010@ (FROM: @REQ-SYS-016@, @DES-UX-014@)
+type Category = 'defect' | 'feature' | 'security'
+
+interface CategoryDef {
+  id: Category
+  label: string
+  summary: string
+  tooltip: string
+}
+
+const categories: CategoryDef[] = [
+  {
+    id: 'defect',
+    label: 'Report a defect',
+    summary: "Something doesn't work the way it should.",
+    tooltip:
+      'Use this when AeroDash shows a wrong number, a button does nothing, the app crashes, or something looks broken. We use these reports to fix problems.',
+  },
+  {
+    id: 'feature',
+    label: 'Request a feature',
+    summary: 'Suggest something new or an improvement.',
+    tooltip:
+      "Use this when you have an idea for something AeroDash could do but currently doesn't — a new calculation, a new layout, support for a new aircraft, an extra option.",
+  },
+  {
+    id: 'security',
+    label: 'Report a security vulnerability',
+    summary: "You've found a way the app could be abused.",
+    tooltip:
+      'Use this when you think someone could misuse AeroDash to harm a pilot, steal data, or bypass a safety check. Security reports are handled privately on GitHub — they are not visible in the public issue list.',
+  },
+]
+
+const emit = defineEmits<{
+  pick: [category: Category]
+}>()
+</script>
+
+<template>
+  <ul class="category-grid" role="list" aria-label="Pick a contribution category">
+    <li v-for="cat in categories" :key="cat.id" class="category-grid__item">
+      <button
+        type="button"
+        class="category-card"
+        :class="`category-card--${cat.id}`"
+        :data-testid="`category-${cat.id}`"
+        :aria-describedby="`tooltip-${cat.id}`"
+        @click="emit('pick', cat.id)"
+      >
+        <span class="category-card__label">{{ cat.label }}</span>
+        <span class="category-card__summary">{{ cat.summary }}</span>
+        <span :id="`tooltip-${cat.id}`" class="visually-hidden">{{ cat.tooltip }}</span>
+      </button>
+      <p class="category-grid__tooltip" :aria-hidden="true">
+        <span class="info-glyph" aria-hidden="true">i</span>
+        <span>{{ cat.tooltip }}</span>
+      </p>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.category-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.category-grid__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.category-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 1rem 1.25rem;
+  min-height: 56px;
+  background: var(--color-surface-card, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+  text-align: left;
+  font-size: 1rem;
+  cursor: pointer;
+  color: inherit;
+  box-shadow: var(--shadow-sm);
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.category-card:hover {
+  border-color: var(--color-primary, #3b82f6);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.category-card:focus-visible {
+  outline: 2px solid var(--color-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.category-card__label {
+  font-weight: 600;
+  font-size: 1.0625rem;
+  color: var(--color-text-primary, #111827);
+}
+
+.category-card__summary {
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.category-card--security {
+  border-style: dashed;
+}
+
+.category-grid__tooltip {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0 0.25rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+  line-height: 1.4;
+}
+
+.info-glyph {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-primary-bg, #dbeafe);
+  color: var(--color-primary, #1d4ed8);
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-style: italic;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .category-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .category-grid__item {
+    height: 100%;
+  }
+  .category-card {
+    flex: 1;
+  }
+}
+</style>

--- a/frontend/src/shared/components/ContributeFeatureForm.vue
+++ b/frontend/src/shared/components/ContributeFeatureForm.vue
@@ -1,0 +1,302 @@
+<script setup lang="ts">
+// @IMP-UI-SHARED-012@ (FROM: @REQ-SYS-017@, @DES-UX-016@)
+import { computed, onMounted, ref } from 'vue'
+import type { FeatureRequestInput } from '@/core/logic/github-issue-url'
+
+const TITLE_MAX = 200
+const DOD_SEED = '- [ ] '
+
+const emit = defineEmits<{
+  back: []
+  submit: [input: FeatureRequestInput]
+}>()
+
+const title = ref('')
+const problem = ref('')
+const solution = ref('')
+const reqId = ref('')
+const safetyImpact = ref('')
+const dod = ref('')
+const showAdvanced = ref(false)
+const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
+
+onMounted(() => {
+  if (dod.value === '') dod.value = DOD_SEED
+  if (typeof window !== 'undefined') {
+    window.addEventListener('online', updateOnline)
+    window.addEventListener('offline', updateOnline)
+  }
+})
+
+function updateOnline(): void {
+  isOnline.value = navigator.onLine
+}
+
+const titleTooLong = computed(() => title.value.trim().length > TITLE_MAX)
+
+const canSubmit = computed(() => {
+  return (
+    title.value.trim() !== '' &&
+    !titleTooLong.value &&
+    problem.value.trim() !== '' &&
+    solution.value.trim() !== '' &&
+    dod.value.trim() !== '' &&
+    dod.value.trim() !== DOD_SEED.trim() &&
+    isOnline.value
+  )
+})
+
+function onSubmit(): void {
+  if (!canSubmit.value) return
+  emit('submit', {
+    title: title.value.trim(),
+    problem: problem.value.trim(),
+    solution: solution.value.trim(),
+    dod: dod.value.trim(),
+    req_id: reqId.value.trim() === '' ? undefined : reqId.value.trim(),
+    safety_impact: safetyImpact.value.trim() === '' ? undefined : safetyImpact.value.trim(),
+  })
+}
+</script>
+
+<template>
+  <form class="contribute-form" data-testid="feature-form" @submit.prevent="onSubmit">
+    <p class="contribute-form__intro">
+      Tell us your idea. We'll move you to GitHub in the next step — you can
+      edit anything before submitting there.
+    </p>
+
+    <label class="field">
+      <span class="field__label">Title</span>
+      <span class="field__help">A short summary of the idea, in one line.</span>
+      <input
+        v-model="title"
+        type="text"
+        data-testid="feature-title"
+        :aria-required="true"
+        :aria-invalid="titleTooLong"
+        :maxlength="TITLE_MAX + 50"
+      />
+      <span v-if="titleTooLong" class="field__error" role="alert">
+        Title must be {{ TITLE_MAX }} characters or fewer.
+      </span>
+    </label>
+
+    <label class="field">
+      <span class="field__label">Problem statement / use case</span>
+      <span class="field__help">
+        What are you trying to do? Try the form: "As a pilot, I want to … so that …".
+      </span>
+      <textarea
+        v-model="problem"
+        data-testid="feature-problem"
+        rows="4"
+        :aria-required="true"
+        placeholder="As a pilot, I want to ... so that ..."
+      />
+    </label>
+
+    <label class="field">
+      <span class="field__label">Proposed solution</span>
+      <span class="field__help">How could AeroDash help? Describe your ideal version.</span>
+      <textarea
+        v-model="solution"
+        data-testid="feature-solution"
+        rows="4"
+        :aria-required="true"
+      />
+    </label>
+
+    <label class="field">
+      <span class="field__label">Definition of Done / checklist</span>
+      <span class="field__help">
+        What would need to be done for this to be "finished"? A short checklist is fine.
+      </span>
+      <textarea
+        v-model="dod"
+        data-testid="feature-dod"
+        rows="4"
+        :aria-required="true"
+      />
+    </label>
+
+    <details
+      class="field-disclosure"
+      :open="showAdvanced"
+      @toggle="(e) => (showAdvanced = (e.target as HTMLDetailsElement).open)"
+    >
+      <summary>Advanced (optional)</summary>
+      <label class="field">
+        <span class="field__label">Related requirement</span>
+        <span class="field__help">Skip if unsure. Format: REQ-SYS-XXX.</span>
+        <input
+          v-model="reqId"
+          type="text"
+          data-testid="feature-req-id"
+          placeholder="REQ-SYS-XXX"
+        />
+      </label>
+      <label class="field">
+        <span class="field__label">Potential safety impact</span>
+        <span class="field__help">
+          Could this feature affect a Go/No-Go decision? Skip if you don't know.
+        </span>
+        <textarea
+          v-model="safetyImpact"
+          data-testid="feature-safety-impact"
+          rows="3"
+        />
+      </label>
+    </details>
+
+    <p
+      v-if="!isOnline"
+      class="contribute-form__offline-note"
+      role="status"
+      data-testid="feature-offline-note"
+    >
+      You need a connection to open GitHub — try again when online.
+    </p>
+
+    <div class="contribute-form__actions">
+      <button
+        type="button"
+        class="btn"
+        data-testid="feature-back"
+        @click="emit('back')"
+      >
+        ← Back
+      </button>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        data-testid="feature-submit"
+        :disabled="!canSubmit"
+        :aria-label="canSubmit ? 'Open GitHub to submit (opens github.com in a new tab)' : 'Fill all required fields to enable submission'"
+      >
+        Open GitHub to submit ↗
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.contribute-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-surface-card, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+}
+
+.contribute-form__intro {
+  margin: 0;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field__help {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.field input,
+.field textarea {
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #111827);
+  font-family: inherit;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.field input:focus-visible,
+.field textarea:focus-visible {
+  outline: 2px solid var(--color-focus, #3b82f6);
+  outline-offset: 1px;
+}
+
+.field__error {
+  color: var(--color-critical, #b91c1c);
+  font-size: 0.85rem;
+}
+
+.field-disclosure {
+  border: 1px dashed var(--color-border, #d1d5db);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}
+
+.field-disclosure summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary, #4b5563);
+}
+
+.field-disclosure .field {
+  margin-top: 0.75rem;
+}
+
+.contribute-form__offline-note {
+  margin: 0;
+  padding: 0.6rem 0.8rem;
+  border-radius: 6px;
+  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning, #92400e);
+  border: 1px solid var(--color-warning, #f59e0b);
+  font-size: 0.9rem;
+}
+
+.contribute-form__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn {
+  min-height: 44px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #111827);
+  cursor: pointer;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #ffffff);
+}
+</style>

--- a/frontend/src/shared/components/ContributeFeatureForm.vue
+++ b/frontend/src/shared/components/ContributeFeatureForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // @IMP-UI-SHARED-012@ (FROM: @REQ-SYS-018@, @DES-UX-016@)
-import { computed, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import type { FeatureRequestInput } from '@/core/logic/github-issue-url'
 
 const TITLE_MAX = 200
@@ -19,6 +19,11 @@ const safetyImpact = ref('')
 const dod = ref('')
 const showAdvanced = ref(false)
 const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
+const submitting = ref(false)
+
+function updateOnline(): void {
+  isOnline.value = navigator.onLine
+}
 
 onMounted(() => {
   if (dod.value === '') dod.value = DOD_SEED
@@ -28,14 +33,18 @@ onMounted(() => {
   }
 })
 
-function updateOnline(): void {
-  isOnline.value = navigator.onLine
-}
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('online', updateOnline)
+    window.removeEventListener('offline', updateOnline)
+  }
+})
 
 const titleTooLong = computed(() => title.value.trim().length > TITLE_MAX)
 
 const canSubmit = computed(() => {
   return (
+    !submitting.value &&
     title.value.trim() !== '' &&
     !titleTooLong.value &&
     problem.value.trim() !== '' &&
@@ -48,6 +57,8 @@ const canSubmit = computed(() => {
 
 function onSubmit(): void {
   if (!canSubmit.value) return
+  // Double-submit guard: prevents a double-tap from opening two GitHub tabs.
+  submitting.value = true
   emit('submit', {
     title: title.value.trim(),
     problem: problem.value.trim(),

--- a/frontend/src/shared/components/ContributeFeatureForm.vue
+++ b/frontend/src/shared/components/ContributeFeatureForm.vue
@@ -20,9 +20,20 @@ const dod = ref('')
 const showAdvanced = ref(false)
 const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
 const submitting = ref(false)
+// Short grace period so a deliberate retry (e.g. after a blocked popup) is
+// possible while still swallowing the classic tablet double-tap.
+const SUBMIT_GUARD_MS = 1500
+let submitGuardTimer: ReturnType<typeof setTimeout> | null = null
 
 function updateOnline(): void {
   isOnline.value = navigator.onLine
+}
+
+function clearSubmitGuardTimer(): void {
+  if (submitGuardTimer !== null) {
+    clearTimeout(submitGuardTimer)
+    submitGuardTimer = null
+  }
 }
 
 onMounted(() => {
@@ -38,6 +49,7 @@ onBeforeUnmount(() => {
     window.removeEventListener('online', updateOnline)
     window.removeEventListener('offline', updateOnline)
   }
+  clearSubmitGuardTimer()
 })
 
 const titleTooLong = computed(() => title.value.trim().length > TITLE_MAX)
@@ -58,7 +70,15 @@ const canSubmit = computed(() => {
 function onSubmit(): void {
   if (!canSubmit.value) return
   // Double-submit guard: prevents a double-tap from opening two GitHub tabs.
+  // Auto-resets after SUBMIT_GUARD_MS so a deliberate retry (e.g. popup
+  // blocked, pilot wants to amend and resend) is possible without forcing
+  // a destructive Back-and-restart cycle.
   submitting.value = true
+  clearSubmitGuardTimer()
+  submitGuardTimer = setTimeout(() => {
+    submitting.value = false
+    submitGuardTimer = null
+  }, SUBMIT_GUARD_MS)
   emit('submit', {
     title: title.value.trim(),
     problem: problem.value.trim(),

--- a/frontend/src/shared/components/ContributePromotionPanel.vue
+++ b/frontend/src/shared/components/ContributePromotionPanel.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+// @IMP-UI-SHARED-014@ (FROM: @REQ-SYS-016@, @DES-UX-018@)
+import { GITHUB_ISSUES_URL, GITHUB_REPO_URL } from '@/core/logic/github-issue-url'
+</script>
+
+<template>
+  <section class="promotion-panel" aria-labelledby="promotion-heading" data-testid="promotion-panel">
+    <h2 id="promotion-heading" class="promotion-panel__title">How else can you help?</h2>
+    <p class="promotion-panel__body">
+      AeroDash is built in the open. Contribution isn't only writing code —
+      telling us what didn't work, suggesting what could work better, improving
+      the wording in the manual, or sharing a real-world flight-prep edge case
+      all directly improve the next version.
+    </p>
+    <ul class="promotion-panel__list">
+      <li>Report a defect you noticed.</li>
+      <li>Suggest a feature.</li>
+      <li>Improve the documentation.</li>
+      <li>Share a real-world edge case in a discussion.</li>
+    </ul>
+    <div class="promotion-panel__links">
+      <a
+        :href="GITHUB_ISSUES_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="promotion-issues-link"
+      >
+        Browse open issues ↗
+      </a>
+      <a
+        :href="GITHUB_REPO_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="promotion-repo-link"
+      >
+        Open the GitHub repository ↗
+      </a>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.promotion-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-surface-card, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+}
+
+.promotion-panel__title {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 600;
+}
+
+.promotion-panel__body {
+  margin: 0;
+  color: var(--color-text-secondary, #4b5563);
+  line-height: 1.5;
+}
+
+.promotion-panel__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  color: var(--color-text-primary, #111827);
+  font-size: 0.95rem;
+}
+
+.promotion-panel__links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
+.promotion-panel__links a {
+  color: var(--color-primary, #1d4ed8);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.promotion-panel__links a:hover,
+.promotion-panel__links a:focus-visible {
+  text-decoration: underline;
+  outline-offset: 2px;
+}
+</style>

--- a/frontend/src/shared/components/ContributeSecurityCard.vue
+++ b/frontend/src/shared/components/ContributeSecurityCard.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+// @IMP-UI-SHARED-013@ (FROM: @REQ-SYS-018@, @DES-UX-017@)
+import { GITHUB_SECURITY_ADVISORY_URL } from '@/core/logic/github-issue-url'
+
+const emit = defineEmits<{
+  back: []
+}>()
+</script>
+
+<template>
+  <section
+    class="security-card"
+    data-testid="security-card"
+    aria-labelledby="security-card-heading"
+  >
+    <h2 id="security-card-heading" class="security-card__title">
+      Security reports are handled privately
+    </h2>
+    <p>
+      Security reports go to a form on GitHub that only the maintainers can read —
+      they are not visible in the public issue list. This protects both pilots and
+      the project while we work on a fix.
+    </p>
+    <ul class="security-card__bullets">
+      <li>
+        Don't post exploit details in a normal bug report — use this path instead.
+      </li>
+      <li>
+        We will reach out via the GitHub advisory thread once we've reproduced the
+        issue.
+      </li>
+    </ul>
+    <div class="security-card__actions">
+      <button
+        type="button"
+        class="btn"
+        data-testid="security-back"
+        @click="emit('back')"
+      >
+        ← Back
+      </button>
+      <a
+        class="btn btn-primary"
+        data-testid="security-open"
+        :href="GITHUB_SECURITY_ADVISORY_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open the private security form on GitHub (opens github.com in a new tab)"
+      >
+        Open the private security form on GitHub ↗
+      </a>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.security-card {
+  padding: 1.25rem 1.5rem;
+  background: var(--color-surface-card, #f9fafb);
+  border: 1px solid var(--color-warning, #f59e0b);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.security-card__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.security-card__bullets {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--color-text-secondary, #4b5563);
+  font-size: 0.95rem;
+}
+
+.security-card__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  min-height: 44px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text-primary, #111827);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary-text, #ffffff);
+}
+</style>

--- a/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
@@ -100,4 +100,37 @@ describe('ContributeBugForm', () => {
     await w.find('[data-testid="bug-title"]').setValue(tooLong)
     expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(true)
   })
+
+  it('guards against double-submit — a second click does not re-emit', async () => {
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    await fillRequired(w)
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+    expect(w.emitted('submit')).toHaveLength(1)
+    expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('removes online/offline listeners on unmount', async () => {
+    const removed: string[] = []
+    const originalRemove = window.removeEventListener.bind(window)
+    const spy = (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ): void => {
+      removed.push(type)
+      originalRemove(type, listener, options)
+    }
+    window.removeEventListener = spy as typeof window.removeEventListener
+    try {
+      const w = mount(ContributeBugForm)
+      await flushPromises()
+      w.unmount()
+      expect(removed).toContain('online')
+      expect(removed).toContain('offline')
+    } finally {
+      window.removeEventListener = originalRemove
+    }
+  })
 })

--- a/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
@@ -1,5 +1,5 @@
 // @UT-UI-SHARED-018@ (FROM: @IMP-UI-SHARED-011@)
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import ContributeBugForm from '../ContributeBugForm.vue'
 
@@ -109,6 +109,29 @@ describe('ContributeBugForm', () => {
     await w.find('[data-testid="bug-submit"]').trigger('submit')
     expect(w.emitted('submit')).toHaveLength(1)
     expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('re-enables submit after the guard window expires so retry is possible', async () => {
+    vi.useFakeTimers()
+    try {
+      const w = mount(ContributeBugForm)
+      await flushPromises()
+      await fillRequired(w)
+      await w.find('[data-testid="bug-submit"]').trigger('submit')
+      expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(
+        true,
+      )
+      // After the guard window the button must re-enable so the pilot can retry.
+      await vi.advanceTimersByTimeAsync(2000)
+      await flushPromises()
+      expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(
+        false,
+      )
+      await w.find('[data-testid="bug-submit"]').trigger('submit')
+      expect(w.emitted('submit')).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('removes online/offline listeners on unmount', async () => {

--- a/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
@@ -1,4 +1,4 @@
-// @UT-UI-SHARED-011@ (FROM: @IMP-UI-SHARED-011@)
+// @UT-UI-SHARED-018@ (FROM: @IMP-UI-SHARED-011@)
 import { describe, it, expect, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import ContributeBugForm from '../ContributeBugForm.vue'

--- a/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
@@ -1,0 +1,103 @@
+// @UT-UI-SHARED-011@ (FROM: @IMP-UI-SHARED-011@)
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ContributeBugForm from '../ContributeBugForm.vue'
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: online })
+}
+
+beforeEach(() => {
+  setOnline(true)
+})
+
+async function fillRequired(w: ReturnType<typeof mount>): Promise<void> {
+  await w.find('[data-testid="bug-title"]').setValue('Wrong CG')
+  await w.find('[data-testid="bug-description"]').setValue('Some description')
+  await w.find('[data-testid="bug-reproduction"]').setValue('1. Steps')
+  await w.find('[data-testid="bug-severity"]').setValue(
+    'Major: Core functionality impaired, no workaround',
+  )
+  await w.find('[data-testid="bug-environment"]').setValue('Chrome on Windows')
+}
+
+describe('ContributeBugForm', () => {
+  it('disables submit until every required field is filled', async () => {
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    const submit = w.find('[data-testid="bug-submit"]')
+    expect((submit.element as HTMLButtonElement).disabled).toBe(true)
+
+    await fillRequired(w)
+    expect((submit.element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('emits "submit" with a typed BugReportInput on click', async () => {
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    await fillRequired(w)
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+
+    const emitted = w.emitted('submit') ?? []
+    expect(emitted).toHaveLength(1)
+    const [first] = emitted
+    expect(first?.[0]).toMatchObject({
+      title: 'Wrong CG',
+      description: 'Some description',
+      reproduction: '1. Steps',
+      severity: 'Major: Core functionality impaired, no workaround',
+      environment: 'Chrome on Windows',
+    })
+    const firstArg = first?.[0] as { hazard_ref?: string } | undefined
+    expect(firstArg?.hazard_ref).toBeUndefined()
+  })
+
+  it('includes hazard_ref when filled', async () => {
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    await fillRequired(w)
+    // Open the advanced disclosure and set the field
+    const details = w.find('details')
+    await details.trigger('toggle')
+    await w.find('[data-testid="bug-hazard-ref"]').setValue('H-014')
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+    const submitted = (w.emitted('submit') ?? [])[0]
+    const submittedArg = submitted?.[0] as { hazard_ref?: string } | undefined
+    expect(submittedArg?.hazard_ref).toBe('H-014')
+  })
+
+  it('emits "back" when the back button is clicked', async () => {
+    const w = mount(ContributeBugForm)
+    await w.find('[data-testid="bug-back"]').trigger('click')
+    expect(w.emitted('back')).toHaveLength(1)
+  })
+
+  it('blocks submit and shows a note when offline', async () => {
+    setOnline(false)
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    await fillRequired(w)
+    expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(true)
+    expect(w.find('[data-testid="bug-offline-note"]').exists()).toBe(true)
+  })
+
+  it('auto-fills the environment textarea on mount', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'TestUA/1.0',
+    })
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    const env = (w.find('[data-testid="bug-environment"]').element as HTMLTextAreaElement).value
+    expect(env).toContain('User-Agent: TestUA/1.0')
+  })
+
+  it('flags an overly-long title and refuses to submit', async () => {
+    const w = mount(ContributeBugForm)
+    await flushPromises()
+    await fillRequired(w)
+    const tooLong = 'X'.repeat(220)
+    await w.find('[data-testid="bug-title"]').setValue(tooLong)
+    expect((w.find('[data-testid="bug-submit"]').element as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/frontend/src/shared/components/__tests__/ContributeCategoryGrid.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeCategoryGrid.spec.ts
@@ -1,0 +1,31 @@
+// @UT-UI-SHARED-010@ (FROM: @IMP-UI-SHARED-010@)
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ContributeCategoryGrid from '../ContributeCategoryGrid.vue'
+
+describe('ContributeCategoryGrid', () => {
+  it('renders three category buttons with plain-language labels', () => {
+    const w = mount(ContributeCategoryGrid)
+    expect(w.find('[data-testid="category-defect"]').text()).toContain('Report a defect')
+    expect(w.find('[data-testid="category-feature"]').text()).toContain('Request a feature')
+    expect(w.find('[data-testid="category-security"]').text()).toContain('Report a security vulnerability')
+  })
+
+  it('exposes the tooltip text via aria-describedby for screen readers', () => {
+    const w = mount(ContributeCategoryGrid)
+    const defectBtn = w.find('[data-testid="category-defect"]')
+    const describedBy = defectBtn.attributes('aria-describedby')
+    expect(describedBy).toBe('tooltip-defect')
+    expect(w.find('#tooltip-defect').text()).toMatch(/wrong number|button does nothing|crashes/i)
+  })
+
+  it.each([
+    ['defect'],
+    ['feature'],
+    ['security'],
+  ])('emits "pick" with the category id when %s button is clicked', async (id) => {
+    const w = mount(ContributeCategoryGrid)
+    await w.find(`[data-testid="category-${id}"]`).trigger('click')
+    expect(w.emitted('pick')).toEqual([[id]])
+  })
+})

--- a/frontend/src/shared/components/__tests__/ContributeCategoryGrid.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeCategoryGrid.spec.ts
@@ -1,4 +1,4 @@
-// @UT-UI-SHARED-010@ (FROM: @IMP-UI-SHARED-010@)
+// @UT-UI-SHARED-017@ (FROM: @IMP-UI-SHARED-010@)
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import ContributeCategoryGrid from '../ContributeCategoryGrid.vue'

--- a/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
@@ -1,0 +1,91 @@
+// @UT-UI-SHARED-012@ (FROM: @IMP-UI-SHARED-012@)
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ContributeFeatureForm from '../ContributeFeatureForm.vue'
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: online })
+}
+
+beforeEach(() => {
+  setOnline(true)
+})
+
+async function fillRequired(w: ReturnType<typeof mount>): Promise<void> {
+  await w.find('[data-testid="feature-title"]').setValue('Wind arrow on runway')
+  await w.find('[data-testid="feature-problem"]').setValue('As a pilot, I want…')
+  await w.find('[data-testid="feature-solution"]').setValue('Render an arrow')
+  await w.find('[data-testid="feature-dod"]').setValue('- [ ] Arrow renders')
+}
+
+describe('ContributeFeatureForm', () => {
+  it('disables submit until every required field is filled', async () => {
+    const w = mount(ContributeFeatureForm)
+    await flushPromises()
+    const submit = w.find('[data-testid="feature-submit"]')
+    expect((submit.element as HTMLButtonElement).disabled).toBe(true)
+    await fillRequired(w)
+    expect((submit.element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('refuses to submit when DoD is only the seed', async () => {
+    const w = mount(ContributeFeatureForm)
+    await flushPromises()
+    await w.find('[data-testid="feature-title"]').setValue('T')
+    await w.find('[data-testid="feature-problem"]').setValue('P')
+    await w.find('[data-testid="feature-solution"]').setValue('S')
+    // DoD still holds the seed "- [ ] " — submit must stay disabled
+    expect((w.find('[data-testid="feature-submit"]').element as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+  })
+
+  it('emits "submit" with a typed FeatureRequestInput', async () => {
+    const w = mount(ContributeFeatureForm)
+    await flushPromises()
+    await fillRequired(w)
+    await w.find('[data-testid="feature-submit"]').trigger('submit')
+    const emitted = w.emitted('submit') ?? []
+    expect(emitted).toHaveLength(1)
+    const [first] = emitted
+    expect(first?.[0]).toMatchObject({
+      title: 'Wind arrow on runway',
+      problem: 'As a pilot, I want…',
+      solution: 'Render an arrow',
+      dod: '- [ ] Arrow renders',
+    })
+    const firstArg = first?.[0] as { req_id?: string; safety_impact?: string } | undefined
+    expect(firstArg?.req_id).toBeUndefined()
+    expect(firstArg?.safety_impact).toBeUndefined()
+  })
+
+  it('includes req_id and safety_impact when filled', async () => {
+    const w = mount(ContributeFeatureForm)
+    await flushPromises()
+    await fillRequired(w)
+    await w.find('details').trigger('toggle')
+    await w.find('[data-testid="feature-req-id"]').setValue('REQ-PF-001')
+    await w.find('[data-testid="feature-safety-impact"]').setValue('Possible')
+    await w.find('[data-testid="feature-submit"]').trigger('submit')
+    const submitted = (w.emitted('submit') ?? [])[0]
+    const out = submitted?.[0] as { req_id?: string; safety_impact?: string } | undefined
+    expect(out?.req_id).toBe('REQ-PF-001')
+    expect(out?.safety_impact).toBe('Possible')
+  })
+
+  it('emits "back" when the back button is clicked', async () => {
+    const w = mount(ContributeFeatureForm)
+    await w.find('[data-testid="feature-back"]').trigger('click')
+    expect(w.emitted('back')).toHaveLength(1)
+  })
+
+  it('blocks submit when offline', async () => {
+    setOnline(false)
+    const w = mount(ContributeFeatureForm)
+    await flushPromises()
+    await fillRequired(w)
+    expect((w.find('[data-testid="feature-submit"]').element as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+  })
+})

--- a/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
@@ -88,4 +88,39 @@ describe('ContributeFeatureForm', () => {
       true,
     )
   })
+
+  it('guards against double-submit — a second click does not re-emit', async () => {
+    const w = mount(ContributeFeatureForm)
+    await flushPromises()
+    await fillRequired(w)
+    await w.find('[data-testid="feature-submit"]').trigger('submit')
+    await w.find('[data-testid="feature-submit"]').trigger('submit')
+    expect(w.emitted('submit')).toHaveLength(1)
+    expect((w.find('[data-testid="feature-submit"]').element as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+  })
+
+  it('removes online/offline listeners on unmount', async () => {
+    const removed: string[] = []
+    const originalRemove = window.removeEventListener.bind(window)
+    const spy = (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ): void => {
+      removed.push(type)
+      originalRemove(type, listener, options)
+    }
+    window.removeEventListener = spy as typeof window.removeEventListener
+    try {
+      const w = mount(ContributeFeatureForm)
+      await flushPromises()
+      w.unmount()
+      expect(removed).toContain('online')
+      expect(removed).toContain('offline')
+    } finally {
+      window.removeEventListener = originalRemove
+    }
+  })
 })

--- a/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
@@ -1,4 +1,4 @@
-// @UT-UI-SHARED-012@ (FROM: @IMP-UI-SHARED-012@)
+// @UT-UI-SHARED-019@ (FROM: @IMP-UI-SHARED-012@)
 import { describe, it, expect, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import ContributeFeatureForm from '../ContributeFeatureForm.vue'

--- a/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
@@ -1,5 +1,5 @@
 // @UT-UI-SHARED-019@ (FROM: @IMP-UI-SHARED-012@)
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import ContributeFeatureForm from '../ContributeFeatureForm.vue'
 
@@ -99,6 +99,28 @@ describe('ContributeFeatureForm', () => {
     expect((w.find('[data-testid="feature-submit"]').element as HTMLButtonElement).disabled).toBe(
       true,
     )
+  })
+
+  it('re-enables submit after the guard window expires so retry is possible', async () => {
+    vi.useFakeTimers()
+    try {
+      const w = mount(ContributeFeatureForm)
+      await flushPromises()
+      await fillRequired(w)
+      await w.find('[data-testid="feature-submit"]').trigger('submit')
+      expect((w.find('[data-testid="feature-submit"]').element as HTMLButtonElement).disabled).toBe(
+        true,
+      )
+      await vi.advanceTimersByTimeAsync(2000)
+      await flushPromises()
+      expect((w.find('[data-testid="feature-submit"]').element as HTMLButtonElement).disabled).toBe(
+        false,
+      )
+      await w.find('[data-testid="feature-submit"]').trigger('submit')
+      expect(w.emitted('submit')).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('removes online/offline listeners on unmount', async () => {

--- a/frontend/src/shared/components/__tests__/ContributeSecurityCard.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeSecurityCard.spec.ts
@@ -1,4 +1,4 @@
-// @UT-UI-SHARED-013@ (FROM: @IMP-UI-SHARED-013@)
+// @UT-UI-SHARED-020@ (FROM: @IMP-UI-SHARED-013@)
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import ContributeSecurityCard from '../ContributeSecurityCard.vue'

--- a/frontend/src/shared/components/__tests__/ContributeSecurityCard.spec.ts
+++ b/frontend/src/shared/components/__tests__/ContributeSecurityCard.spec.ts
@@ -1,0 +1,27 @@
+// @UT-UI-SHARED-013@ (FROM: @IMP-UI-SHARED-013@)
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ContributeSecurityCard from '../ContributeSecurityCard.vue'
+import { GITHUB_SECURITY_ADVISORY_URL } from '@/core/logic/github-issue-url'
+
+describe('ContributeSecurityCard', () => {
+  it('points the primary link at GitHub\'s private advisory form', () => {
+    const w = mount(ContributeSecurityCard)
+    const a = w.find('[data-testid="security-open"]')
+    expect(a.attributes('href')).toBe(GITHUB_SECURITY_ADVISORY_URL)
+    expect(a.attributes('target')).toBe('_blank')
+    expect(a.attributes('rel')).toContain('noopener')
+  })
+
+  it('explains that the report is handled privately', () => {
+    const w = mount(ContributeSecurityCard)
+    expect(w.text()).toMatch(/private/i)
+    expect(w.text()).toMatch(/not visible/i)
+  })
+
+  it('emits "back" when the back button is clicked', async () => {
+    const w = mount(ContributeSecurityCard)
+    await w.find('[data-testid="security-back"]').trigger('click')
+    expect(w.emitted('back')).toHaveLength(1)
+  })
+})

--- a/frontend/src/shared/utils/__tests__/contribution-environment.spec.ts
+++ b/frontend/src/shared/utils/__tests__/contribution-environment.spec.ts
@@ -1,0 +1,51 @@
+// @UT-SYS-SHARED-049@ (FROM: @IMP-UI-SHARED-009@)
+import { describe, it, expect } from 'vitest'
+import { buildContributionEnvironment } from '../contribution-environment'
+
+describe('buildContributionEnvironment', () => {
+  it('joins detected fields with newlines and labels each', () => {
+    const out = buildContributionEnvironment({
+      userAgent: 'Mozilla/5.0 (iPad)',
+      viewportWidth: 1024,
+      viewportHeight: 768,
+      theme: 'dark',
+      appVersion: '0.4.0-alpha',
+    })
+    expect(out).toBe(
+      'User-Agent: Mozilla/5.0 (iPad)\nViewport: 1024 × 768\nTheme: dark\nAeroDash version: 0.4.0-alpha',
+    )
+  })
+
+  it('omits missing pieces silently', () => {
+    const out = buildContributionEnvironment({
+      userAgent: 'UA',
+      viewportWidth: null,
+      viewportHeight: null,
+      theme: null,
+      appVersion: null,
+    })
+    expect(out).toBe('User-Agent: UA')
+  })
+
+  it('skips viewport when only one dimension is known', () => {
+    const out = buildContributionEnvironment({
+      userAgent: 'UA',
+      viewportWidth: 1024,
+      viewportHeight: null,
+      theme: 'light',
+      appVersion: null,
+    })
+    expect(out).toBe('User-Agent: UA\nTheme: light')
+  })
+
+  it('trims whitespace-only fields out', () => {
+    const out = buildContributionEnvironment({
+      userAgent: '   ',
+      viewportWidth: 800,
+      viewportHeight: 600,
+      theme: null,
+      appVersion: '   ',
+    })
+    expect(out).toBe('Viewport: 800 × 600')
+  })
+})

--- a/frontend/src/shared/utils/contribution-environment.ts
+++ b/frontend/src/shared/utils/contribution-environment.ts
@@ -1,0 +1,54 @@
+// @IMP-UI-SHARED-009@ (FROM: @REQ-SYS-017@, @DES-UX-015@)
+//
+// Builds the auto-detected "Environment" string prefilled in the in-app
+// defect form before handoff to the GitHub bug_report template. The user
+// can edit the field before submitting on GitHub, so any detail that may
+// be wrong is corrigible — this helper exists only to save typing.
+
+export interface ContributionEnvironmentSources {
+  userAgent: string
+  viewportWidth: number | null
+  viewportHeight: number | null
+  theme: 'light' | 'dark' | null
+  appVersion: string | null
+}
+
+export function buildContributionEnvironment(src: ContributionEnvironmentSources): string {
+  const lines: string[] = []
+  if (src.userAgent.trim() !== '') {
+    lines.push(`User-Agent: ${src.userAgent.trim()}`)
+  }
+  if (src.viewportWidth !== null && src.viewportHeight !== null) {
+    lines.push(`Viewport: ${src.viewportWidth} × ${src.viewportHeight}`)
+  }
+  if (src.theme !== null) {
+    lines.push(`Theme: ${src.theme}`)
+  }
+  if (src.appVersion !== null && src.appVersion.trim() !== '') {
+    lines.push(`AeroDash version: ${src.appVersion.trim()}`)
+  }
+  return lines.join('\n')
+}
+
+export function detectEnvironmentSources(): ContributionEnvironmentSources {
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : ''
+  const vw = typeof window !== 'undefined' ? window.innerWidth : null
+  const vh = typeof window !== 'undefined' ? window.innerHeight : null
+  const themeAttr =
+    typeof document !== 'undefined' ? document.documentElement.getAttribute('data-theme') : null
+  const theme: ContributionEnvironmentSources['theme'] =
+    themeAttr === 'dark' ? 'dark' : themeAttr === 'light' ? 'light' : null
+  const version =
+    typeof import.meta !== 'undefined' &&
+    typeof (import.meta as { env?: { VITE_APP_VERSION?: string } }).env?.VITE_APP_VERSION ===
+      'string'
+      ? ((import.meta as { env?: { VITE_APP_VERSION?: string } }).env?.VITE_APP_VERSION ?? null)
+      : null
+  return {
+    userAgent: ua,
+    viewportWidth: vw,
+    viewportHeight: vh,
+    theme,
+    appVersion: version,
+  }
+}

--- a/frontend/src/views/ContributeView.vue
+++ b/frontend/src/views/ContributeView.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+// @IMP-UI-VIEW-003@ (FROM: @REQ-SYS-016@, @REQ-SYS-017@, @REQ-SYS-018@, @DES-UX-013@, @DES-UX-014@, @DES-UX-017@, @DES-UX-018@, @DES-UX-019@)
+import { computed, ref } from 'vue'
+import ContributeCategoryGrid from '@/shared/components/ContributeCategoryGrid.vue'
+import ContributeBugForm from '@/shared/components/ContributeBugForm.vue'
+import ContributeFeatureForm from '@/shared/components/ContributeFeatureForm.vue'
+import ContributeSecurityCard from '@/shared/components/ContributeSecurityCard.vue'
+import ContributePromotionPanel from '@/shared/components/ContributePromotionPanel.vue'
+import {
+  buildBugReportUrl,
+  buildFeatureRequestUrl,
+  type BugReportInput,
+  type FeatureRequestInput,
+} from '@/core/logic/github-issue-url'
+
+type Screen = 'category' | 'defect' | 'feature' | 'security'
+
+const screen = ref<Screen>('category')
+const heading = computed(() => {
+  switch (screen.value) {
+    case 'defect':
+      return 'Report a defect'
+    case 'feature':
+      return 'Request a feature'
+    case 'security':
+      return 'Report a security vulnerability'
+    default:
+      return 'Help us improve AeroDash'
+  }
+})
+
+function pickCategory(next: Screen): void {
+  screen.value = next
+}
+
+function backToCategory(): void {
+  screen.value = 'category'
+}
+
+function openInNewTab(url: string): void {
+  if (typeof window === 'undefined') return
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+function onSubmitBug(input: BugReportInput): void {
+  openInNewTab(buildBugReportUrl(input))
+}
+
+function onSubmitFeature(input: FeatureRequestInput): void {
+  openInNewTab(buildFeatureRequestUrl(input))
+}
+</script>
+
+<template>
+  <main class="contribute-view" aria-labelledby="contribute-heading">
+    <header class="contribute-view__header">
+      <h1 id="contribute-heading">{{ heading }}</h1>
+      <p v-if="screen === 'category'" class="contribute-view__intro">
+        Found something that doesn't work? Have an idea for an improvement?
+        Noticed a security concern? Pick the closest match below — we'll guide you
+        through what to write, then hand off to GitHub for submission.
+      </p>
+    </header>
+
+    <ContributeCategoryGrid
+      v-if="screen === 'category'"
+      data-testid="contribute-category-grid"
+      @pick="pickCategory"
+    />
+
+    <ContributeBugForm
+      v-else-if="screen === 'defect'"
+      data-testid="contribute-bug-form"
+      @back="backToCategory"
+      @submit="onSubmitBug"
+    />
+
+    <ContributeFeatureForm
+      v-else-if="screen === 'feature'"
+      data-testid="contribute-feature-form"
+      @back="backToCategory"
+      @submit="onSubmitFeature"
+    />
+
+    <ContributeSecurityCard
+      v-else-if="screen === 'security'"
+      data-testid="contribute-security-card"
+      @back="backToCategory"
+    />
+
+    <ContributePromotionPanel data-testid="contribute-promotion" />
+  </main>
+</template>
+
+<style scoped>
+.contribute-view {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: var(--color-text-primary, #111827);
+}
+
+.contribute-view__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.contribute-view__intro {
+  margin: 0;
+  color: var(--color-text-secondary, #4b5563);
+  line-height: 1.5;
+}
+</style>

--- a/frontend/src/views/ContributeView.vue
+++ b/frontend/src/views/ContributeView.vue
@@ -16,6 +16,7 @@ import {
 type Screen = 'category' | 'defect' | 'feature' | 'security'
 
 const screen = ref<Screen>('category')
+const blockedUrl = ref<string | null>(null)
 const heading = computed(() => {
   switch (screen.value) {
     case 'defect':
@@ -30,16 +31,22 @@ const heading = computed(() => {
 })
 
 function pickCategory(next: Screen): void {
+  blockedUrl.value = null
   screen.value = next
 }
 
 function backToCategory(): void {
+  blockedUrl.value = null
   screen.value = 'category'
 }
 
 function openInNewTab(url: string): void {
   if (typeof window === 'undefined') return
-  window.open(url, '_blank', 'noopener,noreferrer')
+  // window.open returns null when an iOS Safari / mobile popup-blocker
+  // suppresses the new tab; surface a fallback so the pilot can still reach
+  // GitHub instead of seeing a silent no-op.
+  const opened = window.open(url, '_blank', 'noopener,noreferrer')
+  blockedUrl.value = opened === null ? url : null
 }
 
 function onSubmitBug(input: BugReportInput): void {
@@ -88,6 +95,26 @@ function onSubmitFeature(input: FeatureRequestInput): void {
       @back="backToCategory"
     />
 
+    <div
+      v-if="blockedUrl !== null"
+      class="contribute-view__popup-blocked"
+      role="alert"
+      data-testid="contribute-popup-blocked"
+    >
+      <p>
+        Your browser blocked the new tab. Open this link in a new tab to finish
+        submitting on GitHub:
+      </p>
+      <a
+        :href="blockedUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="contribute-popup-blocked-link"
+      >
+        Open GitHub submission ↗
+      </a>
+    </div>
+
     <ContributePromotionPanel data-testid="contribute-promotion" />
   </main>
 </template>
@@ -113,5 +140,28 @@ function onSubmitFeature(input: FeatureRequestInput): void {
   margin: 0;
   color: var(--color-text-secondary, #4b5563);
   line-height: 1.5;
+}
+
+.contribute-view__popup-blocked {
+  padding: 0.85rem 1rem;
+  border-radius: 8px;
+  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning, #92400e);
+  border: 1px solid var(--color-warning, #f59e0b);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.contribute-view__popup-blocked p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.contribute-view__popup-blocked a {
+  font-weight: 600;
+  color: inherit;
+  text-decoration: underline;
+  word-break: break-all;
 }
 </style>

--- a/frontend/src/views/ContributeView.vue
+++ b/frontend/src/views/ContributeView.vue
@@ -42,10 +42,15 @@ function backToCategory(): void {
 
 function openInNewTab(url: string): void {
   if (typeof window === 'undefined') return
-  // window.open returns null when an iOS Safari / mobile popup-blocker
-  // suppresses the new tab; surface a fallback so the pilot can still reach
-  // GitHub instead of seeing a silent no-op.
-  const opened = window.open(url, '_blank', 'noopener,noreferrer')
+  // The features string is intentionally omitted: per the HTML spec any
+  // `noopener`/`noreferrer` token forces `window.open` to return `null`,
+  // which would defeat the popup-blocker check below. Modern browsers add
+  // an implicit `noopener` to cross-origin `target=_blank` opens, so the
+  // tabnabbing posture against github.com remains intact; the explicit
+  // `rel="noopener noreferrer"` on the fallback anchor covers the second
+  // hand-off path. `opened === null` therefore now means "the popup was
+  // actually blocked" and we surface the in-page fallback link.
+  const opened = window.open(url, '_blank')
   blockedUrl.value = opened === null ? url : null
 }
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// @IMP-UI-VIEW-001@ (FROM: @REQ-UI-011@, @REQ-SYS-001@)
+// @IMP-UI-VIEW-001@ (FROM: @REQ-UI-011@, @REQ-SYS-001@, @REQ-SYS-016@)
 import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import AppLogo from '@/shared/components/AppLogo.vue'
@@ -148,6 +148,27 @@ const soonModules = modules.filter((m) => m.soon)
           </div>
         </RouterLink>
       </div>
+    </section>
+
+    <!-- ─── Contribution entry point (REQ-SYS-016) ────────────────────────── -->
+    <section
+      class="contribution-entry"
+      aria-labelledby="contribute-entry-heading"
+      data-testid="home-contribute-entry"
+    >
+      <!-- @IMP-UI-SHARED-016@ (FROM: @REQ-SYS-016@, @DES-UX-013@) -->
+      <div class="contribution-entry__body">
+        <h2 id="contribute-entry-heading" class="contribution-entry__title">
+          Help improve AeroDash
+        </h2>
+        <p class="contribution-entry__sub">
+          Defect, idea, or security concern? The contribution hub guides you
+          through reporting — no GitHub knowledge required.
+        </p>
+      </div>
+      <RouterLink to="/contribute" class="contribution-entry__cta">
+        Open contribution hub →
+      </RouterLink>
     </section>
 
     <!-- ─── Coming soon modules ────────────────────────────────────────────── -->
@@ -461,6 +482,65 @@ const soonModules = modules.filter((m) => m.soon)
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
+/* ─── Contribution entry ────────────────────────────────────────────────── */
+
+.contribution-entry {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-6);
+  background: var(--color-surface-card);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-xl);
+}
+
+.contribution-entry__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.contribution-entry__title {
+  margin: 0 0 var(--space-1);
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.contribution-entry__sub {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.contribution-entry__cta {
+  flex-shrink: 0;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-decoration: none;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.contribution-entry__cta:hover,
+.contribution-entry__cta:focus-visible {
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+  outline: none;
+}
+
+.contribution-entry__cta:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
 @media (max-width: 767.98px) {
   .home-view {
     padding: var(--space-4);
@@ -478,6 +558,12 @@ const soonModules = modules.filter((m) => m.soon)
 
   .modules-grid {
     grid-template-columns: 1fr;
+  }
+
+  .contribution-entry {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: var(--space-4);
   }
 }
 </style>

--- a/frontend/src/views/PrivacyView.vue
+++ b/frontend/src/views/PrivacyView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-// @IMP-UI-VIEW-002@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@, @DES-ARCH-011@, @DES-ARCH-012@)
+// @IMP-UI-VIEW-002@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@, @REQ-SYS-016@, @DES-ARCH-011@, @DES-ARCH-012@)
 import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
 import {
   exportAllProfiles,
   serializeBulkExport,
@@ -269,6 +270,14 @@ function onCancelWipe(): void {
       </button>
     </section>
 
+    <!-- ─── Contribution link (REQ-SYS-016) ────────────────────────── -->
+    <!-- @IMP-UI-SHARED-017@ (FROM: @REQ-SYS-016@, @DES-UX-013@) -->
+    <p class="privacy-view__contribute" data-testid="privacy-contribute-link">
+      <RouterLink to="/contribute">
+        Report a problem or suggest an improvement →
+      </RouterLink>
+    </p>
+
     <!-- ─── Confirmation dialog: wipe ───────────────────────────────── -->
     <div
       v-if="dialog === 'wipe'"
@@ -393,6 +402,22 @@ function onCancelWipe(): void {
   color: var(--color-warning, #92400e);
   background: var(--color-warning-bg, #fef3c7);
   border: 1px solid var(--color-warning, #92400e);
+}
+
+.privacy-view__contribute {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.privacy-view__contribute a {
+  color: var(--color-primary, #1d4ed8);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.privacy-view__contribute a:hover,
+.privacy-view__contribute a:focus-visible {
+  text-decoration: underline;
 }
 
 .card {

--- a/frontend/src/views/__tests__/ContributeView.int.spec.ts
+++ b/frontend/src/views/__tests__/ContributeView.int.spec.ts
@@ -120,3 +120,56 @@ describe('ContributeView integration — back navigation', () => {
     expect(newTitle.value).toBe('')
   })
 })
+
+describe('ContributeView integration — popup-blocker fallback', () => {
+  it('surfaces a visible link to GitHub when window.open is blocked (returns null)', async () => {
+    openSpy.mockImplementation(() => null)
+    const w = mount(ContributeView, { attachTo: document.body })
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    await flushPromises()
+
+    await w.find('[data-testid="bug-title"]').setValue('CG marker drifts')
+    await w.find('[data-testid="bug-description"]').setValue('CG marker drifts.')
+    await w.find('[data-testid="bug-reproduction"]').setValue('1. Open M&B.')
+    await w
+      .find('[data-testid="bug-severity"]')
+      .setValue('Major: Core functionality impaired, no workaround')
+    await w.find('[data-testid="bug-environment"]').setValue('iPad Safari')
+    await flushPromises()
+
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+    await flushPromises()
+
+    const fallback = w.find('[data-testid="contribute-popup-blocked"]')
+    expect(fallback.exists()).toBe(true)
+    const link = w.find('[data-testid="contribute-popup-blocked-link"]')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href') ?? '').toContain(GITHUB_NEW_ISSUE_URL)
+    expect(link.attributes('rel')).toContain('noopener')
+    expect(link.attributes('rel')).toContain('noreferrer')
+    expect(link.attributes('target')).toBe('_blank')
+  })
+
+  it('does not show the fallback when window.open succeeds', async () => {
+    openSpy.mockImplementation(
+      () => ({ focus: () => {}, close: () => {} }) as unknown as Window,
+    )
+    const w = mount(ContributeView, { attachTo: document.body })
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    await flushPromises()
+
+    await w.find('[data-testid="bug-title"]').setValue('CG marker drifts')
+    await w.find('[data-testid="bug-description"]').setValue('CG marker drifts.')
+    await w.find('[data-testid="bug-reproduction"]').setValue('1. Open M&B.')
+    await w
+      .find('[data-testid="bug-severity"]')
+      .setValue('Major: Core functionality impaired, no workaround')
+    await w.find('[data-testid="bug-environment"]').setValue('iPad Safari')
+    await flushPromises()
+
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+    await flushPromises()
+
+    expect(w.find('[data-testid="contribute-popup-blocked"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/views/__tests__/ContributeView.int.spec.ts
+++ b/frontend/src/views/__tests__/ContributeView.int.spec.ts
@@ -1,0 +1,122 @@
+// @IT-SYS-VIEW-001@ (FROM: @IMP-UI-VIEW-003@, @IMP-SYS-CORE-013@)
+//
+// Integration test: walking the full guided defect/feature flow and
+// confirming the prefilled GitHub URL passed to window.open carries the
+// expected template + field values.
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ContributeView from '../ContributeView.vue'
+import {
+  BUG_REPORT_TEMPLATE,
+  FEATURE_REQUEST_TEMPLATE,
+  GITHUB_NEW_ISSUE_URL,
+  GITHUB_SECURITY_ADVISORY_URL,
+} from '@/core/logic/github-issue-url'
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: online })
+}
+
+const openSpy = vi.fn<typeof window.open>()
+const originalOpen = window.open
+
+beforeEach(() => {
+  setOnline(true)
+  openSpy.mockReset()
+  Object.defineProperty(window, 'open', { configurable: true, value: openSpy })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'open', { configurable: true, value: originalOpen })
+})
+
+function parsedFrom(url: string): { base: string; params: URLSearchParams } {
+  const [base = '', q = ''] = url.split('?')
+  return { base, params: new URLSearchParams(q) }
+}
+
+describe('ContributeView integration — defect happy path', () => {
+  it('opens GitHub with the bug template and every entered field prefilled', async () => {
+    const w = mount(ContributeView, { attachTo: document.body })
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    await flushPromises()
+
+    await w.find('[data-testid="bug-title"]').setValue('CG marker drifts after profile swap')
+    await w.find('[data-testid="bug-description"]').setValue('CG marker drifts.')
+    await w.find('[data-testid="bug-reproduction"]').setValue('1. Open M&B.\n2. Swap profile.')
+    await w
+      .find('[data-testid="bug-severity"]')
+      .setValue('Major: Core functionality impaired, no workaround')
+    await w.find('[data-testid="bug-environment"]').setValue('Chrome 130 on iPadOS 17')
+    await flushPromises()
+
+    await w.find('[data-testid="bug-submit"]').trigger('submit')
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    const url = openSpy.mock.calls[0]?.[0] as string
+    const { base, params } = parsedFrom(url)
+    expect(base).toBe(GITHUB_NEW_ISSUE_URL)
+    expect(params.get('template')).toBe(BUG_REPORT_TEMPLATE)
+    expect(params.get('title')).toBe('CG marker drifts after profile swap')
+    expect(params.get('description')).toBe('CG marker drifts.')
+    expect(params.get('reproduction')).toBe('1. Open M&B.\n2. Swap profile.')
+    expect(params.get('severity')).toBe('Major: Core functionality impaired, no workaround')
+    expect(params.get('environment')).toBe('Chrome 130 on iPadOS 17')
+    expect(params.has('hazard_ref')).toBe(false)
+  })
+})
+
+describe('ContributeView integration — feature happy path', () => {
+  it('opens GitHub with the feature template and every entered field prefilled', async () => {
+    const w = mount(ContributeView, { attachTo: document.body })
+    await w.find('[data-testid="category-feature"]').trigger('click')
+    await flushPromises()
+
+    await w.find('[data-testid="feature-title"]').setValue('Wind arrow on runway diagram')
+    await w
+      .find('[data-testid="feature-problem"]')
+      .setValue('As a pilot, I want to see the wind direction on the runway.')
+    await w
+      .find('[data-testid="feature-solution"]')
+      .setValue('Overlay an arrow on the runway diagram.')
+    await w.find('[data-testid="feature-dod"]').setValue('- [ ] Arrow visible when wind known')
+    await flushPromises()
+
+    await w.find('[data-testid="feature-submit"]').trigger('submit')
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    const url = openSpy.mock.calls[0]?.[0] as string
+    const { params } = parsedFrom(url)
+    expect(params.get('template')).toBe(FEATURE_REQUEST_TEMPLATE)
+    expect(params.get('title')).toBe('Wind arrow on runway diagram')
+    expect(params.get('problem')).toBe(
+      'As a pilot, I want to see the wind direction on the runway.',
+    )
+    expect(params.get('solution')).toBe('Overlay an arrow on the runway diagram.')
+    expect(params.get('dod')).toBe('- [ ] Arrow visible when wind known')
+  })
+})
+
+describe('ContributeView integration — security advisory link', () => {
+  it('points at GitHub\'s private advisory form without opening a tab from the app', async () => {
+    const w = mount(ContributeView, { attachTo: document.body })
+    await w.find('[data-testid="category-security"]').trigger('click')
+    const a = w.find('[data-testid="security-open"]')
+    expect(a.attributes('href')).toBe(GITHUB_SECURITY_ADVISORY_URL)
+    // The security path is a plain anchor — no JS-initiated window.open call.
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('ContributeView integration — back navigation', () => {
+  it('returns from the defect form to the category screen and resets state', async () => {
+    const w = mount(ContributeView)
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    await w.find('[data-testid="bug-title"]').setValue('something')
+    await w.find('[data-testid="bug-back"]').trigger('click')
+
+    expect(w.find('[data-testid="contribute-category-grid"]').exists()).toBe(true)
+    // Reopening the defect form starts fresh — back unmounts the form.
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    const newTitle = w.find('[data-testid="bug-title"]').element as HTMLInputElement
+    expect(newTitle.value).toBe('')
+  })
+})

--- a/frontend/src/views/__tests__/ContributeView.spec.ts
+++ b/frontend/src/views/__tests__/ContributeView.spec.ts
@@ -1,0 +1,75 @@
+// @UT-UI-VIEW-003@ (FROM: @IMP-UI-VIEW-003@)
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ContributeView from '../ContributeView.vue'
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: online })
+}
+
+beforeEach(() => {
+  setOnline(true)
+})
+
+describe('ContributeView — screen switching', () => {
+  it('starts on the category screen with all three buttons and the promotion panel', () => {
+    const w = mount(ContributeView)
+    expect(w.find('[data-testid="contribute-category-grid"]').exists()).toBe(true)
+    expect(w.find('[data-testid="category-defect"]').exists()).toBe(true)
+    expect(w.find('[data-testid="category-feature"]').exists()).toBe(true)
+    expect(w.find('[data-testid="category-security"]').exists()).toBe(true)
+    expect(w.find('[data-testid="contribute-promotion"]').exists()).toBe(true)
+  })
+
+  it('switches to the defect form when the defect category is picked', async () => {
+    const w = mount(ContributeView)
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    expect(w.find('[data-testid="contribute-bug-form"]').exists()).toBe(true)
+    expect(w.find('[data-testid="contribute-category-grid"]').exists()).toBe(false)
+  })
+
+  it('switches to the feature form when the feature category is picked', async () => {
+    const w = mount(ContributeView)
+    await w.find('[data-testid="category-feature"]').trigger('click')
+    expect(w.find('[data-testid="contribute-feature-form"]').exists()).toBe(true)
+  })
+
+  it('switches to the security card when the security category is picked', async () => {
+    const w = mount(ContributeView)
+    await w.find('[data-testid="category-security"]').trigger('click')
+    expect(w.find('[data-testid="contribute-security-card"]').exists()).toBe(true)
+  })
+
+  it('returns to the category screen from the security card', async () => {
+    const w = mount(ContributeView)
+    await w.find('[data-testid="category-security"]').trigger('click')
+    await w.find('[data-testid="security-back"]').trigger('click')
+    expect(w.find('[data-testid="contribute-category-grid"]').exists()).toBe(true)
+  })
+
+  it('keeps the promotion panel visible across every screen', async () => {
+    const w = mount(ContributeView)
+    await w.find('[data-testid="category-defect"]').trigger('click')
+    expect(w.find('[data-testid="contribute-promotion"]').exists()).toBe(true)
+    await w.find('[data-testid="bug-back"]').trigger('click')
+    await w.find('[data-testid="category-feature"]').trigger('click')
+    expect(w.find('[data-testid="contribute-promotion"]').exists()).toBe(true)
+  })
+})
+
+describe('ContributeView — heading reflects the current screen', () => {
+  it('shows the promo heading on the category screen', () => {
+    const w = mount(ContributeView)
+    expect(w.find('h1').text()).toContain('Help us improve AeroDash')
+  })
+
+  it.each([
+    ['defect', 'Report a defect'],
+    ['feature', 'Request a feature'],
+    ['security', 'Report a security vulnerability'],
+  ])('updates the heading when %s is picked', async (cat, expected) => {
+    const w = mount(ContributeView)
+    await w.find(`[data-testid="category-${cat}"]`).trigger('click')
+    expect(w.find('h1').text()).toBe(expected)
+  })
+})

--- a/frontend/src/views/__tests__/PrivacyView.spec.ts
+++ b/frontend/src/views/__tests__/PrivacyView.spec.ts
@@ -110,7 +110,15 @@ afterEach(() => {
 })
 
 function mountView() {
-  return mount(PrivacyView, { attachTo: document.body })
+  return mount(PrivacyView, {
+    attachTo: document.body,
+    global: {
+      // PrivacyView includes a RouterLink to /contribute (REQ-SYS-016). The
+      // unit tests focus on REQ-SYS-014 / 015, so we stub the router link out
+      // rather than installing a router just for one anchor.
+      stubs: { RouterLink: { template: '<a><slot /></a>' } },
+    },
+  })
 }
 
 // ─── REQ-SYS-015 ───────────────────────────────────────────────────────────

--- a/trace/design/arch.yaml
+++ b/trace/design/arch.yaml
@@ -97,6 +97,12 @@ Architecture Design
       - REQ-SYS-006
     file: docs/architecture/adr/011-min-safe-version-fetch-privacy.md
 
+  DES-ARCH-014
+    title: P1 GitHub Issue URL Builder & Handoff Contract
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-017
+
 ARCH (auto)
   DES-ARCH-010
     title: TODO: describe this artifact

--- a/trace/design/ux.yaml
+++ b/trace/design/ux.yaml
@@ -75,3 +75,51 @@ UX (auto)
       - docs/ux/mass_balance.md
     req:
       - REQ-UI-019
+
+  DES-UX-013
+    title: Contribution Hub — Entry Points
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-016
+
+  DES-UX-014
+    title: Contribution Hub — Category Intake (Three-Button Entry)
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-016
+
+  DES-UX-015
+    title: Contribution Hub — Defect Guided Form
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-017
+
+  DES-UX-016
+    title: Contribution Hub — Feature Guided Form
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-017
+
+  DES-UX-017
+    title: Contribution Hub — Security Advisory Card
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-018
+
+  DES-UX-018
+    title: Contribution Hub — Promotion Section
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-016
+
+  DES-UX-019
+    title: Contribution Hub — State, Accessibility & Layout
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-016
+
+  DES-UX-020
+    title: Contribution Hub — Out of Scope Boundaries
+    file: docs/ux/contribution.md
+    req:
+      - REQ-SYS-016

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -433,7 +433,7 @@ MB (auto)
     req:
       - REQ-UQ-001
 
-  IMP-MB-UI-009
+  IMP-MB-UI-010
     title: Sanitised decimal station input (DecimalInput pattern) with transient inline rejection feedback (UX-010/UX-011)
     files:
       - frontend/src/modules/mass-balance/components/MassStationInput.vue

--- a/trace/implementation/sys.yaml
+++ b/trace/implementation/sys.yaml
@@ -373,3 +373,14 @@ SYS Store — App Version build-time floor resolution (#271, PR-review Major #2 
       - REQ-SYS-006
     hazard:
       - H-019
+
+SYS Core — In-app contribution intake (#395)
+  IMP-SYS-CORE-013
+    title: github-issue-url — P1 builder for prefilled GitHub issue URLs (bug_report.yml, feature_request.yml) and the security-advisory link constant
+    files:
+      - frontend/src/core/logic/github-issue-url.ts
+    req:
+      - REQ-SYS-017
+      - REQ-SYS-018
+    des:
+      - DES-ARCH-014

--- a/trace/implementation/ui.yaml
+++ b/trace/implementation/ui.yaml
@@ -138,3 +138,107 @@ UI (auto)
     des:
       - DES-ARCH-011
       - DES-ARCH-012
+
+UI — Contribution hub (#395)
+  IMP-UI-SHARED-009
+    title: Contribution environment helper — auto-detected environment string for the defect form
+    files:
+      - frontend/src/shared/utils/contribution-environment.ts
+    req:
+      - REQ-SYS-017
+    des:
+      - DES-UX-015
+
+  IMP-UI-SHARED-010
+    title: ContributeCategoryGrid — three-button entry with plain-language tooltips
+    files:
+      - frontend/src/shared/components/ContributeCategoryGrid.vue
+    req:
+      - REQ-SYS-016
+    des:
+      - DES-UX-014
+
+  IMP-UI-SHARED-011
+    title: ContributeBugForm — guided defect form mapped to bug_report.yml
+    files:
+      - frontend/src/shared/components/ContributeBugForm.vue
+    req:
+      - REQ-SYS-017
+    des:
+      - DES-UX-015
+
+  IMP-UI-SHARED-012
+    title: ContributeFeatureForm — guided feature form mapped to feature_request.yml
+    files:
+      - frontend/src/shared/components/ContributeFeatureForm.vue
+    req:
+      - REQ-SYS-017
+    des:
+      - DES-UX-016
+
+  IMP-UI-SHARED-013
+    title: ContributeSecurityCard — link-only handoff to GitHub's private advisory form
+    files:
+      - frontend/src/shared/components/ContributeSecurityCard.vue
+    req:
+      - REQ-SYS-018
+    des:
+      - DES-UX-017
+
+  IMP-UI-SHARED-014
+    title: ContributePromotionPanel — contribution-promotion card with GitHub links
+    files:
+      - frontend/src/shared/components/ContributePromotionPanel.vue
+    req:
+      - REQ-SYS-016
+    des:
+      - DES-UX-018
+
+  IMP-UI-SHARED-015
+    title: App shell — sidebar footer "Help / contribute" link
+    files:
+      - frontend/src/App.vue
+    req:
+      - REQ-SYS-016
+    des:
+      - DES-UX-013
+
+  IMP-UI-SHARED-016
+    title: HomeView — contribution entry panel
+    files:
+      - frontend/src/views/HomeView.vue
+    req:
+      - REQ-SYS-016
+    des:
+      - DES-UX-013
+
+  IMP-UI-SHARED-017
+    title: PrivacyView — contribution link
+    files:
+      - frontend/src/views/PrivacyView.vue
+    req:
+      - REQ-SYS-016
+    des:
+      - DES-UX-013
+
+  IMP-UI-VIEW-003
+    title: ContributeView — top-level view orchestrating the three intake categories + promotion panel
+    files:
+      - frontend/src/views/ContributeView.vue
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018
+    des:
+      - DES-UX-013
+      - DES-UX-014
+      - DES-UX-019
+
+  IMP-UI-ROUTE-005
+    title: Router — /contribute route registration
+    files:
+      - frontend/src/router/index.ts
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018

--- a/trace/integration_test/sys.yaml
+++ b/trace/integration_test/sys.yaml
@@ -25,3 +25,12 @@ SYS Store — App-version offline enforcement (Integration — #271 CS-011 / TEC
       - IMP-SYS-STORE-013
       - IMP-SYS-STORE-014
       - IMP-SYS-STORE-015
+
+SYS — In-app contribution intake (Integration — #395)
+  IT-SYS-VIEW-001
+    title: ContributeView end-to-end — defect + feature flows compose prefilled URLs; security path routes to GitHub's advisory form
+    files:
+      - frontend/src/views/__tests__/ContributeView.int.spec.ts
+    impl:
+      - IMP-UI-VIEW-003
+      - IMP-SYS-CORE-013

--- a/trace/journeys/d.yaml
+++ b/trace/journeys/d.yaml
@@ -20,3 +20,11 @@ Phase D — System & Usability
       - REQ-UI-014
       - REQ-UI-015
       - REQ-UI-016
+
+  UJ-D-003
+    title: Reporting a Defect, Suggesting a Feature, or Raising a Security Concern
+    file: docs/journeys/04_system_usability.md
+    req:
+      - REQ-SYS-016
+      - REQ-SYS-017
+      - REQ-SYS-018

--- a/trace/requirements/sys.yaml
+++ b/trace/requirements/sys.yaml
@@ -65,3 +65,15 @@ System Requirements
   REQ-SYS-015
     title: Export of All Personal Data
     file: docs/requirements/system.md
+
+  REQ-SYS-016
+    title: In-App Contribution Intake — Three-Channel Entry
+    file: docs/requirements/system.md
+
+  REQ-SYS-017
+    title: Prefilled GitHub Issue Handoff for Defects and Feature Requests
+    file: docs/requirements/system.md
+
+  REQ-SYS-018
+    title: Security Advisory Link-Only Handoff
+    file: docs/requirements/system.md

--- a/trace/unit_test/mb.yaml
+++ b/trace/unit_test/mb.yaml
@@ -1464,4 +1464,4 @@ MB (auto)
     files:
       - frontend/src/modules/mass-balance/components/__tests__/MassStationInput.spec.ts
     impl:
-      - IMP-MB-UI-009
+      - IMP-MB-UI-010

--- a/trace/unit_test/sys.yaml
+++ b/trace/unit_test/sys.yaml
@@ -1578,3 +1578,17 @@ SYS (auto)
       - frontend/src/stores/__tests__/session-persistence.store.spec.ts
     impl:
       - IMP-SYS-STORE-001
+
+  UT-SYS-CORE-102
+    title: github-issue-url builder — prefilled URL composition, severity labels, trimming/fallback paths
+    files:
+      - frontend/src/core/logic/github-issue-url.spec.ts
+    impl:
+      - IMP-SYS-CORE-013
+
+  UT-SYS-SHARED-049
+    title: buildContributionEnvironment — joins detected sources, omits missing pieces
+    files:
+      - frontend/src/shared/utils/__tests__/contribution-environment.spec.ts
+    impl:
+      - IMP-UI-SHARED-009

--- a/trace/unit_test/ui.yaml
+++ b/trace/unit_test/ui.yaml
@@ -136,28 +136,28 @@ UI (auto)
     impl:
       - IMP-UI-VIEW-002
 
-  UT-UI-SHARED-010
+  UT-UI-SHARED-017
     title: ContributeCategoryGrid — three labelled buttons, tooltips reachable via aria-describedby, picks emit category id
     files:
       - frontend/src/shared/components/__tests__/ContributeCategoryGrid.spec.ts
     impl:
       - IMP-UI-SHARED-010
 
-  UT-UI-SHARED-011
+  UT-UI-SHARED-018
     title: ContributeBugForm — required-field gating, offline blocking, auto-environment, hazard_ref optional
     files:
       - frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
     impl:
       - IMP-UI-SHARED-011
 
-  UT-UI-SHARED-012
+  UT-UI-SHARED-019
     title: ContributeFeatureForm — required-field gating, DoD seed rejection, optional fields
     files:
       - frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
     impl:
       - IMP-UI-SHARED-012
 
-  UT-UI-SHARED-013
+  UT-UI-SHARED-020
     title: ContributeSecurityCard — link target, privacy copy, back emission
     files:
       - frontend/src/shared/components/__tests__/ContributeSecurityCard.spec.ts

--- a/trace/unit_test/ui.yaml
+++ b/trace/unit_test/ui.yaml
@@ -44,3 +44,38 @@ UI (auto)
       - frontend/src/views/__tests__/PrivacyView.spec.ts
     impl:
       - IMP-UI-VIEW-002
+
+  UT-UI-SHARED-010
+    title: ContributeCategoryGrid — three labelled buttons, tooltips reachable via aria-describedby, picks emit category id
+    files:
+      - frontend/src/shared/components/__tests__/ContributeCategoryGrid.spec.ts
+    impl:
+      - IMP-UI-SHARED-010
+
+  UT-UI-SHARED-011
+    title: ContributeBugForm — required-field gating, offline blocking, auto-environment, hazard_ref optional
+    files:
+      - frontend/src/shared/components/__tests__/ContributeBugForm.spec.ts
+    impl:
+      - IMP-UI-SHARED-011
+
+  UT-UI-SHARED-012
+    title: ContributeFeatureForm — required-field gating, DoD seed rejection, optional fields
+    files:
+      - frontend/src/shared/components/__tests__/ContributeFeatureForm.spec.ts
+    impl:
+      - IMP-UI-SHARED-012
+
+  UT-UI-SHARED-013
+    title: ContributeSecurityCard — link target, privacy copy, back emission
+    files:
+      - frontend/src/shared/components/__tests__/ContributeSecurityCard.spec.ts
+    impl:
+      - IMP-UI-SHARED-013
+
+  UT-UI-VIEW-003
+    title: ContributeView — screen switching, heading updates, promotion panel always visible
+    files:
+      - frontend/src/views/__tests__/ContributeView.spec.ts
+    impl:
+      - IMP-UI-VIEW-003


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

- New `/contribute` view replaces the rejected approach from PR #392 (incident issue type + offline-queued in-app store + redactor). The pilot picks one of three plain-language categories — *Report a defect*, *Request a feature*, *Report a security vulnerability* — each with a short tooltip; no GitHub knowledge required.
- **Defect / feature**: guided form whose fields map 1:1 to the existing `bug_report.yml` and `feature_request.yml` templates. On submit the app opens GitHub in a new tab with the matching template prefilled (Option B in [ADR-013](https://github.com/naturelle137/AeroDash/blob/feature/issue-395/docs/architecture/adr/013-in-app-contribution-intake.md)). The pilot confirms on GitHub.
- **Security**: link-only handoff to GitHub's private advisory form — GitHub does not accept URL pre-fill on advisories (Option A in ADR-013).
- **Contribution promotion** panel below the buttons advertises non-code ways to help (defects, feature ideas, docs, real-world edge cases) and links to the public issue list and repository.
- No new GitHub issue template; no in-app store, queue, or redactor; no backend, OAuth, or tokens — architecture stays offline-first / client-only.

### Related Issues

- Closes #395
- Supersedes #281 (closed as superseded)
- Supersedes PR #392 (closed)

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-SYS-017`, `REQ-SYS-018`, `REQ-SYS-019`

### Documentation Updates

- [x] **Requirements:** Created ID(s): `REQ-SYS-017`, `REQ-SYS-018`, `REQ-SYS-019` in `docs/requirements/system.md`
- [x] **Architecture:** Created ADR-013 (`docs/architecture/adr/013-in-app-contribution-intake.md`); added `DES-ARCH-018` and `DES-UX-013..020` referencing `docs/ux/contribution.md`
- [x] **Risk Management:** N/A (Reason: contribution intake is a pilot-initiated, non-flight-critical workflow and does not feed any Go/No-Go advisory — no hazard added; security-advisory path stays in GitHub's private workflow per ADR-013)
- [x] **Journeys:** Created `UJ-D-003` in `docs/journeys/04_system_usability.md`
- [x] **Code Docs:** `docs/ux/contribution.md` specifies the per-screen UX and field mappings; CHANGELOG intentionally untouched (release-process owned)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained — only new P1 file is `frontend/src/core/logic/github-issue-url.ts`, pure TS, no Vue/Pinia/router imports; `pnpm --filter frontend test:p1` green (503/503).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added (`github-issue-url.spec.ts`, `contribution-environment.spec.ts`, `ContributeCategoryGrid.spec.ts`, `ContributeBugForm.spec.ts`, `ContributeFeatureForm.spec.ts`, `ContributeSecurityCard.spec.ts`, `ContributeView.spec.ts`) and passing — `pnpm test:unit` green. P1 coverage on `github-issue-url.ts`: 100 % lines, 100 % functions, ≥90 % branches (above the 90 % gate).
- [x] **Integration Tests:** Added (`ContributeView.int.spec.ts`) and passing — `pnpm test:integration` green.
- [x] **Manual Testing:** N/A (Reason: PR targets `develop`, not `main`; the prefilled-URL contract is verified by both the unit suite and the end-to-end `ContributeView.int.spec.ts` which mounts the view, walks the form, and asserts the exact query string handed to `window.open`)
- [x] **DoD:** All Definition of Done items from #395 are met — ADR-013 written, `docs/ux/contribution.md` specifies the design, P1 URL-builder with 90 %+ coverage, P3 UI wired from Home + Privacy + sidebar, existing templates reused unchanged, trace registries updated, lint + typecheck clean.
- [x] **Review:** I have performed a self-review of my own code and documentation. Latest review feedback addressed: window-listener lifecycle (`onBeforeUnmount` cleanup in both contribute forms), popup-blocker fallback (visible link surfaced when `window.open` returns `null`), double-submit guard on submit handlers, ASCII `TRUNCATION_MARKER` so the trim-loop budget matches the URL-encoded cost.
- [x] **ADR:** ADR-013 created (`docs/architecture/adr/013-in-app-contribution-intake.md`).
