### PR TITLE
chore(repo): deactivate PR iteration bot

### DIFF
--- a/.github/workflows/pr-iteration.yml
+++ b/.github/workflows/pr-iteration.yml
@@ -1,5 +1,14 @@
 name: Bounded PR Iteration & Ready Gate
 
+# DEACTIVATED — manual-dispatch only.
+#
+# Reason: the orchestrator's correction round is slower than the human reviewer
+# bot's cadence. By the time a correction lands, the reviewer has already posted
+# 2-3 more rounds of feedback, so the orchestrator's work ships against stale
+# review state. Re-enable by restoring the `pull_request_review` and
+# `workflow_run` triggers below.
+#
+# --- Original behaviour (preserved for re-enablement) ---
 # Drives BOT-authored Draft PRs (feature/issue-*) toward "Ready for review" while
 # ingesting BOTH reviewer feedback and CI/pipeline results. Governed by ADR-317-DEV.
 #
@@ -14,29 +23,11 @@ name: Bounded PR Iteration & Ready Gate
 # refs #320, #316
 
 on:
-  pull_request_review:
-    types: [submitted]
-  workflow_run:
-    # React to EVERY PR-gating workflow, not just CI. A red DoD/Security/E2E/
-    # Traceability/branching gate must also drive a correction — otherwise a PR
-    # whose CI is green but another gate is red sits red forever with no action.
-    # `Autonomous PR Reviewer` is listed defensively: a `pull_request_review`
-    # event fires while the reviewer workflow's own check is still in_progress
-    # (the review is submitted a few seconds before the workflow run reports
-    # `completed`), and the orchestrator's pending-gate (below) used to count
-    # that check as pending and refuse to act. The race is fixed at the source
-    # by excluding the reviewer's check from the pending-set, but listing the
-    # workflow here also makes the loop self-healing for any other transient
-    # race that ever leaves the orchestrator with a `wait` verdict.
-    workflows:
-      - CI
-      - DoD Attestation Gate
-      - Security Scanning
-      - Traceability Gate
-      - E2E Tests (Playwright)
-      - Enforce Branching Model
-      - Autonomous PR Reviewer
-    types: [completed]
+  # Deactivated. Kept as `workflow_dispatch` only (Actions requires at least one
+  # trigger) and guarded by `if: false` on the job below so manual runs are a
+  # clean no-op too. To re-enable, restore the `pull_request_review` +
+  # `workflow_run` triggers and drop the `if: false` (see git history).
+  workflow_dispatch:
 
 # Serialise per branch across BOTH trigger types so the correction budget is honoured.
 concurrency:
@@ -64,6 +55,8 @@ env:
 jobs:
   orchestrate:
     name: Iterate / ready-gate
+    # Deactivated — see header. Drop this guard to re-enable.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
### Summary

Deactivate `.github/workflows/pr-iteration.yml` (the "Bounded PR Iteration & Ready Gate" orchestrator). The orchestrator's correction round is slower than the reviewer bot's cadence: by the time a correction lands, the reviewer has already posted 2-3 more rounds of feedback, so the corrections ship against stale review state and never converge.

Done as a deactivation, **not** a deletion, so the implementation is preserved for later re-enablement once the round-trip is fast enough to keep up:

- Strip the `pull_request_review` + `workflow_run` triggers; keep `workflow_dispatch:` only (Actions requires at least one trigger).
- Add `if: false` to the `orchestrate` job so even a manual dispatch is a clean no-op (the Resolve-action script depends on `pull_request_review` / `workflow_run` payloads that `workflow_dispatch` does not carry).
- Rewrite the header to explain the deactivation; preserve the original behaviour block verbatim below for re-enablement context.

Sibling workflows (`overnight-implementation.yml`, `pr-review-bot.yml`) and docs (ADR-317-DEV, `autonomous-implementation.md`) still reference this workflow in comments — left untouched because they describe the preserved implementation and the deactivation is reversible. To re-enable: restore the two triggers and drop the `if: false` (git history has the previous form).

### Related Issues

- Refs #316, Refs #320 (the autonomous-PR-loop track this workflow belongs to)

### Affected Items

- **Requirements Implemented/Affected:** `N/A` (CI plumbing only)

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: workflow deactivation, no requirement change)
- [x] **Architecture:** `N/A` (Reason: ADR-317-DEV's design is preserved; this is a reversible operational toggle, not an architectural decision change)
- [x] **Risk Management:** `N/A` (Reason: no hazard mitigation change; reviewer bot + human Lead review path unchanged)
- [x] **Journeys:** `N/A` (Reason: developer-workflow CI change, no pilot journey impact)
- [x] **Code Docs:** `N/A` (Reason: docs reference the preserved implementation by file path, which is unchanged)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: GitHub Actions YAML workflow change with no executable test surface in this repo).
- [x] **Integration Tests:** `N/A` (Reason: same as above).
- [x] **Manual Testing:** `N/A` (Reason: deactivation is verified by the `if: false` guard + absence of event triggers; reactivation will be tested before re-enabling).
- [x] **DoD:** No linked Feature/Bug closure — `Refs` only, so no DoD checklist applies.
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** No ADR update required. The autonomous-PR loop architecture (ADR-317-DEV) is intact; this is a reversible operational toggle. If the deactivation becomes permanent, a supersession of the orchestrator section of ADR-317-DEV would be appropriate at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)