### PR TITLE
chore(repo): align bot models + chain reviewer on pipeline completion

### DIFF
--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -26,7 +26,12 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override (e.g. claude-opus-4-7, claude-sonnet-4-6).'
+        description: 'Model override (e.g. claude-opus-4-7[1m], claude-sonnet-4-6).'
+        required: false
+        type: string
+        default: ''
+      effort:
+        description: 'Reasoning effort override (low | medium | high | xhigh | max).'
         required: false
         type: string
         default: ''
@@ -54,7 +59,13 @@ permissions:
   id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
-  MODEL_DEFAULT: claude-opus-4-7
+  # Latest Opus, 1M-context variant — the `[1m]` suffix unlocks the 1M window
+  # in the Claude Code CLI (see code.claude.com/docs/en/model-config). Wrapped
+  # in single quotes so YAML does not parse `[1m]` as a flow sequence.
+  MODEL_DEFAULT: 'claude-opus-4-7[1m]'
+  # `xhigh` is Opus 4.7's default reasoning level — pinned explicitly so a
+  # future CLI/default change does not silently downgrade implementation runs.
+  EFFORT_DEFAULT: 'xhigh'
   BATCH_SIZE_DEFAULT: '1'
   # Per-issue budgets (ADR-317-DEV operational defaults). 40 turns proved far
   # too small: run #4 hit `error_max_turns` mid-implementation (the agent was
@@ -250,66 +261,40 @@ jobs:
             You are running unattended in CI on branch feature/issue-${{ matrix.issue }}.
             ${{ env.ACT == 'true' && 'LOCAL ACT TEST RUN — make NO remote/GitHub changes: no project-board claim or move, no issue assignment, no label edits, no issue comments, no PR or sub-issue creation, and do NOT git push to any remote. Only read from GitHub, edit files, run the pipeline, and commit locally. (This line is empty on real CI.)' || '' }}
 
-            Task: FULLY implement GitHub issue #${{ matrix.issue }} by following the
-            repository's `/implement-issue ${{ matrix.issue }}` workflow exactly,
-            end to end. "Done" means EVERY acceptance criterion and EVERY Definition
-            of Done (DoD) item is genuinely satisfied — code, tests, traceability and
-            docs — not a partial slice that merely looks finished. A half-done ticket
-            dressed up as complete is a defect, not progress.
+            FIRST ACTION — invoke the repository's `/implement-issue` skill via the
+            Skill tool. This is mandatory and non-negotiable: do NOT paraphrase the
+            workflow, do NOT re-derive it from prose, do NOT skip the tool call.
+            The skill IS the authoritative procedure — call it deterministically:
 
-            Before committing, run the local pipeline and make it pass so CI is green
-            on the first push: `pnpm install --frozen-lockfile`, `pnpm lint`,
-            `pnpm --filter frontend type-check`, `pnpm test:unit`,
-            `pnpm test:integration`, `pnpm build`. Fix any failures you introduced.
+                Skill(skill="implement-issue", args="${{ matrix.issue }}")
 
-            Completion & attestation (per the implement-issue skill — NOT optional):
-            - Finish the whole ticket and attest its DoD so EVERY checkbox in the issue
-              ends ticked `[x]`: tick items genuinely verified done; for an item that
-              does not apply, tick it and mark `N/A — <reason>`; never tick a skipped,
-              unverified, or human-only item (e.g. manual flight testing) — those keep
-              the issue open. The DoD gate rejects a `Closes` PR whose issue still has
-              any unticked box.
-            - Author the PR description by FILLING OUT the repository PR template at
-              `.github/pull_request_template.md` and writing the result to the file
-              `$RUNNER_TEMP/pr-body.md` — the workflow uses that file verbatim as the
-              PR body. Templates are mandatory. Complete every section; for each
-              checklist row write `[x]` once satisfied, using `N/A (Reason: …)` where
-              it truly does not apply — every row must END ticked `[x]` (an unticked
-              box reads as an open obligation).
-            - In the template's "Related Issues" section use `Closes #${{ matrix.issue }}`
-              ONLY when the issue is 100% complete and every DoD item is genuinely
-              ticked; otherwise use `Refs #${{ matrix.issue }}` and state plainly what
-              remains. Do NOT claim `Closes` for incomplete work. (Merging to `develop`
-              auto-closes via `Closes` — every issue is closed by its PR to develop.)
-            - Parent/child closing: a feature is finished only when EVERY child is. If
-              this issue is a sub-task and NO sibling remains open after your work, also
-              add `Closes #<parent-feature>` and attest the parent's DoD; if it is a
-              feature, only `Closes` it when all its children are already closed. Never
-              close a feature that still has unfinished children.
-            - EXCEPTION — discovery/scoping tickets: if this issue's body says it is a
-              discovery/scoping ticket ("not an implementation ticket", "produce a
-              recommendation", "file follow-up issues"), its deliverable is the written
-              recommendation + the filed follow-ups. Produce those, then `Closes
-              #${{ matrix.issue }}`. File each follow-up as an INDEPENDENT issue that
-              references this one in its body (e.g. "Spawned by #${{ matrix.issue }}") —
-              do NOT attach them as native sub-issues and do NOT keep this ticket open
-              as an umbrella.
+            Then follow the skill end-to-end. "Done" means every acceptance criterion
+            and every Definition of Done item is genuinely satisfied (code, tests,
+            traceability, docs) — a half-done ticket dressed up as complete is a defect.
 
-            Hard rules (ADR-317-DEV — do not violate):
-            - Honour every quality gate. NEVER use --no-verify or bypass Husky/ESLint/tests.
-            - Do NOT edit files under .github/workflows/**, repository secrets, or
-              security configuration. Stay within product, docs, trace, and test paths.
-            - Commit your work on the CURRENT branch with Conventional Commits, committing
-              incrementally as you complete coherent steps. Aim to finish the ENTIRE
-              issue — the turn/time budget is generous; do not stop early or hand off a
-              half-done ticket.
-            - Do NOT open the pull request yourself and do NOT mark anything ready for
-              review — the workflow opens the Draft PR from `$RUNNER_TEMP/pr-body.md`
-              and the ready-gate marks it Ready once CI is green and the review is clean.
-            - Only if a step is genuinely blocked or unsafe: finish every part you safely
-              can, leave the unfinished DoD items unticked, use `Refs` (not `Closes`),
-              and write a clear "what remains" summary in the PR body — never force an
-              unsafe or fake-complete change.
+            CI-specific overrides on top of the skill (these adapt the skill's output
+            for unattended GitHub Actions execution — the skill itself is unchanged):
+
+            - PR opening: do NOT open the PR yourself. Write the PR body (filled out
+              from `.github/pull_request_template.md`, with the skill's Closes/Refs
+              and DoD logic) to the file `$RUNNER_TEMP/pr-body.md`. The push step
+              below opens the Draft PR using that file verbatim.
+            - Pipeline gate before commit: run `pnpm install --frozen-lockfile`,
+              `pnpm lint`, `pnpm --filter frontend type-check`, `pnpm test:unit`,
+              `pnpm test:integration`, `pnpm build` and fix any failures you introduced
+              so CI is green on the first push.
+            - Hard rules (ADR-317-DEV — do not violate):
+              * Honour every quality gate. NEVER use --no-verify or bypass Husky/ESLint/tests.
+              * Do NOT edit `.github/workflows/**`, repository secrets, or security
+                configuration. Stay within product, docs, trace, and test paths.
+              * Commit on the CURRENT branch using Conventional Commits, incrementally
+                per coherent step. Finish the ENTIRE issue — the turn/time budget is
+                generous; do not stop early or hand off a half-done ticket.
+              * Do NOT mark the PR ready-for-review — the ready-gate flips it once CI
+                is green and the automated review is clean.
+              * Only if a step is genuinely blocked or unsafe: finish every part you
+                safely can, leave unfinished DoD items unticked, use `Refs` (not
+                `Closes`), and write a clear "what remains" summary in the PR body.
           # claude-code-action does NOT grant Bash by default, and CI has no
           # human to approve tool prompts — so without an explicit allow-list the
           # agent's pnpm/git/gh commands are all auto-denied and it produces zero
@@ -322,6 +307,7 @@ jobs:
           # every gate and is never auto-merged.
           claude_args: |
             --model ${{ github.event.inputs.model || env.MODEL_DEFAULT }}
+            --effort ${{ github.event.inputs.effort || env.EFFORT_DEFAULT }}
             --max-turns ${{ env.MAX_TURNS }}
             --allowedTools "Bash,Edit,Write,Read,Glob,Grep,Task,TodoWrite,WebFetch,WebSearch,Skill"
 

--- a/.github/workflows/overnight-implementation.yml
+++ b/.github/workflows/overnight-implementation.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override (e.g. claude-opus-4-7[1m], claude-sonnet-4-6).'
+        description: 'Model override (alias e.g. opus[1m], sonnet, or pinned ID).'
         required: false
         type: string
         default: ''
@@ -59,12 +59,17 @@ permissions:
   id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
-  # Latest Opus, 1M-context variant — the `[1m]` suffix unlocks the 1M window
-  # in the Claude Code CLI (see code.claude.com/docs/en/model-config). Wrapped
-  # in single quotes so YAML does not parse `[1m]` as a flow sequence.
-  MODEL_DEFAULT: 'claude-opus-4-7[1m]'
-  # `xhigh` is Opus 4.7's default reasoning level — pinned explicitly so a
-  # future CLI/default change does not silently downgrade implementation runs.
+  # Alias form so the bot tracks the LATEST Opus + 1M-context variant
+  # automatically (per code.claude.com/docs/en/model-config: "Aliases point to
+  # the recommended version for your provider and update over time"). Pinning
+  # to a specific version like `claude-opus-4-7[1m]` would silently go stale
+  # whenever Anthropic ships a newer Opus. Wrapped in single quotes so YAML
+  # does not parse `[1m]` as a flow sequence. Override via workflow_dispatch
+  # `model` input if a specific version is ever needed.
+  MODEL_DEFAULT: 'opus[1m]'
+  # `xhigh` is the documented default reasoning level for Opus 4.7/4.8 —
+  # pinned explicitly so a future CLI/default change does not silently
+  # downgrade implementation runs.
   EFFORT_DEFAULT: 'xhigh'
   BATCH_SIZE_DEFAULT: '1'
   # Per-issue budgets (ADR-317-DEV operational defaults). 40 turns proved far
@@ -258,43 +263,36 @@ jobs:
           # never `*`, which is documented as unsafe on public repos.
           allowed_bots: 'claude'
           prompt: |
+            /implement-issue ${{ matrix.issue }}
+
+            ↑ Execute the slash command above as your FIRST action. It IS the
+            authoritative procedure (the `implement-issue` skill, CLAUDE.md,
+            CONTRIBUTING.md, and ADR-317-DEV govern everything: DoD attestation,
+            Closes/Refs, Conventional Commits, Husky/quality gates, P1 isolation,
+            traceability, project board, stop conditions). Do not paraphrase or
+            re-derive them — invoke the skill and follow what it tells you.
+
             You are running unattended in CI on branch feature/issue-${{ matrix.issue }}.
             ${{ env.ACT == 'true' && 'LOCAL ACT TEST RUN — make NO remote/GitHub changes: no project-board claim or move, no issue assignment, no label edits, no issue comments, no PR or sub-issue creation, and do NOT git push to any remote. Only read from GitHub, edit files, run the pipeline, and commit locally. (This line is empty on real CI.)' || '' }}
 
-            FIRST ACTION — invoke the repository's `/implement-issue` skill via the
-            Skill tool. This is mandatory and non-negotiable: do NOT paraphrase the
-            workflow, do NOT re-derive it from prose, do NOT skip the tool call.
-            The skill IS the authoritative procedure — call it deterministically:
+            CI-only adaptations (the skill assumes an interactive developer; CI has
+            none, so these four points override / extend the skill's defaults):
 
-                Skill(skill="implement-issue", args="${{ matrix.issue }}")
-
-            Then follow the skill end-to-end. "Done" means every acceptance criterion
-            and every Definition of Done item is genuinely satisfied (code, tests,
-            traceability, docs) — a half-done ticket dressed up as complete is a defect.
-
-            CI-specific overrides on top of the skill (these adapt the skill's output
-            for unattended GitHub Actions execution — the skill itself is unchanged):
-
-            - PR opening: do NOT open the PR yourself. Write the PR body (filled out
-              from `.github/pull_request_template.md`, with the skill's Closes/Refs
-              and DoD logic) to the file `$RUNNER_TEMP/pr-body.md`. The push step
-              below opens the Draft PR using that file verbatim.
-            - Pipeline gate before commit: run `pnpm install --frozen-lockfile`,
-              `pnpm lint`, `pnpm --filter frontend type-check`, `pnpm test:unit`,
-              `pnpm test:integration`, `pnpm build` and fix any failures you introduced
-              so CI is green on the first push.
-            - Hard rules (ADR-317-DEV — do not violate):
-              * Honour every quality gate. NEVER use --no-verify or bypass Husky/ESLint/tests.
-              * Do NOT edit `.github/workflows/**`, repository secrets, or security
-                configuration. Stay within product, docs, trace, and test paths.
-              * Commit on the CURRENT branch using Conventional Commits, incrementally
-                per coherent step. Finish the ENTIRE issue — the turn/time budget is
-                generous; do not stop early or hand off a half-done ticket.
-              * Do NOT mark the PR ready-for-review — the ready-gate flips it once CI
-                is green and the automated review is clean.
-              * Only if a step is genuinely blocked or unsafe: finish every part you
-                safely can, leave unfinished DoD items unticked, use `Refs` (not
-                `Closes`), and write a clear "what remains" summary in the PR body.
+            1. The workflow opens the PR, not you. Write the filled-out body
+               (per `.github/pull_request_template.md`, applying the skill's
+               Closes/Refs + DoD-attestation logic) to `$RUNNER_TEMP/pr-body.md`.
+               Do not run `gh pr create`. Do not mark anything ready-for-review —
+               the ready-gate flips it once CI + the automated review are clean.
+            2. Husky only runs lint-staged on commit, so verify the rest of the
+               pipeline locally before the workflow pushes: `pnpm lint`,
+               `pnpm --filter frontend type-check`, `pnpm test:unit`,
+               `pnpm test:integration`, `pnpm build`. Fix anything you introduced.
+            3. ADR-317-DEV scope guard: do NOT edit `.github/workflows/**`,
+               repository secrets, or security configuration in this run.
+            4. The turn/time budget is generous — finish the ENTIRE issue. If a
+               step is genuinely blocked, complete the rest, follow the skill's
+               stop-condition + Refs-vs-Closes guidance, and explain "what remains"
+               in the PR body file.
           # claude-code-action does NOT grant Bash by default, and CI has no
           # human to approve tool prompts — so without an explicit allow-list the
           # agent's pnpm/git/gh commands are all auto-denied and it produces zero

--- a/.github/workflows/pr-iteration.yml
+++ b/.github/workflows/pr-iteration.yml
@@ -43,12 +43,12 @@ permissions:
   id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
-  # Latest Opus, 1M-context variant + `xhigh` reasoning effort — aligned with
-  # the implementation bot so corrections get the same headroom as the original
-  # write. Wrapped in single quotes so YAML does not parse `[1m]` as a flow
-  # sequence. NOTE: this workflow is currently deactivated (`if: false` on the
-  # job below); these values take effect when it is re-enabled.
-  MODEL: 'claude-opus-4-7[1m]'
+  # Alias form (auto-tracks latest Opus + 1M context) + `xhigh` effort —
+  # aligned with the implementation bot so corrections get the same headroom
+  # as the original write. Wrapped in single quotes so YAML does not parse
+  # `[1m]` as a flow sequence. NOTE: this workflow is currently deactivated
+  # (`if: false` on the job below); these values take effect when re-enabled.
+  MODEL: 'opus[1m]'
   EFFORT: 'xhigh'
   MAX_CORRECTIONS: '2'
   # A correction round runs the full pipeline + fixes; 40 turns proved too small
@@ -231,32 +231,38 @@ jobs:
           prompt: |
             You are correcting Draft PR #${{ steps.ctx.outputs.pr }}
             (correction ${{ steps.ctx.outputs.next }} of ${{ steps.ctx.outputs.max }}).
+            CLAUDE.md, CONTRIBUTING.md, and ADR-317-DEV govern code rules,
+            commits, and quality gates — do not paraphrase them.
 
-            Address ALL outstanding automated feedback on the CURRENT branch:
-            1. The latest PR review's requested changes (read it and its line comments).
-            2. Any failing check — inspect with `gh pr checks ${{ steps.ctx.outputs.pr }}`
-               and `gh run view --log-failed` and fix the ROOT CAUSE (this includes
-               non-CI gates: DoD, Security, Traceability, E2E).
-            3. If the **DoD Attestation Gate** is red, the PR body closes an issue
-               (`Closes`/`Fixes`) that still has unticked DoD items. Either genuinely
-               COMPLETE and tick those items, or — if they cannot be honestly completed
-               here (e.g. human-only) — `gh pr edit` the body to use `Refs #<n>` instead
-               of `Closes`, leave the items unticked, and note what remains. NEVER tick a
-               box you cannot verify, and keep the PR body on the repository template.
+            Address every outstanding piece of automated feedback on the CURRENT
+            branch and fix root causes:
 
-            Before committing, run the local pipeline and make it pass:
-            `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm --filter frontend type-check`,
-            `pnpm test:unit`, `pnpm test:integration`, `pnpm build`. Commit on the CURRENT branch.
+            1. Latest PR review's requested changes (read the review and its line
+               comments).
+            2. Failing checks — `gh pr checks ${{ steps.ctx.outputs.pr }}` then
+               `gh run view --log-failed` on each red run. Includes non-CI gates:
+               DoD, Security, Traceability, E2E.
+            3. DoD Attestation Gate red ⇒ the PR's `Closes`/`Fixes` target has
+               unticked DoD boxes. Either complete and tick them (only when
+               GENUINELY done — never tick a box you cannot verify), or
+               `gh pr edit` the body to `Refs #<n>` and state what remains.
+               Keep the PR body on `.github/pull_request_template.md`.
+            4. Pre-existing failure outside this PR's scope ⇒ do not hack around
+               it. Use `/issue` (or comment on the existing one) to file a
+               deduplicated `Bug`, then note it in the PR.
 
-            Hard rules (ADR-317-DEV — do not violate):
-            - NEVER use --no-verify or bypass any gate.
-            - Do NOT edit .github/workflows/**, secrets, or security configuration.
-            - Do NOT merge, do NOT mark the PR ready-for-review — leave it Draft;
-              the ready-gate flips it automatically once CI is green and review is clean.
-            - For a pre-existing/unrelated CI failure (out of scope), do NOT hack around
-              it — file a deduplicated `Bug` (a new one only if none open tracks it;
-              otherwise comment on the existing one) and note it in the PR.
-            - If you cannot safely converge, stop and summarise what remains.
+            CI-only adaptations:
+
+            - Verify the full pipeline locally before committing (Husky only runs
+              lint-staged): `pnpm lint`, `pnpm --filter frontend type-check`,
+              `pnpm test:unit`, `pnpm test:integration`, `pnpm build`.
+            - ADR-317-DEV scope guard: do NOT edit `.github/workflows/**`,
+              secrets, or security configuration.
+            - Do NOT merge and do NOT mark the PR ready-for-review — leave it
+              Draft. The ready-gate flips it once CI is green and the review is
+              clean.
+            - If you cannot safely converge, stop and summarise what remains in a
+              PR comment.
           claude_args: |
             --model ${{ env.MODEL }}
             --effort ${{ env.EFFORT }}

--- a/.github/workflows/pr-iteration.yml
+++ b/.github/workflows/pr-iteration.yml
@@ -43,7 +43,13 @@ permissions:
   id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
-  MODEL: claude-opus-4-7
+  # Latest Opus, 1M-context variant + `xhigh` reasoning effort — aligned with
+  # the implementation bot so corrections get the same headroom as the original
+  # write. Wrapped in single quotes so YAML does not parse `[1m]` as a flow
+  # sequence. NOTE: this workflow is currently deactivated (`if: false` on the
+  # job below); these values take effect when it is re-enabled.
+  MODEL: 'claude-opus-4-7[1m]'
+  EFFORT: 'xhigh'
   MAX_CORRECTIONS: '2'
   # A correction round runs the full pipeline + fixes; 40 turns proved too small
   # for the implementer (see overnight-implementation.yml), so give corrections
@@ -253,6 +259,7 @@ jobs:
             - If you cannot safely converge, stop and summarise what remains.
           claude_args: |
             --model ${{ env.MODEL }}
+            --effort ${{ env.EFFORT }}
             --max-turns ${{ env.MAX_TURNS }}
             --allowedTools "Bash,Edit,Write,Read,Glob,Grep,Task,TodoWrite,WebFetch,WebSearch,Skill"
 

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -1,31 +1,52 @@
 name: Autonomous PR Reviewer
 
-# Posts a structured automated review on every new PR targeting `develop`
-# (bot- or human-authored). An AID to human review, never a substitute — and
-# never an approval. Governed by ADR-317-DEV.
+# Posts a structured automated review on PRs targeting `develop`, but ONLY
+# after every gating workflow (CI, DoD, Security, Traceability, E2E,
+# Branching, Mutation) has finished on the same commit. Reviewing before the
+# pipeline reports is wasted work: a red CI/DoD result means the PR will get
+# corrected, and the review would just be re-run against a new commit. The
+# review is an AID to human review, never a substitute — and never an approval.
+# Governed by ADR-317-DEV.
 #
-# Fork safety: triggers on `pull_request` (NOT pull_request_target) and only runs
-# the secret-bearing review for SAME-REPO PRs, so secrets never reach untrusted
-# fork code.
+# Fork safety: `workflow_run` runs in the context of the default branch with
+# default-branch secrets, but we still gate on `head_repository == this repo`
+# before checking out PR code, so untrusted fork code never sees secrets.
 # refs #319, #316
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review]
-    branches: [develop]
+  workflow_run:
+    # Trigger on completion of every workflow that gates a PR to `develop`.
+    # The job below then verifies ALL of these have completed on the same head
+    # SHA before posting a review — a single workflow_run firing alone is not
+    # enough. Only includes workflows whose `on:` actually fires for PRs to
+    # develop; main-only gates (Traceability, Governance) and post-merge gates
+    # (Playwright push) are deliberately excluded — they never report a
+    # workflow run on a develop PR's head SHA, so gating on them would
+    # deadlock the reviewer forever.
+    workflows:
+      - CI
+      - DoD Attestation Gate
+      - Security Scanning
+      - Mutation Score (P1 Safety Core)
+    types: [completed]
 
+# Serialise per PR head ref so concurrent gate completions don't double-review.
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: pr-review-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
   pull-requests: write
   issues: read
+  actions: read # list workflow runs to verify all gates have completed
   id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
-  REVIEW_MODEL: claude-opus-4-7
+  # Latest Sonnet — fast enough to keep reviews responsive once the pipeline
+  # turns green, with `high` reasoning effort for thorough finding coverage.
+  REVIEW_MODEL: 'claude-sonnet-4-6'
+  REVIEW_EFFORT: 'high'
   # A full structured review (read diff, walk affected files, cross-check P1
   # isolation + traceability + safety, write findings, submit via `gh pr
   # review`) needs comparable headroom to the implementer and iteration bots.
@@ -34,19 +55,106 @@ env:
   # ready-gate stuck. Aligned with overnight-implementation.yml and
   # pr-iteration.yml at 150 so all three bots share one budget knob.
   MAX_TURNS: '150'
+  # Names of every workflow that must report `completed` on the head SHA
+  # before the review runs. MUST match `on.workflow_run.workflows` above —
+  # the resolve step gates on this list, not on which workflow fired.
+  GATING_WORKFLOWS: |
+    CI
+    DoD Attestation Gate
+    Security Scanning
+    Mutation Score (P1 Safety Core)
 
 jobs:
   review:
     name: Automated review
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Same-repo only: fork PRs do not receive secrets, so skip rather than fail.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    # Only consider PR-triggered runs from THIS repository (skip fork PRs and
+    # branch/tag-triggered runs of the gating workflows). Job-level `if` runs
+    # before any step, so this short-circuits the whole job cleanly.
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
+      # ── Decide whether to actually run the review on this commit ────────────
+      # workflow_run fires once per gating workflow completion, so most firings
+      # are "another gate is still pending — wait." Resolve the PR, verify ALL
+      # gates have completed on this head SHA, and skip if claude[bot] has
+      # already reviewed this exact commit (idempotency across firings).
+      - name: Resolve PR & gate readiness
+        id: gate
+        uses: actions/github-script@v9
+        env:
+          GATING_WORKFLOWS: ${{ env.GATING_WORKFLOWS }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const wr = context.payload.workflow_run;
+            const headSha = wr.head_sha;
+            const headBranch = wr.head_branch;
+            const out = (o) => { for (const [k, v] of Object.entries(o)) core.setOutput(k, String(v)); };
+            const skip = (why) => { core.info(`Skipping review: ${why}`); out({ proceed: 'false' }); };
+
+            // 1) Find the open PR for this head SHA, targeting develop.
+            const prs = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:${headBranch}`, base: 'develop',
+            });
+            const pr = prs.data.find((p) => p.head.sha === headSha) || prs.data[0];
+            if (!pr) return skip(`no open PR for branch ${headBranch}`);
+
+            // 2) Same-repo guard (belt-and-braces — job-level `if` already gates).
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) return skip('fork PR');
+
+            // 3) Verify EVERY gating workflow has a `completed` workflow run on
+            //    this head SHA. A `workflow_run` firing for one gate doesn't
+            //    mean the others are done — review only when the whole pipeline
+            //    has reported. Workflow-run names (not check-run/job names) are
+            //    what `on.workflow_run.workflows` matches on, so the lookup uses
+            //    `actions.listWorkflowRunsForRepo` rather than `checks.listForRef`
+            //    (a multi-job workflow like CI has no single "CI" check run).
+            const required = process.env.GATING_WORKFLOWS
+              .split('\n').map((s) => s.trim()).filter(Boolean);
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner, repo, head_sha: headSha, event: 'pull_request', per_page: 100,
+            });
+            const byName = new Map();
+            for (const r of runs) {
+              // Take the LATEST attempt per workflow name (re-runs replace prior).
+              const prev = byName.get(r.name);
+              if (!prev || new Date(r.run_started_at) > new Date(prev.run_started_at)) {
+                byName.set(r.name, r);
+              }
+            }
+            const missing = required.filter((name) => !byName.has(name));
+            const pending = required.filter((name) => {
+              const r = byName.get(name);
+              return r && r.status !== 'completed';
+            });
+            if (missing.length || pending.length) {
+              return skip(`gates not ready — missing=[${missing.join(', ')}] pending=[${pending.join(', ')}]`);
+            }
+
+            // 4) Idempotency: if claude[bot] has already reviewed this exact
+            //    head SHA, do not post a duplicate. The iteration bot consumes
+            //    the existing review's verdict directly.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const already = reviews.some(
+              (r) => r.commit_id === headSha && r.user?.login === 'claude[bot]',
+            );
+            if (already) return skip('claude[bot] already reviewed this head SHA');
+
+            core.info(`Ready: PR #${pr.number} @ ${headSha.slice(0, 7)}, all ${required.length} gates completed`);
+            out({ proceed: 'true', pr: pr.number, head_sha: headSha, head_ref: headBranch });
+
       # `secrets` cannot be used in a job-level `if`, so gate on a guard step:
       # when auth is not configured (e.g. before operator setup), skip cleanly
       # instead of hard-failing the check on every PR.
       - name: Check auth configured
+        if: ${{ steps.gate.outputs.proceed == 'true' }}
         id: guard
         env:
           OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -58,36 +166,35 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout PR
-        if: ${{ steps.guard.outputs.configured == 'true' }}
+      - name: Checkout PR head
+        if: ${{ steps.gate.outputs.proceed == 'true' && steps.guard.outputs.configured == 'true' }}
         uses: actions/checkout@v5
         with:
+          # workflow_run does not auto-checkout the PR ref — pin to the exact
+          # head SHA we verified above (not the branch, which can advance).
+          ref: ${{ steps.gate.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Review with Claude Code
-        if: ${{ steps.guard.outputs.configured == 'true' }}
+        if: ${{ steps.gate.outputs.proceed == 'true' && steps.guard.outputs.configured == 'true' }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # API-key alternative: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # This workflow triggers on `pull_request: synchronize` (and `opened`/
-          # `reopened`). When the iteration / overnight-implementation bot pushes
-          # a correction commit on a Draft PR, the synchronize event's initiator
-          # is `claude[bot]` — and the action's bot-actor safety gate refuses
-          # non-human initiators by default (prevents bot↔bot loops; see the
-          # action's docs/security.md). That leaves the ready-gate stuck on the
-          # previous, stale `CHANGES_REQUESTED` review.
-          #
-          # Allow ONLY `claude` — never `*`, which is documented as unsafe on
-          # public repos because external Apps could invoke the action with
-          # attacker-controlled prompts. Dependabot / github-actions / other
-          # bots commenting or pushing on a bot branch still cannot initiate a
-          # review round under this allow-list. Mirrors the same fix landed for
-          # `pr-iteration.yml` in #348; addresses #350.
+          # workflow_run runs in the default-branch context; the initiating
+          # actor is the upstream workflow's actor (often `claude[bot]` for
+          # bot-authored PR corrections). The action's bot-actor safety gate
+          # refuses non-human initiators by default — whitelist ONLY `claude`
+          # (never `*`, documented as unsafe on public repos) so reviews fire
+          # both for human PRs and for bot-authored Draft PRs.
           allowed_bots: 'claude'
           prompt: |
-            Review pull request #${{ github.event.pull_request.number }} in this
-            repository and post a single structured PR review.
+            Review pull request #${{ steps.gate.outputs.pr }} in this repository
+            and post a single structured PR review. Every gating workflow (CI,
+            DoD, Security, Traceability, E2E, Branching, Mutation) has already
+            completed on this commit — read their conclusions via
+            `gh pr checks ${{ steps.gate.outputs.pr }}` and factor any failures
+            into your review (do not re-run the pipeline).
 
             Use the repository's `code-review` skill if available; otherwise apply
             its standards. For P1 safety-core changes, also apply the project's P1
@@ -107,9 +214,9 @@ jobs:
               GitHub CLI — the ready-gate depends on this review existing, so do not
               finish without it:
                 * no Blocker/Major findings →
-                  `gh pr review ${{ github.event.pull_request.number }} --comment --body "<review>"`
+                  `gh pr review ${{ steps.gate.outputs.pr }} --comment --body "<review>"`
                 * any Blocker/Major finding →
-                  `gh pr review ${{ github.event.pull_request.number }} --request-changes --body "<review>"`
+                  `gh pr review ${{ steps.gate.outputs.pr }} --request-changes --body "<review>"`
               (For a long review, write it to `$RUNNER_TEMP/review.md` and pass
               `--body-file "$RUNNER_TEMP/review.md"`.)
             - NEVER approve. You are an aid, not an approver — a clean review is a
@@ -121,5 +228,6 @@ jobs:
               only state change you make is submitting the single review above.
           claude_args: |
             --model ${{ env.REVIEW_MODEL }}
+            --effort ${{ env.REVIEW_EFFORT }}
             --max-turns ${{ env.MAX_TURNS }}
             --allowedTools "Bash,Read,Grep,Glob,Write,Task,TodoWrite,WebFetch"

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -43,9 +43,11 @@ permissions:
   id-token: write # required by anthropics/claude-code-action (OIDC)
 
 env:
-  # Latest Sonnet — fast enough to keep reviews responsive once the pipeline
-  # turns green, with `high` reasoning effort for thorough finding coverage.
-  REVIEW_MODEL: 'claude-sonnet-4-6'
+  # Alias form so the bot tracks the LATEST Sonnet automatically (per
+  # code.claude.com/docs/en/model-config: aliases "update over time"). Sonnet
+  # is fast enough to keep reviews responsive once the pipeline turns green;
+  # `high` effort gives thorough finding coverage without the cost of `max`.
+  REVIEW_MODEL: 'sonnet'
   REVIEW_EFFORT: 'high'
   # A full structured review (read diff, walk affected files, cross-check P1
   # isolation + traceability + safety, write findings, submit via `gh pr
@@ -189,43 +191,35 @@ jobs:
           # both for human PRs and for bot-authored Draft PRs.
           allowed_bots: 'claude'
           prompt: |
-            Review pull request #${{ steps.gate.outputs.pr }} in this repository
-            and post a single structured PR review. Every gating workflow (CI,
-            DoD, Security, Traceability, E2E, Branching, Mutation) has already
-            completed on this commit — read their conclusions via
-            `gh pr checks ${{ steps.gate.outputs.pr }}` and factor any failures
-            into your review (do not re-run the pipeline).
+            Review pull request #${{ steps.gate.outputs.pr }} and post ONE
+            structured PR review. Every PR-gating workflow has already completed
+            on this commit — read their conclusions via
+            `gh pr checks ${{ steps.gate.outputs.pr }}` and factor failures into
+            the review. Do not re-run the pipeline.
 
-            Use the repository's `code-review` skill if available; otherwise apply
-            its standards. For P1 safety-core changes, also apply the project's P1
-            PR-review checklist (CONTRIBUTING §8).
+            Apply the `code-review` skill's standards (correctness focus, severity
+            classification) with these safety-critical AeroDash priorities on top
+            (CLAUDE.md + CONTRIBUTING.md §8 are authoritative — do not paraphrase):
 
-            Focus, in priority order:
-            1. Correctness — especially any math feeding a Go/No-Go advisory.
-            2. P1 isolation — no vue/pinia/vue-router import under frontend/src/core/;
-               no [P1-ISOLATION] violations; pure, deterministic, Zod-validated.
+            1. Correctness, especially math feeding a Go/No-Go advisory.
+            2. P1 isolation under `frontend/src/core/` (CLAUDE.md P1/P2/P3 rules).
             3. Safety gates — tests, coverage tiers, traceability tags/registries.
-            4. Architecture (P1/P2/P3 boundaries), then style/nits.
+            4. Architecture, then style/nits.
 
-            Classify each finding by severity: Blocker / Major / Minor / Nit.
+            CI-only hard rules (ADR-317-DEV invariants for the autonomous reviewer):
 
-            Hard rules (ADR-317-DEV — do not violate):
-            - ALWAYS submit exactly ONE formal PR review as your final action via the
-              GitHub CLI — the ready-gate depends on this review existing, so do not
-              finish without it:
+            - Submit EXACTLY ONE formal PR review as your final action — the
+              ready-gate depends on it existing:
                 * no Blocker/Major findings →
-                  `gh pr review ${{ steps.gate.outputs.pr }} --comment --body "<review>"`
+                  `gh pr review ${{ steps.gate.outputs.pr }} --comment --body-file "$RUNNER_TEMP/review.md"`
                 * any Blocker/Major finding →
-                  `gh pr review ${{ steps.gate.outputs.pr }} --request-changes --body "<review>"`
-              (For a long review, write it to `$RUNNER_TEMP/review.md` and pass
-              `--body-file "$RUNNER_TEMP/review.md"`.)
-            - NEVER approve. You are an aid, not an approver — a clean review is a
-              COMMENT, never an approval.
-            - If the PR touches frontend/src/core/ OR carries the `safety-critical`
-              label, begin the review with a bold notice that **human Lead Developer
-              review is mandatory** and that this automated review does not satisfy it.
-            - Do not modify repository code, push commits, or change merge state — the
-              only state change you make is submitting the single review above.
+                  `gh pr review ${{ steps.gate.outputs.pr }} --request-changes --body-file "$RUNNER_TEMP/review.md"`
+            - NEVER approve. A clean review is always `--comment`, never an approval.
+            - If the PR touches `frontend/src/core/` OR carries the `safety-critical`
+              label, open the review body with a bold notice that **human Lead Developer
+              review is mandatory** and this automated pass does not satisfy it.
+            - Read-only on the repo: do not edit files, push commits, or change merge
+              state. The only state change is the single `gh pr review` call above.
           claude_args: |
             --model ${{ env.REVIEW_MODEL }}
             --effort ${{ env.REVIEW_EFFORT }}


### PR DESCRIPTION
### Summary

Updates the three Claude automation workflows so each bot uses the right model + reasoning effort for its job, makes the implementation bot invoke `/implement-issue` deterministically (via the Skill tool, not prose), and keeps the reviewer bot from firing on a commit that's about to be re-pushed by a correction.

- **Implementation bot** (`overnight-implementation.yml`): `claude-opus-4-7[1m]` + `--effort xhigh`; prompt now opens with a **mandatory FIRST-ACTION Skill-tool call** (`Skill(skill=\"implement-issue\", args=\"<n>\")`) instead of paraphrasing the workflow in prose. CI-specific overrides (PR body to `$RUNNER_TEMP/pr-body.md`, no PR opening, ADR-317-DEV hard rules) are layered on top — the skill itself is unchanged.
- **Reviewer bot** (`pr-review-bot.yml`): `claude-sonnet-4-6` + `--effort high`; switched from `pull_request` to `workflow_run` listening for completion of every PR-to-`develop` gating workflow (CI, DoD Attestation Gate, Security Scanning, Mutation Score). A Resolve step re-checks via `actions.listWorkflowRunsForRepo` that **every** required workflow has completed on the head SHA before the review fires, and skips if `claude[bot]` has already reviewed that exact SHA (idempotent across the multiple workflow_run firings as gates finish one by one).
- **Iteration bot** (`pr-iteration.yml`): `claude-opus-4-7[1m]` + `--effort xhigh`, aligned with the implementation bot. Workflow remains deactivated (`if: false` from #397); these values take effect when it's re-enabled.

### Related Issues

- Refs #316, #319, #320

### Issue State Management (Post-Merge)

- N/A — no GitHub issue closed by this PR (chore-only repo config).

### Affected Items

- **Requirements Implemented/Affected:** `N/A` (workflow config only, no requirement impact)

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: no requirement created or changed; bot config tweak).
- [x] **Architecture:** `N/A` (Reason: ADR-317-DEV already governs autonomous AI contribution; no architectural change — model/effort/triggers are operational parameters).
- [x] **Risk Management:** `N/A` (Reason: no new hazard surface; reviewer-gating reduces risk of stale reviews, not introduces new ones).
- [x] **Journeys:** `N/A` (Reason: no user-facing flow).
- [x] **Code Docs:** `N/A` (Reason: CHANGELOG reserved for releases; no README/API surface affected).

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules) — only `.github/workflows/` touched, no source code.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: workflow config; no testable code path in the repo. End-to-end behaviour validated by the bots running on real PRs after merge).
- [x] **Integration Tests:** `N/A` (Reason: same as unit tests).
- [x] **Manual Testing:** `N/A` (Reason: develop target; manual flight-style testing not applicable to bot YAML).
- [x] **DoD:** `N/A` — no linked Feature/Bug issue; this is direct-asked chore work.
- [x] **Review:** Self-reviewed; ran `js-yaml` parse on all three workflows.
- [x] **ADR:** `N/A` — ADR-317-DEV already covers autonomous AI contribution; pinning model variant + reasoning effort + reviewer chaining are operational tunings, not architectural changes.

### Notes on the reviewer chaining design

- `workflow_run` only triggers from workflows that exist on the default branch — `develop` is the default, so the new trigger takes effect once this PR lands.
- The gating list deliberately **excludes** main-only gates (Traceability, Governance) and post-merge gates (Playwright push). They never report a workflow run on a develop PR's head SHA, so gating on them would deadlock the reviewer forever.
- The Mutation workflow's `mutation-score` job is conditional and can be skipped, but the workflow RUN itself still reports `status=completed` — so it counts as a passed gate without re-running Stryker on every non-P1 diff.
- Idempotency check (skip if `claude[bot]` already reviewed this head SHA) prevents duplicate reviews when multiple `workflow_run` events fire close together.