### PR TITLE
feat: [Task]: Enable remaining @wip M&B E2E flows (fleet-seeding fixture + wizard nav/save defects) (#294)

### DIFF
--- a/frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
+++ b/frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
@@ -1,6 +1,8 @@
 <template>
   <!-- @IMP-AC-VIEW-015@ (FROM: @REQ-AC-001@, @REQ-AC-005@, @REQ-AD-001@, @REQ-AD-002@, @REQ-AD-003@, @REQ-AD-004@, @REQ-AD-005@, @REQ-AD-007@, @REQ-AD-011@, @REQ-AD-012@, @REQ-AD-013@, @REQ-AD-014@, @REQ-AD-018@, @REQ-AD-019@) -->
-  <main class="profile-editor-view">
+  <!-- Plain <div>, not <main>: nested inside the App shell's single <main>
+       landmark (refs #294). -->
+  <div class="profile-editor-view">
     <header class="editor-header">
       <div class="editor-title">
         <button type="button" class="btn-back" @click="onCancel">← Back to Fleet</button>
@@ -116,7 +118,7 @@
         </button>
       </div>
     </footer>
-  </main>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/modules/aircraft/views/AircraftProfileWizardView.vue
+++ b/frontend/src/modules/aircraft/views/AircraftProfileWizardView.vue
@@ -1,6 +1,9 @@
 <!-- @IMP-AC-VIEW-WIZARD-001@ (FROM: @REQ-AC-001@, @REQ-UQ-003@) -->
 <template>
-  <main class="wizard-view">
+  <!-- Plain <div>, not <main>: routed views live inside the App shell's single
+       <main> landmark. A nested <main> breaks getByRole('main') and is an a11y
+       landmark defect (refs #294). -->
+  <div class="wizard-view">
     <header class="wizard-header">
       <button type="button" class="btn-back" @click="onNavigateBack">← Back to Fleet</button>
       <h1>Add New Aircraft</h1>
@@ -223,7 +226,7 @@
       @choose="onPostSaveChoice"
       @dismiss="onPostSaveDismiss"
     />
-  </main>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/modules/aircraft/views/FleetManagementView.vue
+++ b/frontend/src/modules/aircraft/views/FleetManagementView.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- @IMP-AC-VIEW-007@ (FROM: @REQ-AC-001@, @REQ-AC-004@, @REQ-AC-005@, @REQ-AC-006@) -->
-  <main class="fleet-management-view">
+  <!-- Routed views render inside the App shell's single <main> landmark, so this
+       root is a plain <div> — a nested second <main> breaks getByRole('main')
+       (strict-mode) and is an a11y landmark defect (refs #294). -->
+  <div class="fleet-management-view">
     <h1>Aircraft Fleet Management</h1>
 
     <!-- Notifications banner -->
@@ -60,7 +63,7 @@
         </div>
       </div>
     </section>
-  </main>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/views/ContributeView.vue
+++ b/frontend/src/views/ContributeView.vue
@@ -64,7 +64,9 @@ function onSubmitFeature(input: FeatureRequestInput): void {
 </script>
 
 <template>
-  <main class="contribute-view" aria-labelledby="contribute-heading">
+  <!-- Labelled <section> region, not <main>: nested inside the App shell's single
+       <main> landmark (refs #294). -->
+  <section class="contribute-view" aria-labelledby="contribute-heading">
     <header class="contribute-view__header">
       <h1 id="contribute-heading">{{ heading }}</h1>
       <p v-if="screen === 'category'" class="contribute-view__intro">
@@ -121,7 +123,7 @@ function onSubmitFeature(input: FeatureRequestInput): void {
     </div>
 
     <ContributePromotionPanel data-testid="contribute-promotion" />
-  </main>
+  </section>
 </template>
 
 <style scoped>

--- a/frontend/src/views/PrivacyView.vue
+++ b/frontend/src/views/PrivacyView.vue
@@ -154,7 +154,9 @@ function onCancelWipe(): void {
 </script>
 
 <template>
-  <main class="privacy-view" aria-labelledby="privacy-heading">
+  <!-- Labelled <section> region, not <main>: nested inside the App shell's single
+       <main> landmark (refs #294). -->
+  <section class="privacy-view" aria-labelledby="privacy-heading">
     <header class="privacy-view__header">
       <h1 id="privacy-heading">Privacy &amp; Local Data</h1>
       <p class="privacy-view__intro">
@@ -353,7 +355,7 @@ function onCancelWipe(): void {
         </div>
       </div>
     </div>
-  </main>
+  </section>
 </template>
 
 <style scoped>

--- a/frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/aircraft-wizard-creation.feature
@@ -1,4 +1,4 @@
-@wip @phase-A @fleet @wizard
+@phase-A @fleet @wizard
 Feature: Aircraft creation wizard
   As a pilot
   I want to create a new aircraft profile via a guided 5-step wizard
@@ -38,11 +38,15 @@ Feature: Aircraft creation wizard
     Then the wizard is on Step 5 — Review and Save
 
     When the pilot clicks "Save as Draft"
+    And the pilot returns to the fleet from the saved-aircraft options
     Then the pilot is back on the Fleet page
     And the aircraft "D-EBPN" is listed with a "Draft" status badge
 
   # @E2E-A-003@ (FROM: @UJ-A-001@)
-  @UJ-A-001 @phase-A @e2e @E2E-A-003
+  # @wip: blocked by a separate EnvelopeSection defect (cannot reduce below the
+  # 4-point minimum via the ✕ remove buttons) — out of scope for #294 (fleet
+  # seeding + duplicate-<main> + wizard nav). Un-wip once that is fixed.
+  @wip @UJ-A-001 @phase-A @e2e @E2E-A-003
   Scenario: Pilot cannot advance past Step 2 with fewer than 4 envelope points — Continue is disabled and an error is visible
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"

--- a/frontend/tests/e2e/features/phase-a-fleet-management/certification-category-switch.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/certification-category-switch.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Switch certification category and enforce utility constraints
   As a pilot
   I want category-specific limits and stations to update when I change certification category

--- a/frontend/tests/e2e/features/phase-a-fleet-management/decimal-input-precision.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/decimal-input-precision.feature
@@ -1,3 +1,8 @@
+# @wip: blocked by separate DecimalInput defects in the wizard (comma→period BEM
+# normalisation, and the Arm field on a newly-added load station) — out of scope
+# for #294 (fleet seeding + duplicate-<main> + wizard nav). The duplicate-<main>
+# + wizard-nav fixes do unblock the Background here; un-wip once the DecimalInput
+# precision behaviour is fixed.
 @wip @phase-A @fleet @wizard @decimal
 Feature: Decimal input precision in the aircraft wizard
   As a pilot

--- a/frontend/tests/e2e/features/phase-a-fleet-management/electric-aircraft-wizard.feature
+++ b/frontend/tests/e2e/features/phase-a-fleet-management/electric-aircraft-wizard.feature
@@ -1,4 +1,4 @@
-@wip @phase-A @fleet @wizard @electric
+@phase-A @fleet @wizard @electric
 Feature: Battery-electric aircraft wizard (Pipistrel Velis Electro)
   As a pilot / flight-school instructor
   I want to add a Pipistrel Velis Electro to the fleet without seeing fuel fields
@@ -6,7 +6,11 @@ Feature: Battery-electric aircraft wizard (Pipistrel Velis Electro)
   And so that the combustion UX for the rest of my fleet is unchanged
 
   # @E2E-A-007@ (FROM: @UJ-A-004@)
-  @UJ-A-004 @phase-A @e2e @smoke @E2E-A-007
+  # @wip: blocked by a separate electric-wizard defect (the build never reaches
+  # Step 5 — Pipistrel powertrain auto-flip / Battery-Pack step), out of scope
+  # for #294. The combustion control scenario (A-008) below passes and proves the
+  # duplicate-<main> + wizard-nav fixes. Un-wip once the electric path is fixed.
+  @wip @UJ-A-004 @phase-A @e2e @smoke @E2E-A-007
   Scenario: Pilot creates a Pipistrel Velis Electro, the wizard flips to electric and fuel UI is hidden
     Given the pilot navigates to the Fleet page
     When the pilot clicks "Add New Aircraft"
@@ -42,6 +46,7 @@ Feature: Battery-electric aircraft wizard (Pipistrel Velis Electro)
     And the review shows battery pack usable energy "24.8"
 
     When the pilot clicks "Save as Draft"
+    And the pilot returns to the fleet from the saved-aircraft options
     Then the pilot is back on the Fleet page
     And the aircraft "OK-VVV" is listed with a "Draft" status badge
 

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/burn-sequence-polygon.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/burn-sequence-polygon.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Reveal CG migration risk across burn sequences
   As a pilot
   I want to see CG behavior under all fuel burn sequences

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/burnout-check.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/burnout-check.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Detect CG migration during fuel burn-off
   As a pilot
   I want to discover unsafe CG migration before flight

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/fleet-based-aircraft-selection.feature
@@ -15,8 +15,11 @@ Feature: Fleet-based aircraft selection on the Flight Prep page
     Then the pilot is taken to the aircraft creation wizard
 
   # @E2E-B-009@ (FROM: @UJ-B-005@)
-  # @wip: depends on the wizard-creation flow (completeWizardFlow helper), which is
-  # not yet stable end-to-end — un-wip together with aircraft-wizard-creation.feature.
+  # @wip: superseded by the H-011 draft-acknowledgement gate — selecting a Draft
+  # now routes through the inline ack (M&B stays locked until acknowledged), so
+  # "the M&B section becomes unlocked" on a bare select no longer holds. The
+  # correct behaviour is covered by E2E-B-011 below (which passes). Out of scope
+  # for #294; remove or rewrite B-009 to reflect the ack gate.
   @wip @UJ-B-005 @phase-B @e2e @E2E-B-009
   Scenario: Aircraft added via wizard appears in the Flight Prep dropdown with a [Draft] label
     Given the pilot has added an aircraft with registration "D-EBPN" via the wizard
@@ -28,9 +31,7 @@ Feature: Fleet-based aircraft selection on the Flight Prep page
     Then the M&B section becomes unlocked
 
   # @E2E-B-011@ (FROM: @UJ-B-005@)
-  # @wip: depends on the wizard-creation flow (completeWizardFlow helper), which is
-  # not yet stable end-to-end — un-wip together with aircraft-wizard-creation.feature.
-  @wip @UJ-B-005 @phase-B @e2e @E2E-B-011
+  @UJ-B-005 @phase-B @e2e @E2E-B-011
   Scenario: Selecting a draft aircraft requires acknowledging the unverified-data warning
     Given the pilot has added an aircraft with registration "D-EBPN" via the wizard
     When the pilot navigates to the Flight Prep page

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/happy-path.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/happy-path.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Complete a textbook flight preparation without warnings
   As a pilot
   I want to prepare a flight without warnings or inconsistencies

--- a/frontend/tests/e2e/features/phase-b-flight-preparation/overweight-discovery.feature
+++ b/frontend/tests/e2e/features/phase-b-flight-preparation/overweight-discovery.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Discover structural mass limit violations
   As a pilot
   I want to be warned about all structural mass limits

--- a/frontend/tests/e2e/fixtures/fleet-seed.ts
+++ b/frontend/tests/e2e/fixtures/fleet-seed.ts
@@ -1,0 +1,470 @@
+// @IMP-AC-TEST-FIXTURE-002@ (FROM: @REQ-AC-001@, @REQ-MB-002@)
+//
+// E2E fleet-seeding fixture (refs #294).
+//
+// The Flight-Prep page now reads its aircraft dropdown from the IndexedDB fleet
+// (`fleetStore.profiles`), not the legacy hardcoded `AIRCRAFT_CATALOGUE`. The
+// four critical Mass & Balance journeys (happy-path, overweight-discovery,
+// burnout-check, burn-sequence-polygon) each `select aircraft "D-…"` a
+// pre-existing registration that no test created — so they could never pass.
+//
+// `seedFleet()` writes the registrations below directly into the
+// `aerodash-fleet` IndexedDB store *before* the M&B view hydrates, so the
+// dropdown is populated when the scenario runs. The four airframes mirror the
+// known-good values in `src/modules/mass-balance/data/aircraft-catalogue.ts`
+// (the data the journeys were authored against) translated into the
+// `AircraftProfile` (fleet aggregate-root) field names — `bem`/`mtom` rather
+// than `basicEmptyMass`/`maxTakeoffMass`.
+//
+// Each profile is seeded as `verified` with NO `verification` provenance block,
+// i.e. "verified-unattributed": `evaluateVerificationFreshness` returns
+// `requiresReverification: false`, so selecting it loads straight into the M&B
+// store with no draft/expired acknowledgement gate (which the math journeys do
+// not drive). Documents are validated against `AircraftProfileSchema` on read
+// by the repository's migration registry — an invalid seed is dropped, which
+// surfaces immediately as an empty dropdown.
+
+import type { Page } from '@playwright/test'
+import type { AircraftProfile } from '../../../src/core/adapters/aircraft.schema'
+
+// Mirror of `fleet.repository.ts` storage coordinates. Kept inline (not imported)
+// because the seed runs in the browser page context via `page.evaluate`.
+const DB_NAME = 'aerodash-fleet'
+const DB_VERSION = 2
+const STORE_NAME = 'aircraft_profiles'
+
+/** Shared owner for every seeded airframe — value is irrelevant to M&B math. */
+const SEED_OWNER_ID = '00000000-0000-4000-8000-000000000000'
+
+/**
+ * D-EBPN — Tecnam P2008 JC. Happy-path (E2E-B-001 / UJ-B-005):
+ * Pilot & Passenger / Baggage / Fuel within limits → VERIFIED SAFE.
+ */
+const TECNAM_P2008_DEBPN: AircraftProfile = {
+  id: '11111111-1111-4111-8111-111111111111',
+  ownerId: SEED_OWNER_ID,
+  registration: 'D-EBPN',
+  manufacturer: 'Tecnam',
+  model: 'P2008 JC',
+  icaoTypeDesignator: 'P208',
+  sourceUnit: 'kg',
+  referenceDatumDescription: 'Wing leading edge',
+  referenceDatumLocation: 'Datum',
+  shareCode: null,
+  status: 'verified',
+  schemaVersion: 1,
+  passengerProfiles: [],
+  powertrain: 'combustion',
+  weighingReports: [
+    { bem: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+  ],
+  loadPoints: [
+    {
+      name: 'Pilot & Passenger',
+      arm: 1.8,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 90,
+      unit: 'kg',
+      allowableCategories: ['Normal'],
+      fuelTank: null,
+    },
+    {
+      name: 'Baggage',
+      arm: 2.417,
+      armLookup: [],
+      operationalLimit: 20,
+      defaultQuantity: 5,
+      unit: 'kg',
+      allowableCategories: ['Normal'],
+      fuelTank: null,
+    },
+    {
+      name: 'Fuel',
+      arm: 2.209,
+      armLookup: [],
+      operationalLimit: 75,
+      defaultQuantity: 60,
+      unit: 'kg',
+      allowableCategories: ['Normal'],
+      fuelTank: {
+        unusableFuel: 3,
+        permissibleFuelTypes: ['MoGas', 'AvGas 100LL'],
+        burnSequences: [],
+      },
+    },
+  ],
+  certificationCategories: [
+    {
+      category: 'Normal',
+      mtom: 650,
+      maxZeroFuelMass: null,
+      graphType: 'arm',
+      envelope: [
+        { armOrMoment: 1.841, mass: 432 },
+        { armOrMoment: 1.841, mass: 650 },
+        { armOrMoment: 1.978, mass: 650 },
+        { armOrMoment: 1.978, mass: 432 },
+      ],
+    },
+  ],
+}
+
+/**
+ * D-ECSM — Cessna 172S Skyhawk SP. Overweight-discovery (E2E-B-004/005,
+ * UJ-B-003) and certification-category-switch (E2E-A-001, UJ-A-003):
+ * MTOM/MZFM limits, Normal vs Utility category, Normal-only rear seats.
+ */
+const CESSNA_172S_DECSM: AircraftProfile = {
+  id: '22222222-2222-4222-8222-222222222222',
+  ownerId: SEED_OWNER_ID,
+  registration: 'D-ECSM',
+  manufacturer: 'Cessna',
+  model: '172S Skyhawk SP',
+  icaoTypeDesignator: 'C172',
+  sourceUnit: 'kg',
+  referenceDatumDescription: 'Forward datum (36.4 in ahead of firewall)',
+  referenceDatumLocation: 'Forward datum',
+  shareCode: null,
+  status: 'verified',
+  schemaVersion: 1,
+  passengerProfiles: [],
+  powertrain: 'combustion',
+  weighingReports: [
+    { bem: 680, emptyCg: 2.083, weighingDate: '2025-09-15', validFrom: '2025-09-15' },
+  ],
+  loadPoints: [
+    {
+      name: 'Front Seats',
+      arm: 2.045,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Rear Seats',
+      arm: 2.997,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: ['Normal'],
+      fuelTank: null,
+    },
+    {
+      name: 'Baggage Area 1',
+      arm: 3.607,
+      armLookup: [],
+      operationalLimit: 54,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Baggage Area 2',
+      arm: 3.886,
+      armLookup: [],
+      operationalLimit: 23,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Fuel Tanks',
+      arm: 2.413,
+      armLookup: [],
+      operationalLimit: 153,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: {
+        unusableFuel: 6,
+        permissibleFuelTypes: ['AvGas 100LL', 'AvGas UL91'],
+        burnSequences: [{ sequenceName: 'Standard', ordinalPosition: 1 }],
+      },
+    },
+  ],
+  certificationCategories: [
+    {
+      category: 'Normal',
+      mtom: 1111,
+      maxZeroFuelMass: 1085,
+      graphType: 'arm',
+      envelope: [
+        { armOrMoment: 2.021, mass: 680 },
+        { armOrMoment: 2.085, mass: 800 },
+        { armOrMoment: 2.085, mass: 1111 },
+        { armOrMoment: 2.362, mass: 1111 },
+        { armOrMoment: 2.362, mass: 680 },
+      ],
+    },
+    {
+      category: 'Utility',
+      mtom: 953,
+      maxZeroFuelMass: null,
+      graphType: 'arm',
+      envelope: [
+        { armOrMoment: 2.021, mass: 680 },
+        { armOrMoment: 2.085, mass: 800 },
+        { armOrMoment: 2.085, mass: 953 },
+        { armOrMoment: 2.286, mass: 953 },
+        { armOrMoment: 2.286, mass: 680 },
+      ],
+    },
+  ],
+}
+
+/**
+ * D-EAMB — Piper PA-28-161 Warrior III. Burnout-check (E2E-B-002/003, UJ-B-001):
+ * aft CG migration during fuel burn-off, resolved by redistributing forward.
+ */
+const PIPER_PA28_DEAMB: AircraftProfile = {
+  id: '33333333-3333-4333-8333-333333333333',
+  ownerId: SEED_OWNER_ID,
+  registration: 'D-EAMB',
+  manufacturer: 'Piper',
+  model: 'PA-28-161 Warrior III',
+  icaoTypeDesignator: 'P28A',
+  sourceUnit: 'kg',
+  referenceDatumDescription: 'Wing leading edge',
+  referenceDatumLocation: 'Datum',
+  shareCode: null,
+  status: 'verified',
+  schemaVersion: 1,
+  passengerProfiles: [],
+  powertrain: 'combustion',
+  weighingReports: [
+    { bem: 556, emptyCg: 2.16, weighingDate: '2025-06-12', validFrom: '2025-06-12' },
+  ],
+  loadPoints: [
+    {
+      name: 'Front Seats',
+      arm: 2.054,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Rear Seats',
+      arm: 2.921,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Baggage',
+      arm: 3.556,
+      armLookup: [],
+      operationalLimit: 91,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Fuel Tanks',
+      arm: 1.87,
+      armLookup: [],
+      operationalLimit: 131,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: {
+        unusableFuel: 3,
+        permissibleFuelTypes: ['AvGas 100LL', 'AvGas UL91'],
+        burnSequences: [{ sequenceName: 'Standard', ordinalPosition: 1 }],
+      },
+    },
+  ],
+  certificationCategories: [
+    {
+      category: 'Normal',
+      mtom: 1055,
+      maxZeroFuelMass: null,
+      graphType: 'arm',
+      envelope: [
+        { armOrMoment: 2.08, mass: 556 },
+        { armOrMoment: 2.13, mass: 1055 },
+        { armOrMoment: 2.37, mass: 1055 },
+        { armOrMoment: 2.37, mass: 556 },
+      ],
+    },
+  ],
+}
+
+/**
+ * D-EMTK — Robin DR400/120 Petit Prince. Burn-sequence-polygon (E2E-B-006/007,
+ * UJ-B-004): forward + aft tanks with two burn sequences reveal a CG-migration
+ * polygon that a single-line trend hides.
+ */
+const ROBIN_DR400_DEMTK: AircraftProfile = {
+  id: '44444444-4444-4444-8444-444444444444',
+  ownerId: SEED_OWNER_ID,
+  registration: 'D-EMTK',
+  manufacturer: 'Robin',
+  model: 'DR400/120 Petit Prince',
+  icaoTypeDesignator: 'DR40',
+  sourceUnit: 'kg',
+  referenceDatumDescription: 'Wing leading edge',
+  referenceDatumLocation: 'Datum',
+  shareCode: null,
+  status: 'verified',
+  schemaVersion: 1,
+  passengerProfiles: [],
+  powertrain: 'combustion',
+  weighingReports: [
+    { bem: 560, emptyCg: 1.8, weighingDate: '2025-04-20', validFrom: '2025-04-20' },
+  ],
+  loadPoints: [
+    {
+      name: 'Front Seats',
+      arm: 1.6,
+      armLookup: [],
+      operationalLimit: 200,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Rear Seats',
+      arm: 2.7,
+      armLookup: [],
+      operationalLimit: 120,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Baggage',
+      arm: 3.4,
+      armLookup: [],
+      operationalLimit: 30,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: null,
+    },
+    {
+      name: 'Forward Tank',
+      arm: 0.8,
+      armLookup: [],
+      operationalLimit: 43,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: {
+        unusableFuel: 1,
+        permissibleFuelTypes: ['AvGas 100LL', 'AvGas UL91'],
+        burnSequences: [
+          { sequenceName: 'Standard', ordinalPosition: 2 },
+          { sequenceName: 'Alternative', ordinalPosition: 1 },
+        ],
+      },
+    },
+    {
+      name: 'Aft Tank',
+      arm: 3.2,
+      armLookup: [],
+      operationalLimit: 43,
+      defaultQuantity: 0,
+      unit: 'kg',
+      allowableCategories: null,
+      fuelTank: {
+        unusableFuel: 1,
+        permissibleFuelTypes: ['AvGas 100LL', 'AvGas UL91'],
+        burnSequences: [
+          { sequenceName: 'Standard', ordinalPosition: 1 },
+          { sequenceName: 'Alternative', ordinalPosition: 2 },
+        ],
+      },
+    },
+  ],
+  certificationCategories: [
+    {
+      category: 'Normal',
+      mtom: 900,
+      maxZeroFuelMass: null,
+      graphType: 'arm',
+      envelope: [
+        { armOrMoment: 1.55, mass: 560 },
+        { armOrMoment: 1.65, mass: 900 },
+        { armOrMoment: 1.97, mass: 900 },
+        { armOrMoment: 1.97, mass: 560 },
+      ],
+    },
+  ],
+}
+
+/** The four pre-seeded airframes the @module-mb Flight-Prep journeys select. */
+export const MB_E2E_FLEET: readonly AircraftProfile[] = [
+  TECNAM_P2008_DEBPN,
+  CESSNA_172S_DECSM,
+  PIPER_PA28_DEAMB,
+  ROBIN_DR400_DEMTK,
+]
+
+/**
+ * Seed the given AircraftProfile documents into the app's IndexedDB fleet store
+ * for the current browser context. Must run before the M&B view hydrates its
+ * fleet (i.e. before the scenario navigates to `/mass-balance`).
+ *
+ * Self-contained: opens `aerodash-fleet` at the repository's version and creates
+ * the object store + indexes if the app has not already, then `put`s each
+ * record in a single readwrite transaction. Resolves once the transaction
+ * commits, guaranteeing the records are durable before the next navigation.
+ */
+export async function seedFleet(
+  page: Page,
+  profiles: readonly AircraftProfile[] = MB_E2E_FLEET,
+): Promise<void> {
+  // IndexedDB is per-origin: navigate onto the app origin first. The home route
+  // does not touch the fleet DB, so this never races the app's own loader.
+  if (new URL(page.url() || 'about:blank').protocol === 'about:') {
+    await page.goto('/')
+  }
+
+  await page.evaluate(
+    async ({ dbName, dbVersion, storeName, records }) => {
+      const db = await new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open(dbName, dbVersion)
+        req.onupgradeneeded = () => {
+          const database = req.result
+          if (!database.objectStoreNames.contains(storeName)) {
+            const store = database.createObjectStore(storeName, { keyPath: 'id' })
+            store.createIndex('ownerId', 'ownerId', { unique: false })
+            store.createIndex('registration', 'registration', { unique: false })
+          }
+        }
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      })
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const tx = db.transaction(storeName, 'readwrite')
+          const store = tx.objectStore(storeName)
+          for (const record of records) store.put(record)
+          tx.oncomplete = () => resolve()
+          tx.onerror = () => reject(tx.error)
+          tx.onabort = () => reject(tx.error)
+        })
+      } finally {
+        db.close()
+      }
+    },
+    { dbName: DB_NAME, dbVersion: DB_VERSION, storeName: STORE_NAME, records: profiles },
+  )
+}

--- a/frontend/tests/e2e/steps/aircraft-wizard.steps.ts
+++ b/frontend/tests/e2e/steps/aircraft-wizard.steps.ts
@@ -197,6 +197,27 @@ Then('the wizard is on Step 5 — Review and Save', async ({ page }) => {
   await expect(page.getByRole('heading', { name: /Step 5.*Review/i })).toBeVisible()
 })
 
+// ─── Post-save action chooser (UX-012) ─────────────────────────────────────
+// Saving a draft no longer drops the pilot straight back on the fleet list —
+// it opens an in-app chooser ("Start flight prep" / "Verify now" / "Back to
+// Fleet"). Drive the "Back to Fleet" path so the journey returns to /fleet.
+
+/** Click "Back to Fleet" in the post-save chooser dialog and wait for /fleet. */
+export async function returnToFleetFromPostSave(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  // Scope to the modal so we don't collide with the wizard header's
+  // "← Back to Fleet" button, which is still in the DOM behind the dialog.
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Back to Fleet' }).click()
+  await expect(page).toHaveURL(/\/fleet$/)
+}
+
+When('the pilot returns to the fleet from the saved-aircraft options', async ({ page }) => {
+  await returnToFleetFromPostSave(page)
+})
+
 // ─── Post-save assertions ──────────────────────────────────────────────────
 
 Then('the pilot is back on the Fleet page', async ({ page }) => {
@@ -353,6 +374,6 @@ export async function completeWizardFlow(
   await expect(page.getByRole('heading', { name: /Step 5/i })).toBeVisible()
   await page.getByRole('button', { name: 'Save as Draft' }).click()
 
-  // Back on fleet page
-  await expect(page).toHaveURL(/\/fleet$/)
+  // Post-save chooser (UX-012) → return to the fleet list.
+  await returnToFleetFromPostSave(page)
 }

--- a/frontend/tests/e2e/steps/fleet-management.steps.ts
+++ b/frontend/tests/e2e/steps/fleet-management.steps.ts
@@ -6,10 +6,24 @@ const { When, Then } = createBdd()
 // ─── When steps — Certification category switch (UJ-A-003) ─────────────────
 
 When('loads a pilot, a rear passenger, and training fuel', async ({ page }) => {
-  await page.getByLabel('Front Seats').fill('90')
-  await page.getByLabel('Rear Seats').fill('110')
-  await page.getByLabel('Fuel Tanks').fill('100')
+  // Target the DecimalInput station fields by role+exact-name: getByLabel('Front
+  // Seats') also matches the field's <label>, its presets group and preset
+  // buttons (strict-mode violation) — refs #294.
+  await fillStationField(page, 'Front Seats', '90')
+  await fillStationField(page, 'Rear Seats', '110')
+  await fillStationField(page, 'Fuel Tanks', '100')
 })
+
+/** Fill a Mass & Balance station's decimal text field by its accessible name. */
+async function fillStationField(
+  page: import('@playwright/test').Page,
+  label: string,
+  value: string,
+): Promise<void> {
+  const input = page.getByRole('textbox', { name: label, exact: true })
+  await input.fill(value)
+  await input.dispatchEvent('input')
+}
 
 When(
   'the pilot switches the certification category to {string}',

--- a/frontend/tests/e2e/steps/fleet-seed.hooks.ts
+++ b/frontend/tests/e2e/steps/fleet-seed.hooks.ts
@@ -1,0 +1,19 @@
+// E2E Before hook — seeds the IndexedDB fleet with the pre-existing aircraft the
+// Mass & Balance journeys select. Scoped to `@module-mb` scenarios so only the
+// flows that `select aircraft "D-…"` a pre-seeded registration pay the cost
+// (refs #294). The four math journeys (happy-path, overweight-discovery,
+// burnout-check, burn-sequence-polygon) and the certification-category-switch
+// flow all carry the `@module-mb` tag.
+//
+// The fleet/IndexedDB is isolated per Playwright browser context, so the seed
+// is fresh for every scenario and never leaks into the wizard-creation flows
+// (which deliberately start from an empty fleet).
+
+import { createBdd } from 'playwright-bdd'
+import { seedFleet, MB_E2E_FLEET } from '../fixtures/fleet-seed'
+
+const { Before } = createBdd()
+
+Before({ tags: '@module-mb' }, async ({ page }) => {
+  await seedFleet(page, MB_E2E_FLEET)
+})

--- a/frontend/tests/e2e/steps/flight-preparation.steps.ts
+++ b/frontend/tests/e2e/steps/flight-preparation.steps.ts
@@ -6,10 +6,11 @@ const { When, Then } = createBdd()
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 async function fillStation(page: import('@playwright/test').Page, label: string, value: string) {
-  // .mass-station-input: compound component has no single ARIA role; label-scoped CSS is the narrowest viable locator
-  const input = page
-    .locator('.mass-station-input', { has: page.locator('label', { hasText: label }) })
-    .locator('input[type="number"]')
+  // The station field is a DecimalInput: a sanitised decimal text input
+  // (type="text", inputmode="decimal"), NOT input[type="number"]. Its <label for>
+  // gives it role=textbox with the station name as accessible name, so target it
+  // by role+name — exact so "Baggage" never matches "Baggage Area 1/2" (refs #294).
+  const input = page.getByRole('textbox', { name: label, exact: true })
   await input.fill(value)
   await input.dispatchEvent('input')
 }
@@ -77,8 +78,15 @@ When('fills both fuel tanks to capacity', async ({ page }) => {
 })
 
 When('the pilot moves the passenger forward and reduces aft baggage', async ({ page }) => {
-  await fillStation(page, 'Front Seats', '160')
-  await fillStation(page, 'Rear Seats', '0')
+  // Move most of the rear-passenger mass forward and trim aft baggage. The rear
+  // occupant is kept at a small but non-zero mass on purpose: zeroing a required
+  // (non-fuel) station trips WARN-UQ-001 "Implausible mass on required station"
+  // (REQ-UQ-006), which post-dates this journey and would hold the result at
+  // WARNING. With a plausible rear mass the burn-sequence CG migration is
+  // resolved and the result reaches VERIFIED SAFE — the behaviour this journey
+  // asserts (refs #294).
+  await fillStation(page, 'Front Seats', '140')
+  await fillStation(page, 'Rear Seats', '20')
   await fillStation(page, 'Baggage', '10')
 })
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
### Summary

Enables the remaining `@wip` Mass & Balance E2E journeys by fixing the three blockers named in #294.

- **Fleet-seeding fixture** (`tests/e2e/fixtures/fleet-seed.ts` + `steps/fleet-seed.hooks.ts`): seeds the four pre-existing registrations (`D-EBPN`, `D-ECSM`, `D-EAMB`, `D-EMTK`) into IndexedDB as `verified` profiles for `@module-mb` scenarios. The Flight-Prep dropdown reads `fleetStore.profiles` (not the legacy catalogue), so these journeys had no aircraft to select. Values mirror `aircraft-catalogue.ts`, translated to the `AircraftProfile` shape; schema-validity verified.
- **Duplicate `<main>` landmark**: routed views (`FleetManagementView`, `AircraftProfileWizardView`, `AircraftProfileEditorView`, `PrivacyView`, `ContributeView`) each rendered a second `<main>` nested inside the App shell's `<main>` — a `getByRole('main')` strict-mode violation and an a11y landmark defect. Converted to `<div>` / labelled `<section>`.
- **Wizard save → /fleet**: footer "Save as Draft" opens the UX-012 post-save chooser (not a direct redirect). The E2E flow now drives "Back to Fleet" via a scoped step + `completeWizardFlow` helper.
- **`fillStation` locator fix**: station fields are `DecimalInput` (`type="text"`, role `textbox`), not `input[type="number"]` — retargeted by role + exact accessible name.
- **Un-`@wip`**: the four critical M&B journeys (happy-path, overweight-discovery, burnout-check, burn-sequence-polygon) plus certification-category-switch and the wizard scenarios the fixes unblock (A-002, A-004, A-008, B-011). Scenarios blocked by *separate, pre-existing* defects stay `@wip` with inline reasons — see **What remains**.
- **B-007 redistribution**: kept the rear occupant plausibly non-zero (Front 140 / Rear 20 / Baggage 10). Zeroing a required station trips the post-authoring `WARN-UQ-001` plausibility warning (REQ-UQ-006); the burn-sequence CG migration is still resolved → `VERIFIED SAFE`, verified through the real store→core pipeline.

No P1 (`src/core/`) changes; no math changes.

### Related Issues

- Closes #294

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-MB-002`, `REQ-AC-001`, `REQ-AC-005`, `REQ-UQ-006` (existing — now exercised end-to-end by the un-`@wip` journeys; none newly implemented or status-changed). Journeys: `UJ-B-001`, `UJ-B-003`, `UJ-B-004`, `UJ-B-005`, `UJ-A-003`. Hazard `H-011` mitigation (draft-ack gate) preserved.

### Documentation Updates

- [x] **Requirements:** `N/A` (Reason: enables E2E coverage of existing requirements; no requirement added/changed)
- [x] **Architecture:** `N/A` (Reason: no architectural change; views remain P2/P3)
- [x] **Risk Management:** `N/A` (Reason: no hazard added/changed; H-011 mitigation preserved)
- [x] **Journeys:** `N/A` (Reason: existing UJs/E2E tags unchanged; only `@wip` removed)
- [x] **Code Docs:** `N/A` (Reason: CHANGELOG reserved for release process per implement-issue skill; new fixture/hook self-documented)

### Safety Considerations

- [x] Checked Safety Traceability Matrix. (Trace structural gate green: "no new violations"; E2E `@E2E-…@` tags and registries unchanged.)
- [x] No new hazards introduced.
- [x] Existing mitigations preserved. (H-011 draft-ack gate and REQ-UQ-006 zero-mass plausibility check left intact — B-007 input adjusted *to* the plausibility rule, not around it.)
- [x] P1 isolation maintained (no new P2/P3 imports in core modules — no `src/core/` change).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** `N/A` (Reason: no new unit logic; full unit suite **1558 passed** re-run to confirm the `<main>`→`<div>`/`<section>` view changes introduce no regression).
- [x] **Integration Tests:** Passing (**74 passed**).
- [x] **Manual Testing:** `N/A` (Reason: verified via E2E — full non-`@wip` Playwright suite **16 passed / 0 failed** on chromium against the production preview build; not a `main`-targeted PR).
- [x] **DoD:** All Definition of Done items from #294 are met (fleet-seed fixture ✔, duplicate `<main>` ✔, wizard save→/fleet ✔, four M&B journeys un-`@wip` & green ✔).
- [x] **Review:** I have performed a self-review of my own code and documentation.
- [x] **ADR:** `N/A` — no P1 interface or developer-workflow change.

### Verification

- `pnpm lint` (oxlint + eslint + trace structural + markdownlint) — green
- `pnpm --filter frontend type-check` — green
- `pnpm test:unit` — 1558 passed · `pnpm test:integration` — 74 passed
- `pnpm build` — green (PWA generated)
- `pnpm exec playwright test --project=chromium --grep-invert @wip` — **16 passed, 0 failed**

### What remains (out of scope for #294 — left `@wip` with inline reasons)

These wizard scenarios fail on **separate pre-existing defects**, not the `<main>`/nav/seed blockers this task fixed (the sibling scenarios A-002/A-004/A-008/B-011 pass and prove the fixes):

- **A-003** — EnvelopeSection cannot reduce below the 4-point minimum via the ✕ remove buttons.
- **A-005 / A-006** (decimal-input-precision) — `DecimalInput` comma→period BEM normalisation and the Arm field on a newly-added load station.
- **A-007** — electric wizard never reaches Step 5 (Pipistrel powertrain auto-flip / Battery-Pack step).
- **B-009** — superseded by the H-011 draft-ack gate (selecting a Draft now routes through the inline acknowledgement); the correct behaviour is covered by the passing **B-011**. Recommend rewrite/removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
