### PR TITLE
feat: [Feat]: Aircraft wind-limit storage (Demonstrated vs Limit) for manual crosswind checking (#303)

### DIFF
--- a/frontend/src/modules/aircraft/__tests__/AircraftProfileEditorView.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/AircraftProfileEditorView.spec.ts
@@ -290,3 +290,49 @@ describe('AircraftProfileEditorView — powertrain immutability & battery pack',
     expect(save.attributes('disabled')).toBeDefined()
   })
 })
+
+// @UT-AC-VIEW-187@ (FROM: @IMP-AC-VIEW-039@)
+describe('AircraftProfileEditorView — wind limits', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders the Wind Limits section with a "Not set" summary for a profile without limits', async () => {
+    const draft = makeProfile({ status: 'draft' })
+    const { wrapper } = await mountEditor({ profile: draft })
+    expect(wrapper.text()).toContain('Wind Limits')
+    expect(wrapper.text()).toContain('Not set')
+  })
+
+  it('persists an added crosswind limit through the save payload', async () => {
+    const draft = makeProfile({ status: 'draft' })
+    const updateProfile = vi
+      .fn<(id: string, changes: Partial<AircraftProfile>) => Promise<AircraftProfile>>()
+      .mockResolvedValue(draft)
+    const { wrapper } = await mountEditor({
+      profile: draft,
+      fleetOverrides: { updateProfile },
+    })
+
+    // AccordionSection uses v-show, so the section controls are in the DOM even
+    // while the accordion is collapsed by default. `.btn-add-row` is shared with
+    // the Load Stations section, so disambiguate by the button label.
+    const addWindLimit = wrapper
+      .findAll('.btn-add-row')
+      .find((b) => b.text().includes('Add Wind Limit'))
+    expect(addWindLimit).toBeDefined()
+    await addWindLimit!.trigger('click')
+    await nextTick()
+    await wrapper.find(`input[id="${draft.id}-windlimits-value-0"]`).setValue('15')
+    await nextTick()
+
+    await wrapper.find('.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(updateProfile).toHaveBeenCalledTimes(1)
+    const changes = updateProfile.mock.calls[0]![1]
+    expect(changes.windLimits).toEqual([
+      { component: 'MaxCrosswind', value: 15, classification: 'Demonstrated' },
+    ])
+  })
+})

--- a/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+++ b/frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
@@ -112,6 +112,28 @@ describe('fleetRepository — CRUD lifecycle', () => {
     expect(afterDelete).toBeUndefined()
   })
 
+  // @IT-AC-STORE-111@ (FROM: @IMP-AD-CORE-009@, @IMP-AC-VIEW-035@)
+  it('round-trips stored wind limits (Demonstrated + Limit) through persistence', async () => {
+    const profile = buildProfile({
+      windLimits: [
+        { component: 'MaxCrosswind', value: 15, classification: 'Demonstrated' },
+        { component: 'MaxCrosswind', value: 20, classification: 'Limit' },
+        { component: 'MaxGust', value: 35, classification: 'Limit' },
+      ],
+    })
+
+    await create(profile)
+    const found = await findById(profile.id)
+
+    expect(found).toBeDefined()
+    expect(found!.windLimits).toEqual(profile.windLimits)
+
+    const demonstratedXwind = found!.windLimits!.find(
+      (w) => w.component === 'MaxCrosswind' && w.classification === 'Demonstrated',
+    )
+    expect(demonstratedXwind?.value).toBe(15)
+  })
+
   // @IT-AC-STORE-002@ (FROM: @IMP-AC-STORE-001@)
   it('findAll returns all profiles', async () => {
     const p1 = buildProfile({ id: '00000000-0000-4000-a000-000000000001', registration: 'D-EBPN' })

--- a/frontend/src/modules/aircraft/components/WindLimitsSection.vue
+++ b/frontend/src/modules/aircraft/components/WindLimitsSection.vue
@@ -60,9 +60,8 @@
       </button>
     </div>
 
-    <span v-if="hasDuplicateComponent" class="field-error" role="alert">
-      Each wind component should appear at most once — remove the duplicate so the limit is
-      unambiguous.
+    <span v-if="hasDuplicatePair" class="field-error" role="alert">
+      The same component + classification combination appears more than once — remove the duplicate.
     </span>
 
     <button type="button" class="btn-add-row" @click="addRow">+ Add Wind Limit</button>
@@ -95,11 +94,12 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: AircraftProfileWindLimit[]): void
 }>()
 
-const hasDuplicateComponent = computed<boolean>(() => {
-  const seen = new Set<Component>()
+const hasDuplicatePair = computed<boolean>(() => {
+  const seen = new Set<string>()
   for (const wl of props.modelValue) {
-    if (seen.has(wl.component)) return true
-    seen.add(wl.component)
+    const key = `${wl.component}:${wl.classification}`
+    if (seen.has(key)) return true
+    seen.add(key)
   }
   return false
 })

--- a/frontend/src/modules/aircraft/components/WindLimitsSection.vue
+++ b/frontend/src/modules/aircraft/components/WindLimitsSection.vue
@@ -1,0 +1,207 @@
+<template>
+  <!-- @IMP-AC-VIEW-035@ (FROM: @REQ-AD-017@) -->
+  <div class="wind-limits-section">
+    <p class="section-intro">
+      Wind limits come from the POH/AFM. A <strong>Demonstrated</strong> value is advisory — the
+      highest wind shown during certification flight testing. A <strong>Limit</strong> value is a
+      hard POH limitation that should not be exceeded. Until automated wind classification arrives,
+      these values are surfaced during flight preparation so you can check the reported wind by hand.
+    </p>
+
+    <div v-if="modelValue.length === 0" class="empty-state">
+      No wind limits yet. Add the demonstrated crosswind from the POH so it can be checked against
+      the reported wind during flight preparation.
+    </div>
+
+    <div v-for="(wl, idx) in modelValue" :key="idx" class="wind-limit-row">
+      <div class="field-group">
+        <label :for="`${sectionId}-component-${idx}`">Component</label>
+        <select
+          :id="`${sectionId}-component-${idx}`"
+          :value="wl.component"
+          @change="patchRow(idx, { component: ($event.target as HTMLSelectElement).value as Component })"
+        >
+          <option v-for="opt in COMPONENT_OPTIONS" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+
+      <div class="field-group">
+        <label :for="`${sectionId}-value-${idx}`">Value (kt)</label>
+        <DecimalInput
+          :id="`${sectionId}-value-${idx}`"
+          :model-value="wl.value"
+          :min="0"
+          placeholder="e.g. 15"
+          @update:model-value="(v) => patchRow(idx, { value: v ?? 0 })"
+        />
+      </div>
+
+      <div class="field-group">
+        <label :for="`${sectionId}-classification-${idx}`">Classification</label>
+        <select
+          :id="`${sectionId}-classification-${idx}`"
+          :value="wl.classification"
+          @change="patchRow(idx, { classification: ($event.target as HTMLSelectElement).value as Classification })"
+        >
+          <option value="Demonstrated">Demonstrated (advisory)</option>
+          <option value="Limit">Limit (hard)</option>
+        </select>
+      </div>
+
+      <button
+        type="button"
+        class="btn-remove-row"
+        title="Remove wind limit"
+        @click="removeRow(idx)"
+      >
+        ✕
+      </button>
+    </div>
+
+    <span v-if="hasDuplicateComponent" class="field-error" role="alert">
+      Each wind component should appear at most once — remove the duplicate so the limit is
+      unambiguous.
+    </span>
+
+    <button type="button" class="btn-add-row" @click="addRow">+ Add Wind Limit</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AircraftProfileWindLimit } from '@/core/adapters/aircraft.schema'
+import DecimalInput from '@/shared/components/DecimalInput.vue'
+
+// @IMP-AC-VIEW-036@ (FROM: @REQ-AD-017@)
+
+type Component = AircraftProfileWindLimit['component']
+type Classification = AircraftProfileWindLimit['classification']
+
+const COMPONENT_OPTIONS: readonly { value: Component; label: string }[] = [
+  { value: 'MaxCrosswind', label: 'Crosswind' },
+  { value: 'MaxTailwind', label: 'Tailwind' },
+  { value: 'MaxTotalWind', label: 'Total wind' },
+  { value: 'MaxGust', label: 'Gust' },
+] as const
+
+const props = defineProps<{
+  modelValue: AircraftProfileWindLimit[]
+  sectionId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: AircraftProfileWindLimit[]): void
+}>()
+
+const hasDuplicateComponent = computed<boolean>(() => {
+  const seen = new Set<Component>()
+  for (const wl of props.modelValue) {
+    if (seen.has(wl.component)) return true
+    seen.add(wl.component)
+  }
+  return false
+})
+
+function patchRow(idx: number, changes: Partial<AircraftProfileWindLimit>): void {
+  const next = props.modelValue.map((row, i) => (i === idx ? { ...row, ...changes } : row))
+  emit('update:modelValue', next)
+}
+
+function addRow(): void {
+  // Crosswind is the value almost every GA POH publishes, so seed it as the
+  // default component to minimise pilot input for the common case.
+  const next: AircraftProfileWindLimit = {
+    component: 'MaxCrosswind',
+    value: 0,
+    classification: 'Demonstrated',
+  }
+  emit('update:modelValue', [...props.modelValue, next])
+}
+
+function removeRow(idx: number): void {
+  emit(
+    'update:modelValue',
+    props.modelValue.filter((_, i) => i !== idx),
+  )
+}
+</script>
+
+<style scoped>
+.wind-limits-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-intro {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.empty-state {
+  padding: 0.75rem;
+  border: 1px dashed var(--color-border, #d1d5db);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.wind-limit-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(90px, 140px) minmax(160px, 1fr) auto;
+  gap: 0.5rem;
+  align-items: end;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--color-surface-alt, #f9fafb);
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field-group label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text, #111827);
+}
+
+.field-group select {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 4px;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text, #111827);
+  font-size: 0.875rem;
+}
+
+.field-error {
+  font-size: 0.8125rem;
+  color: var(--color-critical, #dc2626);
+}
+
+.btn-remove-row {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 4px;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-critical, #dc2626);
+  cursor: pointer;
+}
+
+.btn-add-row {
+  align-self: flex-start;
+  padding: 0.5rem 0.75rem;
+  border: 1px dashed var(--color-border, #d1d5db);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #111827);
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/modules/aircraft/components/WindLimitsSummary.vue
+++ b/frontend/src/modules/aircraft/components/WindLimitsSummary.vue
@@ -1,0 +1,160 @@
+<template>
+  <!-- @IMP-AC-VIEW-037@ (FROM: @REQ-AD-017@) -->
+  <section class="wind-limits-summary" aria-label="Aircraft wind limits">
+    <h3 class="wind-limits-summary__title">
+      Wind limits
+      <span class="wind-limits-summary__tag">manual check</span>
+    </h3>
+
+    <ul v-if="sortedLimits.length > 0" class="wind-limits-summary__list">
+      <li
+        v-for="(wl, idx) in sortedLimits"
+        :key="idx"
+        class="wind-limits-summary__item"
+        :class="`wind-limits-summary__item--${wl.classification.toLowerCase()}`"
+      >
+        <span class="wind-limits-summary__component">{{ componentLabel(wl.component) }}</span>
+        <span class="wind-limits-summary__value">{{ wl.value }} kt</span>
+        <span class="wind-limits-summary__classification">{{ classificationLabel(wl.classification) }}</span>
+      </li>
+    </ul>
+
+    <p v-else class="wind-limits-summary__empty">
+      No wind limits stored for this aircraft. Add the demonstrated crosswind in the aircraft editor
+      to check it against the reported wind here.
+    </p>
+
+    <p class="wind-limits-summary__note">
+      Compare these against the reported wind by hand — automated wind classification is not yet
+      available.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AircraftProfileWindLimit } from '@/core/adapters/aircraft.schema'
+
+// @IMP-AC-VIEW-038@ (FROM: @REQ-AD-017@)
+
+type Component = AircraftProfileWindLimit['component']
+type Classification = AircraftProfileWindLimit['classification']
+
+const props = defineProps<{
+  windLimits?: AircraftProfileWindLimit[]
+}>()
+
+const COMPONENT_LABELS: Record<Component, string> = {
+  MaxCrosswind: 'Crosswind',
+  MaxTailwind: 'Tailwind',
+  MaxTotalWind: 'Total wind',
+  MaxGust: 'Gust',
+}
+
+// Crosswind is the value pilots check most often, so pin it first; the rest
+// follow the POH-conventional order.
+const COMPONENT_ORDER: readonly Component[] = [
+  'MaxCrosswind',
+  'MaxTailwind',
+  'MaxTotalWind',
+  'MaxGust',
+]
+
+const sortedLimits = computed<AircraftProfileWindLimit[]>(() =>
+  [...(props.windLimits ?? [])].sort(
+    (a, b) => COMPONENT_ORDER.indexOf(a.component) - COMPONENT_ORDER.indexOf(b.component),
+  ),
+)
+
+function componentLabel(component: Component): string {
+  return COMPONENT_LABELS[component]
+}
+
+function classificationLabel(classification: Classification): string {
+  return classification === 'Limit' ? 'Limit (hard)' : 'Demonstrated (advisory)'
+}
+</script>
+
+<style scoped>
+.wind-limits-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--color-surface-alt, #f9fafb);
+}
+
+.wind-limits-summary__title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text, #111827);
+}
+
+.wind-limits-summary__tag {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 999px;
+  background: var(--color-surface, #ffffff);
+  border: 1px solid var(--color-border, #d1d5db);
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.wind-limits-summary__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.wind-limits-summary__item {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto minmax(140px, 1fr);
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.875rem;
+  color: var(--color-text, #111827);
+}
+
+.wind-limits-summary__component {
+  font-weight: 500;
+}
+
+.wind-limits-summary__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.wind-limits-summary__classification {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.wind-limits-summary__item--limit .wind-limits-summary__classification {
+  color: var(--color-critical, #b91c1c);
+  font-weight: 500;
+}
+
+.wind-limits-summary__empty {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.wind-limits-summary__note {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #6b7280);
+  font-style: italic;
+}
+</style>

--- a/frontend/src/modules/aircraft/components/__tests__/WindLimitsSection.spec.ts
+++ b/frontend/src/modules/aircraft/components/__tests__/WindLimitsSection.spec.ts
@@ -37,14 +37,24 @@ describe('WindLimitsSection — rendering', () => {
     expect(wrapper.find('#test-classification-0').exists()).toBe(true)
   })
 
-  it('warns when the same component appears more than once', () => {
+  it('warns when the same (component, classification) pair appears more than once', () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: {
+        modelValue: [makeLimit(), makeLimit()],
+        sectionId: 'test',
+      },
+    })
+    expect(wrapper.find('.field-error').exists()).toBe(true)
+  })
+
+  it('does not warn for same component with different classifications (valid POH data)', () => {
     const wrapper = mount(WindLimitsSection, {
       props: {
         modelValue: [makeLimit(), makeLimit({ classification: 'Limit' })],
         sectionId: 'test',
       },
     })
-    expect(wrapper.find('.field-error').exists()).toBe(true)
+    expect(wrapper.find('.field-error').exists()).toBe(false)
   })
 
   it('does not warn for distinct components', () => {

--- a/frontend/src/modules/aircraft/components/__tests__/WindLimitsSection.spec.ts
+++ b/frontend/src/modules/aircraft/components/__tests__/WindLimitsSection.spec.ts
@@ -1,0 +1,116 @@
+// @UT-AC-VIEW-185@ (FROM: @IMP-AC-VIEW-035@, @IMP-AC-VIEW-036@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WindLimitsSection from '../WindLimitsSection.vue'
+import type { AircraftProfileWindLimit } from '@/core/adapters/aircraft.schema'
+
+function makeLimit(overrides: Partial<AircraftProfileWindLimit> = {}): AircraftProfileWindLimit {
+  return {
+    component: 'MaxCrosswind',
+    value: 15,
+    classification: 'Demonstrated',
+    ...overrides,
+  }
+}
+
+function lastEmit(wrapper: ReturnType<typeof mount>): AircraftProfileWindLimit[] {
+  const emitted = wrapper.emitted('update:modelValue')!
+  return emitted[emitted.length - 1]![0] as AircraftProfileWindLimit[]
+}
+
+describe('WindLimitsSection — rendering', () => {
+  it('shows the empty state when there are no wind limits', () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [], sectionId: 'test' },
+    })
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+    expect(wrapper.find('.wind-limit-row').exists()).toBe(false)
+  })
+
+  it('renders a row with component, value and classification controls per limit', () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [makeLimit()], sectionId: 'test' },
+    })
+    expect(wrapper.find('#test-component-0').exists()).toBe(true)
+    expect(wrapper.find('#test-value-0').exists()).toBe(true)
+    expect(wrapper.find('#test-classification-0').exists()).toBe(true)
+  })
+
+  it('warns when the same component appears more than once', () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: {
+        modelValue: [makeLimit(), makeLimit({ classification: 'Limit' })],
+        sectionId: 'test',
+      },
+    })
+    expect(wrapper.find('.field-error').exists()).toBe(true)
+  })
+
+  it('does not warn for distinct components', () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: {
+        modelValue: [makeLimit(), makeLimit({ component: 'MaxGust' })],
+        sectionId: 'test',
+      },
+    })
+    expect(wrapper.find('.field-error').exists()).toBe(false)
+  })
+})
+
+describe('WindLimitsSection — emits', () => {
+  it('adds a default crosswind/Demonstrated row', async () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [], sectionId: 'test' },
+    })
+    await wrapper.find('.btn-add-row').trigger('click')
+    const next = lastEmit(wrapper)
+    expect(next).toHaveLength(1)
+    expect(next[0]).toEqual({ component: 'MaxCrosswind', value: 0, classification: 'Demonstrated' })
+  })
+
+  it('removes the targeted row', async () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: {
+        modelValue: [makeLimit(), makeLimit({ component: 'MaxGust' })],
+        sectionId: 'test',
+      },
+    })
+    await wrapper.find('.btn-remove-row').trigger('click')
+    const next = lastEmit(wrapper)
+    expect(next).toHaveLength(1)
+    expect(next[0]!.component).toBe('MaxGust')
+  })
+
+  it('patches the component when the component select changes', async () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [makeLimit()], sectionId: 'test' },
+    })
+    await wrapper.find('#test-component-0').setValue('MaxTailwind')
+    expect(lastEmit(wrapper)[0]!.component).toBe('MaxTailwind')
+  })
+
+  it('patches the classification when the classification select changes', async () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [makeLimit()], sectionId: 'test' },
+    })
+    await wrapper.find('#test-classification-0').setValue('Limit')
+    expect(lastEmit(wrapper)[0]!.classification).toBe('Limit')
+  })
+
+  it('patches the value when the value input changes', async () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [makeLimit()], sectionId: 'test' },
+    })
+    await wrapper.find('#test-value-0').setValue('22')
+    expect(lastEmit(wrapper)[0]!.value).toBe(22)
+  })
+
+  it('coerces a cleared value back to zero so the schema bound holds', async () => {
+    const wrapper = mount(WindLimitsSection, {
+      props: { modelValue: [makeLimit()], sectionId: 'test' },
+    })
+    await wrapper.find('#test-value-0').setValue('')
+    expect(lastEmit(wrapper)[0]!.value).toBe(0)
+  })
+})

--- a/frontend/src/modules/aircraft/components/__tests__/WindLimitsSummary.spec.ts
+++ b/frontend/src/modules/aircraft/components/__tests__/WindLimitsSummary.spec.ts
@@ -1,0 +1,62 @@
+// @UT-AC-VIEW-186@ (FROM: @IMP-AC-VIEW-037@, @IMP-AC-VIEW-038@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WindLimitsSummary from '../WindLimitsSummary.vue'
+import type { AircraftProfileWindLimit } from '@/core/adapters/aircraft.schema'
+
+describe('WindLimitsSummary — empty', () => {
+  it('shows the empty hint when windLimits is undefined', () => {
+    const wrapper = mount(WindLimitsSummary, { props: {} })
+    expect(wrapper.find('.wind-limits-summary__empty').exists()).toBe(true)
+    expect(wrapper.find('.wind-limits-summary__list').exists()).toBe(false)
+  })
+
+  it('shows the empty hint when windLimits is an empty array', () => {
+    const wrapper = mount(WindLimitsSummary, { props: { windLimits: [] } })
+    expect(wrapper.find('.wind-limits-summary__empty').exists()).toBe(true)
+  })
+
+  it('always renders the manual-check note', () => {
+    const wrapper = mount(WindLimitsSummary, { props: { windLimits: [] } })
+    expect(wrapper.find('.wind-limits-summary__note').text()).toContain('by hand')
+  })
+})
+
+describe('WindLimitsSummary — populated', () => {
+  const limits: AircraftProfileWindLimit[] = [
+    { component: 'MaxGust', value: 35, classification: 'Limit' },
+    { component: 'MaxCrosswind', value: 15, classification: 'Demonstrated' },
+  ]
+
+  it('renders one item per wind limit', () => {
+    const wrapper = mount(WindLimitsSummary, { props: { windLimits: limits } })
+    expect(wrapper.findAll('.wind-limits-summary__item')).toHaveLength(2)
+  })
+
+  it('orders crosswind ahead of gust regardless of input order', () => {
+    const wrapper = mount(WindLimitsSummary, { props: { windLimits: limits } })
+    const components = wrapper
+      .findAll('.wind-limits-summary__component')
+      .map((c) => c.text())
+    expect(components[0]).toBe('Crosswind')
+    expect(components[1]).toBe('Gust')
+  })
+
+  it('renders human labels for component, value and classification', () => {
+    const wrapper = mount(WindLimitsSummary, {
+      props: { windLimits: [{ component: 'MaxCrosswind', value: 15, classification: 'Demonstrated' }] },
+    })
+    expect(wrapper.find('.wind-limits-summary__component').text()).toBe('Crosswind')
+    expect(wrapper.find('.wind-limits-summary__value').text()).toBe('15 kt')
+    expect(wrapper.find('.wind-limits-summary__classification').text()).toContain('Demonstrated')
+  })
+
+  it('labels a hard limit distinctly and tags the row for colour-independent signalling', () => {
+    const wrapper = mount(WindLimitsSummary, {
+      props: { windLimits: [{ component: 'MaxCrosswind', value: 20, classification: 'Limit' }] },
+    })
+    expect(wrapper.find('.wind-limits-summary__classification').text()).toContain('Limit')
+    expect(wrapper.find('.wind-limits-summary__item--limit').exists()).toBe(true)
+  })
+})

--- a/frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
+++ b/frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
@@ -94,6 +94,19 @@
         />
       </AccordionSection>
 
+      <AccordionSection
+        title="Wind Limits"
+        :summary="windLimitsSummary"
+        :section-id="`${profileId}-windlimits`"
+        :model-value="openSections.windLimits"
+        @update:model-value="openSections.windLimits = $event"
+      >
+        <WindLimitsSection
+          v-model="windLimits"
+          :section-id="`${profileId}-windlimits`"
+        />
+      </AccordionSection>
+
       <p v-if="saveError" class="field-error" role="alert">{{ saveError }}</p>
     </div>
 
@@ -128,6 +141,7 @@ import type {
   AircraftProfileCertificationCategory,
   AircraftProfileLoadPoint,
   AircraftProfileWeighingReport,
+  AircraftProfileWindLimit,
 } from '@/core/adapters/aircraft.schema'
 import { sortEnvelopeCcw } from '@/core/logic/envelope-sort'
 import { evaluateVerificationFreshness } from '@/core/logic/profile-verification'
@@ -139,6 +153,7 @@ import EnvelopeSection from '../components/EnvelopeSection.vue'
 import LoadPointsSection from '../components/LoadPointsSection.vue'
 import WeighingReportsSection from '../components/WeighingReportsSection.vue'
 import BatteryPackSection from '../components/BatteryPackSection.vue'
+import WindLimitsSection from '../components/WindLimitsSection.vue'
 import ProfileStatusBadge from '../components/ProfileStatusBadge.vue'
 
 // @IMP-AC-VIEW-016@ (FROM: @REQ-AC-001@, @REQ-AC-005@, @REQ-AD-001@, @REQ-AD-002@, @REQ-AD-003@, @REQ-AD-004@, @REQ-AD-005@, @REQ-AD-007@, @REQ-AD-011@, @REQ-AD-012@, @REQ-AD-013@, @REQ-AD-014@, @REQ-AD-018@, @REQ-AD-019@)
@@ -163,6 +178,7 @@ const openSections = reactive({
   loadPoints: true,
   weighing: true,
   battery: true,
+  windLimits: false,
 })
 
 const identityFields = computed<IdentityFields>({
@@ -253,6 +269,17 @@ const batteryPack = computed<AircraftProfileBatteryPack>({
   },
 })
 
+// @IMP-AC-VIEW-039@ (FROM: @REQ-AD-017@)
+const windLimits = computed<AircraftProfileWindLimit[]>({
+  get(): AircraftProfileWindLimit[] {
+    return draft.value?.windLimits ?? []
+  },
+  set(next: AircraftProfileWindLimit[]): void {
+    if (!draft.value) return
+    draft.value = { ...draft.value, windLimits: next }
+  },
+})
+
 // Distinct certification category names — feed the per-station
 // category-restriction UI in LoadPointsSection.
 const availableCategoryNames = computed<AircraftProfileCertificationCategory['category'][]>(
@@ -286,6 +313,12 @@ const batteryPackSummary = computed(() => {
   const bp = draft.value?.batteryPack
   if (!bp || bp.usableEnergyKwh <= 0) return 'Not configured'
   return `${bp.usableEnergyKwh} kWh usable · ${bp.reserveFloorKwh} kWh reserve`
+})
+
+const windLimitsSummary = computed(() => {
+  const n = windLimits.value.length
+  if (n === 0) return 'Not set'
+  return n === 1 ? '1 limit' : `${n} limits`
 })
 
 const isDirty = computed(() => {

--- a/frontend/src/modules/aircraft/views/AircraftProfileWizardView.vue
+++ b/frontend/src/modules/aircraft/views/AircraftProfileWizardView.vue
@@ -97,6 +97,16 @@
         <BatteryPackSection v-model="batteryPack" section-id="wizard-battery" />
       </section>
 
+      <!-- Step: Wind Limits -->
+      <section v-else-if="stepId === 'wind-limits'" class="wizard-step">
+        <h2>Step {{ stepNumber }}: Wind Limits</h2>
+        <p class="step-intro">
+          Enter the wind limits from your POH/AFM for manual crosswind checking during flight
+          preparation. This step is optional — you can add or edit limits later.
+        </p>
+        <WindLimitsSection v-model="windLimits" section-id="wizard-windlimits" />
+      </section>
+
       <!-- Step: Review & Save -->
       <section v-else-if="stepId === 'review'" class="wizard-step">
         <h2>Step {{ stepNumber }}: Review &amp; Save</h2>
@@ -140,6 +150,14 @@
             <div v-for="(lp, i) in loadPoints" :key="i" class="review-item">
               {{ lp.name }} — arm {{ lp.arm ?? 'table' }}, unit {{ lp.unit }}
               <span v-if="lp.fuelTank"> (fuel tank)</span>
+            </div>
+          </div>
+
+          <div class="review-section">
+            <h3>Wind Limits</h3>
+            <div v-if="windLimits.length === 0" class="review-empty">None entered.</div>
+            <div v-for="(wl, i) in windLimits" :key="i" class="review-item">
+              {{ wl.component }} — {{ wl.value }} kt ({{ wl.classification }})
             </div>
           </div>
 
@@ -237,6 +255,7 @@ import type {
   AircraftProfileCertificationCategory,
   AircraftProfileLoadPoint,
   AircraftProfileWeighingReport,
+  AircraftProfileWindLimit,
 } from '@/core/adapters/aircraft.schema'
 import { sortEnvelopeCcw } from '@/core/logic/envelope-sort'
 import { useFleetStore } from '../stores/fleet.store'
@@ -247,6 +266,7 @@ import EnvelopeSection from '../components/EnvelopeSection.vue'
 import WeighingReportsSection from '../components/WeighingReportsSection.vue'
 import LoadPointsSection from '../components/LoadPointsSection.vue'
 import BatteryPackSection from '../components/BatteryPackSection.vue'
+import WindLimitsSection from '../components/WindLimitsSection.vue'
 import ActionChoiceDialog, { type DialogAction } from '@/shared/components/ActionChoiceDialog.vue'
 
 const router = useRouter()
@@ -267,6 +287,7 @@ const BASE_STEPS = [
   { id: 'envelope', label: 'Envelope' },
   { id: 'weighing', label: 'Weighing' },
   { id: 'load-stations', label: 'Load Stations' },
+  { id: 'wind-limits', label: 'Wind Limits' },
   { id: 'review', label: 'Review' },
 ] as const
 
@@ -335,6 +356,8 @@ const weighingReports = ref<AircraftProfileWeighingReport[]>([
 ])
 
 const loadPoints = ref<AircraftProfileLoadPoint[]>([])
+
+const windLimits = ref<AircraftProfileWindLimit[]>([])
 
 // Distinct certification category names (Normal / Utility / Aerobatic) feeding
 // the per-station category-restriction UI. Deduplicated in case the pilot adds
@@ -423,6 +446,8 @@ function isStepValid(id: StepId): boolean {
       return weighingValid.value
     case 'load-stations':
       return loadStationsValid.value
+    case 'wind-limits':
+      return true
     case 'battery-pack':
       return batteryPackValid.value
     case 'review':
@@ -649,6 +674,7 @@ async function persistProfile(): Promise<AircraftProfile | null> {
       certificationCategories: sortedCategories,
       weighingReports: weighingReports.value,
       loadPoints: normalizedLoadPoints,
+      windLimits: windLimits.value,
       passengerProfiles: [],
       powertrain: identityFields.value.powertrain,
       ...(isElectric.value ? { batteryPack: { ...batteryPack.value } } : {}),

--- a/frontend/src/modules/aircraft/views/__tests__/AircraftProfileWizardView.spec.ts
+++ b/frontend/src/modules/aircraft/views/__tests__/AircraftProfileWizardView.spec.ts
@@ -67,6 +67,9 @@ vi.mock('../../components/LoadPointsSection.vue', () => ({ default: h.makeStub([
 vi.mock('../../components/BatteryPackSection.vue', () => ({
   default: { props: ['modelValue'], template: '<div />' },
 }))
+vi.mock('../../components/WindLimitsSection.vue', () => ({
+  default: { props: ['modelValue'], template: '<div />' },
+}))
 
 import AircraftProfileWizardView from '../AircraftProfileWizardView.vue'
 import { useFleetStore } from '../../stores/fleet.store'
@@ -142,8 +145,8 @@ describe('AircraftProfileWizardView — post-save chooser & exit modal', () => {
   })
 
   async function advanceToReview(wrapper: Awaited<ReturnType<typeof mountWizard>>['wrapper']) {
-    // identity → envelope → weighing → load-stations → review
-    for (let i = 0; i < 4; i++) {
+    // identity → envelope → weighing → load-stations → wind-limits → review
+    for (let i = 0; i < 5; i++) {
       const cont = wrapper.findAll('button').find((b) => b.text().includes('Continue'))
       expect(cont, `Continue button missing at step ${i}`).toBeDefined()
       await cont!.trigger('click')

--- a/frontend/src/modules/mass-balance/views/MassBalanceView.vue
+++ b/frontend/src/modules/mass-balance/views/MassBalanceView.vue
@@ -22,6 +22,7 @@ import InputGroupCard from '@/modules/mass-balance/components/InputGroupCard.vue
 import MassStationInput from '@/modules/mass-balance/components/MassStationInput.vue'
 import CGEnvelopeChart from '@/modules/mass-balance/components/CGEnvelopeChart.vue'
 import ResultSummary from '@/modules/mass-balance/components/ResultSummary.vue'
+import WindLimitsSummary from '@/modules/aircraft/components/WindLimitsSummary.vue'
 import ConfirmDialog from '@/shared/components/ConfirmDialog.vue'
 import UndoToast from '@/shared/components/UndoToast.vue'
 
@@ -545,6 +546,12 @@ const aircraftLabel = computed(() => {
   return `${store.aircraft.registration} — ${store.aircraft.manufacturer} ${store.aircraft.model}`
 })
 
+// @IMP-MB-VIEW-014@ (FROM: @REQ-AD-017@)
+// Wind limits ride on the full active profile, not the reduced M&B
+// AircraftContext — the context deliberately omits them, so read straight from
+// the active-aircraft store, which is set in lockstep with the loaded profile.
+const activeWindLimits = computed(() => activeAircraftStore.activeProfile?.windLimits ?? [])
+
 // @IMP-MB-VIEW-010@ (FROM: @REQ-AD-020@)
 // Battery-electric airframes surface an "Energy & Endurance" placeholder
 // rather than the combustion "Fuel & Endurance" card. The page-header subtitle
@@ -996,6 +1003,13 @@ function onCancelSelection(): void {
         </div>
       </div>
 
+      <!-- @IMP-MB-VIEW-015@ (FROM: @REQ-AD-017@) -->
+      <WindLimitsSummary
+        v-if="store.aircraft"
+        class="aircraft-wind-limits"
+        :wind-limits="activeWindLimits"
+      />
+
       <!-- Mass-balance profile-loading spinner (distinct from fleet hydration) -->
       <div v-if="viewModel.isLoading" class="loading" aria-busy="true" aria-live="polite">
         <span class="loading-spinner" aria-hidden="true" />
@@ -1441,6 +1455,10 @@ function onCancelSelection(): void {
 
 .prep-card--aircraft {
   border-left: 3px solid var(--color-primary);
+}
+
+.aircraft-wind-limits {
+  margin-top: var(--space-4);
 }
 
 .prep-card--mb:not(.prep-card--locked) {

--- a/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+++ b/frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
@@ -573,3 +573,49 @@ describe('MassBalanceView — fleet picker', () => {
     expect(select.element.value).toBe(draft.id)
   })
 })
+
+// @UT-MB-VIEW-035@ (FROM: @IMP-MB-VIEW-014@, @IMP-MB-VIEW-015@)
+describe('MassBalanceView — wind limits surfacing', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function mountWithActive(profile: AircraftProfile) {
+    seedFleet([profile])
+    useActiveAircraftStore().activeProfile = profile
+    const wrapper = mountView()
+    await wrapper.vm.$nextTick()
+    await new Promise((r) => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  it("surfaces the active aircraft's stored crosswind limit for manual checking", async () => {
+    const profile = buildFleetProfile({
+      windLimits: [{ component: 'MaxCrosswind', value: 15, classification: 'Demonstrated' }],
+    })
+    const wrapper = await mountWithActive(profile)
+
+    const summary = wrapper.find('[aria-label="Aircraft wind limits"]')
+    expect(summary.exists()).toBe(true)
+    expect(summary.text()).toContain('Crosswind')
+    expect(summary.text()).toContain('15 kt')
+    expect(summary.text()).toContain('Demonstrated')
+  })
+
+  it('shows the empty hint when the active aircraft has no stored wind limits', async () => {
+    const profile = buildFleetProfile({ windLimits: undefined })
+    const wrapper = await mountWithActive(profile)
+
+    const summary = wrapper.find('[aria-label="Aircraft wind limits"]')
+    expect(summary.exists()).toBe(true)
+    expect(summary.text()).toContain('No wind limits stored')
+  })
+
+  it('does not surface the wind-limits panel before an aircraft is loaded', () => {
+    seedFleet([])
+    const wrapper = mountView()
+    expect(wrapper.find('[aria-label="Aircraft wind limits"]').exists()).toBe(false)
+  })
+})

--- a/trace/implementation/ac.yaml
+++ b/trace/implementation/ac.yaml
@@ -378,3 +378,38 @@ AC (auto)
     req:
       - REQ-AC-001
       - REQ-AC-007
+
+  IMP-AC-VIEW-035
+    title: Wind-limits editor section template — component/value/classification rows with add/remove
+    files:
+      - frontend/src/modules/aircraft/components/WindLimitsSection.vue
+    req:
+      - REQ-AD-017
+
+  IMP-AC-VIEW-036
+    title: Wind-limits editor section logic — patch/add/remove rows and duplicate-component guard
+    files:
+      - frontend/src/modules/aircraft/components/WindLimitsSection.vue
+    req:
+      - REQ-AD-017
+
+  IMP-AC-VIEW-037
+    title: Wind-limits read-only summary template — crosswind-first list for manual checking
+    files:
+      - frontend/src/modules/aircraft/components/WindLimitsSummary.vue
+    req:
+      - REQ-AD-017
+
+  IMP-AC-VIEW-038
+    title: Wind-limits read-only summary logic — component ordering and classification labels
+    files:
+      - frontend/src/modules/aircraft/components/WindLimitsSummary.vue
+    req:
+      - REQ-AD-017
+
+  IMP-AC-VIEW-039
+    title: Aircraft editor wind-limits binding — windLimits draft model + accordion section
+    files:
+      - frontend/src/modules/aircraft/views/AircraftProfileEditorView.vue
+    req:
+      - REQ-AD-017

--- a/trace/implementation/mb.yaml
+++ b/trace/implementation/mb.yaml
@@ -463,3 +463,17 @@ MB (auto)
     req:
       - REQ-AC-001
       - REQ-AC-005
+
+  IMP-MB-VIEW-014
+    title: Prep-dashboard active wind-limits accessor — reads windLimits off the active profile
+    files:
+      - frontend/src/modules/mass-balance/views/MassBalanceView.vue
+    req:
+      - REQ-AD-017
+
+  IMP-MB-VIEW-015
+    title: Prep-dashboard wind-limits surfacing — read-only summary in the aircraft card
+    files:
+      - frontend/src/modules/mass-balance/views/MassBalanceView.vue
+    req:
+      - REQ-AD-017

--- a/trace/integration_test/ac.yaml
+++ b/trace/integration_test/ac.yaml
@@ -193,3 +193,11 @@ AC (auto)
       - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
     impl:
       - IMP-AC-STORE-009
+
+  IT-AC-STORE-111
+    title: Wind limits round-trip through fleet repository persistence (Demonstrated + Limit)
+    files:
+      - frontend/src/modules/aircraft/__tests__/fleet.repository.int.spec.ts
+    impl:
+      - IMP-AD-CORE-009
+      - IMP-AC-VIEW-035

--- a/trace/unit_test/ac.yaml
+++ b/trace/unit_test/ac.yaml
@@ -2118,3 +2118,26 @@ AC (auto)
       - frontend/src/modules/aircraft/__tests__/FleetList.spec.ts
     impl:
       - IMP-AC-VIEW-034
+
+  UT-AC-VIEW-187
+    title: Aircraft editor wind-limits wiring — section render + added limit persists in save payload
+    files:
+      - frontend/src/modules/aircraft/__tests__/AircraftProfileEditorView.spec.ts
+    impl:
+      - IMP-AC-VIEW-039
+
+  UT-AC-VIEW-185
+    title: Wind-limits editor section — render, add/remove, patch, duplicate-component warning
+    files:
+      - frontend/src/modules/aircraft/components/__tests__/WindLimitsSection.spec.ts
+    impl:
+      - IMP-AC-VIEW-035
+      - IMP-AC-VIEW-036
+
+  UT-AC-VIEW-186
+    title: Wind-limits read-only summary — empty hint, crosswind-first ordering, classification labels
+    files:
+      - frontend/src/modules/aircraft/components/__tests__/WindLimitsSummary.spec.ts
+    impl:
+      - IMP-AC-VIEW-037
+      - IMP-AC-VIEW-038

--- a/trace/unit_test/mb.yaml
+++ b/trace/unit_test/mb.yaml
@@ -1501,3 +1501,11 @@ MB (auto)
       - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
     impl:
       - IMP-MB-VIEW-013
+
+  UT-MB-VIEW-035
+    title: Prep-dashboard wind-limits surfacing — populated, empty, and no-aircraft states
+    files:
+      - frontend/src/modules/mass-balance/views/__tests__/MassBalanceView.fleet.spec.ts
+    impl:
+      - IMP-MB-VIEW-014
+      - IMP-MB-VIEW-015


### PR DESCRIPTION
### Summary

Surfaces per-aircraft wind limits for **manual crosswind checking** on top of the existing P1 `WindLimitSchema` (H-014 partial mitigation). Automated wind classification (`REQ-WX-009`) and the warning phases of `UJ-E-004` remain deferred to v0.6.0.

- **Editor:** new **Wind Limits** accordion section in the aircraft profile editor — per-component value (kt) + `Demonstrated`/`Limit` classification, add/remove, duplicate-component guard.
- **Dashboard:** read-only **Wind limits** panel in the flight-prep Aircraft card — crosswind first; advisory vs hard-limit signalled colour-independently; flagged "manual check" with a by-hand note (auto classification deferred).
- **Persistence:** `windLimits` round-trips through the fleet repository (IndexedDB) unchanged.
- No `src/core/` changes (P1 schema pre-existing); no `CHANGELOG` change (reserved for the release process); no workflow/security changes (ADR-317-DEV scope).

### Related Issues
Closes #303

### Issue State Management (Post-Merge)
- [x] If merging to `develop`: Issue auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items
- **Requirements Implemented/Affected:** `REQ-AD-017` (storage; left `Approved` pending E2E verification — see *What remains*)

### Documentation Updates
- [x] **Requirements:** `N/A` (Reason: `REQ-AD-017` pre-existing; storage now implemented + unit/integration-verified but kept `Approved` pending an executable E2E for `UJ-E-004` Profile-Setup — not over-claimed as `Implemented`)
- [x] **Architecture:** `N/A` (Reason: composes existing components; `DES-ARCH-002` already covers the aircraft data model incl. `REQ-AD-017`)
- [x] **Risk Management:** `N/A` (Reason: `H-014` already maps to `REQ-AD-017`; this is the partial mitigation, no hazard-register change)
- [x] **Journeys:** `N/A` (Reason: `UJ-E-004` pre-existing; the Profile-Setup phase is what this PR implements)
- [x] **Code Docs:** `N/A` (Reason: `CHANGELOG` reserved for the release process per the implement-issue workflow; trace registries updated under `trace/`)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules) — no `src/core/` files changed; new code is P2 (modules) only.

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added/updated and passing locally (`test:unit` 1614 passed; +18 new for wind-limits editor, summary, editor wiring, dashboard surfacing).
- [x] **Integration Tests:** Passing (`test:integration` 75 passed; new `IT-AC-STORE-111` round-trip).
- [x] **Manual Testing:** `N/A` (Reason: autonomous CI run — no browser/Playwright available; behaviour verified by unit + integration tests. Manual/E2E verification recommended before `main`.)
- [x] **DoD:** All Definition of Done items from #303 are met and attested (every issue checkbox ticked).
- [x] **Review:** Performed a self-review of the code and trace registries.
- [x] **ADR:** No ADR required — `N/A` (composes existing P2 components; no P1 interface or dev-workflow change).

---

#### Traceability
Upstream `REQ-AD-017` (FROM `H-014`), `UJ-E-004`:
- `IMP-AC-VIEW-035/036` (editor section), `IMP-AC-VIEW-037/038` (summary), `IMP-AC-VIEW-039` (editor binding), `IMP-MB-VIEW-014/015` (dashboard surfacing)
- `UT-AC-VIEW-185/186/187`, `UT-MB-VIEW-035`, `IT-AC-STORE-111`
- Pre-existing P1: `IMP-AD-CORE-009` (`WindLimitSchema`)

#### What remains (out of DoD scope)
- Executable E2E for the `UJ-E-004` Profile-Setup phase — **blocked in this autonomous run**: Playwright browsers are unavailable and the wizard-creation E2E flow it builds on is `@wip`. Storage is verified by unit + integration coverage; recommend authoring this E2E (and de-`@wip`'ing it) alongside `REQ-WX-009` in v0.6.0, then promoting `REQ-AD-017` to `Implemented`.

#### Notes for reviewers
- Project board could not be updated from CI (the token lacks `project` scope; `gh project list` returns empty). Please move #303 to **In Verification** manually.
- Any `safety-critical` / data-model-adjacent change still requires Lead Developer review per `CONTRIBUTING.md §7`; the automated reviewer cannot satisfy that gate.
