### PR TITLE
feat: [Task]: Extrapolation cap/penalty/floor + acknowledgment state (P1) (#308)

### DIFF
--- a/frontend/src/core/logic/performance.extrapolation.spec.ts
+++ b/frontend/src/core/logic/performance.extrapolation.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for the conservative extrapolation-control layer.
+ *
+ * @see performance.extrapolation.ts
+ */
+
+// @UT-PF-CORE-042@ (FROM: @IMP-PF-CORE-006@, @IMP-PF-CORE-007@, @IMP-PF-CORE-008@, @IMP-PF-CORE-009@, @IMP-PF-CORE-010@, @IMP-PF-CORE-011@)
+import { describe, it, expect } from 'vitest'
+import type { PohDistanceConditions } from './performance.poh-distance'
+import type { PerformanceCube3D } from './performance.poh-distance'
+import {
+  EXTRAPOLATION_CAP_FRACTION,
+  EXTRAPOLATION_PENALTY_FRACTION,
+  EXTRAPOLATION_LIMITS,
+  classifyAxisExcursion,
+  assessExtrapolation,
+  applyExtrapolationPenalty,
+  cubeEnvelopeRanges,
+  resolveExtrapolatedDistance,
+  type EnvelopeRanges,
+} from './performance.extrapolation'
+
+// POH envelope mirroring UJ-C-001 (50 °C / 10,000 ft maxima).
+const RANGES: EnvelopeRanges = {
+  mass: { min: 850, max: 1157 },
+  pressureAltitude: { min: 0, max: 10_000 },
+  temperature: { min: -20, max: 50 },
+}
+
+const WITHIN: PohDistanceConditions = { mass: 1000, pressureAltitude: 5000, temperature: 20 }
+
+function conditions(over: Partial<PohDistanceConditions>): PohDistanceConditions {
+  return { ...WITHIN, ...over }
+}
+
+describe('extrapolation constants', () => {
+  it('fixes the cap at 10% and the penalty at 20%', () => {
+    expect(EXTRAPOLATION_CAP_FRACTION).toBe(0.1)
+    expect(EXTRAPOLATION_PENALTY_FRACTION).toBe(0.2)
+    expect(EXTRAPOLATION_LIMITS).toEqual({ capFraction: 0.1, penaltyFraction: 0.2 })
+  })
+
+  it('is frozen so it cannot be made user-configurable at runtime', () => {
+    expect(Object.isFrozen(EXTRAPOLATION_LIMITS)).toBe(true)
+    expect(() => {
+      ;(EXTRAPOLATION_LIMITS as { capFraction: number }).capFraction = 0.5
+    }).toThrow(TypeError)
+    expect(EXTRAPOLATION_LIMITS.capFraction).toBe(0.1)
+  })
+})
+
+describe('classifyAxisExcursion', () => {
+  it('reports "within" at and inside both boundaries', () => {
+    expect(classifyAxisExcursion(0, { min: 0, max: 10 }).direction).toBe('within')
+    expect(classifyAxisExcursion(10, { min: 0, max: 10 }).direction).toBe('within')
+    expect(classifyAxisExcursion(5, { min: 0, max: 10 }).direction).toBe('within')
+  })
+
+  it('reports "better" below the minimum (benefit direction)', () => {
+    const e = classifyAxisExcursion(-1, { min: 0, max: 10 })
+    expect(e.direction).toBe('better')
+    expect(e.beyondCap).toBe(false)
+    expect(e.worseFraction).toBe(0)
+  })
+
+  it('reports "worse" within the 10% cap', () => {
+    const e = classifyAxisExcursion(11_000, { min: 0, max: 10_000 })
+    expect(e.direction).toBe('worse')
+    expect(e.worseFraction).toBeCloseTo(0.1, 10)
+    expect(e.beyondCap).toBe(false)
+  })
+
+  it('treats exactly the 10% boundary as within the cap', () => {
+    expect(classifyAxisExcursion(55, { min: -20, max: 50 }).beyondCap).toBe(false)
+  })
+
+  it('reports "worse" beyond the cap', () => {
+    const e = classifyAxisExcursion(11_100, { min: 0, max: 10_000 })
+    expect(e.direction).toBe('worse')
+    expect(e.worseFraction).toBeCloseTo(0.11, 10)
+    expect(e.beyondCap).toBe(true)
+  })
+
+  it('blocks any excursion above a non-positive maximum', () => {
+    const e = classifyAxisExcursion(5, { min: -10, max: 0 })
+    expect(e.direction).toBe('worse')
+    expect(e.worseFraction).toBe(Number.POSITIVE_INFINITY)
+    expect(e.beyondCap).toBe(true)
+  })
+
+  it('throws on a non-finite value', () => {
+    expect(() => classifyAxisExcursion(Number.NaN, { min: 0, max: 10 })).toThrow(/finite/)
+    expect(() => classifyAxisExcursion(Number.POSITIVE_INFINITY, { min: 0, max: 10 })).toThrow(/finite/)
+  })
+
+  it('throws on non-finite range bounds', () => {
+    expect(() => classifyAxisExcursion(5, { min: Number.NaN, max: 10 })).toThrow(/finite/)
+    expect(() => classifyAxisExcursion(5, { min: 0, max: Number.POSITIVE_INFINITY })).toThrow(/finite/)
+  })
+
+  it('throws when min exceeds max', () => {
+    expect(() => classifyAxisExcursion(5, { min: 10, max: 0 })).toThrow(/min.*max/)
+  })
+})
+
+describe('assessExtrapolation', () => {
+  it('is within the envelope when every axis is in range', () => {
+    const a = assessExtrapolation(WITHIN, RANGES)
+    expect(a.state).toBe('within_envelope')
+    expect(a.requiresAcknowledgment).toBe(false)
+    expect(a.benefitCapped).toBe(false)
+    expect(a.penaltyFactor).toBe(1)
+  })
+
+  it('marks extrapolated + acknowledgment when one axis is worse within cap', () => {
+    const a = assessExtrapolation(conditions({ temperature: 54 }), RANGES)
+    expect(a.state).toBe('extrapolated')
+    expect(a.requiresAcknowledgment).toBe(true)
+    expect(a.penaltyFactor).toBe(1.2)
+  })
+
+  it('blocks when any axis is beyond the cap', () => {
+    const a = assessExtrapolation(conditions({ pressureAltitude: 11_100 }), RANGES)
+    expect(a.state).toBe('blocked')
+    expect(a.requiresAcknowledgment).toBe(false)
+  })
+
+  it('beyond-cap on one axis dominates worse-within-cap on another', () => {
+    const a = assessExtrapolation(conditions({ temperature: 54, pressureAltitude: 11_100 }), RANGES)
+    expect(a.state).toBe('blocked')
+  })
+
+  it('flags benefitCapped for a below-minimum axis without requiring acknowledgment', () => {
+    const a = assessExtrapolation(conditions({ temperature: -40 }), RANGES)
+    expect(a.state).toBe('within_envelope')
+    expect(a.benefitCapped).toBe(true)
+    expect(a.requiresAcknowledgment).toBe(false)
+    expect(a.penaltyFactor).toBe(1)
+  })
+
+  it('combines extrapolation on one axis with benefit capping on another', () => {
+    const a = assessExtrapolation(conditions({ temperature: 54, mass: 800 }), RANGES)
+    expect(a.state).toBe('extrapolated')
+    expect(a.benefitCapped).toBe(true)
+    expect(a.requiresAcknowledgment).toBe(true)
+  })
+
+  it('detects a worse excursion independently on each axis', () => {
+    expect(assessExtrapolation(conditions({ mass: 2000 }), RANGES).state).toBe('blocked')
+    expect(assessExtrapolation(conditions({ mass: 1200 }), RANGES).state).toBe('extrapolated')
+    expect(assessExtrapolation(conditions({ pressureAltitude: 10_500 }), RANGES).state).toBe('extrapolated')
+    expect(assessExtrapolation(conditions({ temperature: 52 }), RANGES).state).toBe('extrapolated')
+  })
+})
+
+describe('applyExtrapolationPenalty', () => {
+  it('leaves a within-envelope distance unchanged', () => {
+    const a = assessExtrapolation(WITHIN, RANGES)
+    expect(applyExtrapolationPenalty(1000, a)).toBe(1000)
+  })
+
+  it('applies the +20% penalty to an extrapolated distance', () => {
+    const a = assessExtrapolation(conditions({ temperature: 54 }), RANGES)
+    expect(applyExtrapolationPenalty(1000, a)).toBeCloseTo(1200, 10)
+  })
+
+  it('never returns a distance shorter than the base (Minimum Distance Rule)', () => {
+    const a = assessExtrapolation(conditions({ temperature: -40 }), RANGES)
+    expect(applyExtrapolationPenalty(1000, a)).toBeGreaterThanOrEqual(1000)
+  })
+
+  it('throws on a non-finite base distance', () => {
+    const a = assessExtrapolation(WITHIN, RANGES)
+    expect(() => applyExtrapolationPenalty(Number.NaN, a)).toThrow(/finite/)
+  })
+})
+
+describe('cubeEnvelopeRanges', () => {
+  it('derives min/max ranges from a performance cube', () => {
+    const cube: PerformanceCube3D = {
+      massAxis: [850, 1000, 1157],
+      altitudeAxis: [0, 5000, 10_000],
+      temperatureAxis: [-20, 0, 50],
+      values: [[[0]]],
+    }
+    expect(cubeEnvelopeRanges(cube)).toEqual(RANGES)
+  })
+})
+
+describe('resolveExtrapolatedDistance', () => {
+  it('passes a within-envelope point through unchanged', () => {
+    const r = resolveExtrapolatedDistance(1000, WITHIN, RANGES)
+    expect(r.state).toBe('within_envelope')
+    if (r.state === 'blocked') throw new Error('unexpected block')
+    expect(r.distance).toBe(1000)
+    expect(r.requiresAcknowledgment).toBe(false)
+    expect(r.benefitCapped).toBe(false)
+  })
+
+  it('penalises and flags acknowledgment for a within-cap extrapolation', () => {
+    const r = resolveExtrapolatedDistance(1000, conditions({ temperature: 54 }), RANGES)
+    expect(r.state).toBe('extrapolated')
+    if (r.state === 'blocked') throw new Error('unexpected block')
+    expect(r.distance).toBeCloseTo(1200, 10)
+    expect(r.requiresAcknowledgment).toBe(true)
+  })
+
+  it('floors a benefit excursion at the best-case POH distance', () => {
+    const r = resolveExtrapolatedDistance(1000, conditions({ temperature: -40 }), RANGES)
+    expect(r.state).toBe('within_envelope')
+    if (r.state === 'blocked') throw new Error('unexpected block')
+    expect(r.distance).toBe(1000)
+    expect(r.benefitCapped).toBe(true)
+    expect(r.requiresAcknowledgment).toBe(false)
+  })
+
+  it('blocks beyond the cap and carries no distance', () => {
+    const r = resolveExtrapolatedDistance(1000, conditions({ pressureAltitude: 11_100 }), RANGES)
+    expect(r.state).toBe('blocked')
+    if (r.state !== 'blocked') throw new Error('expected block')
+    expect(r.reason).toBe('extrapolation_exceeds_cap')
+    expect(r.message).toContain('10%')
+    expect(r.assessment).not.toBeNull()
+    expect('distance' in r).toBe(false)
+  })
+
+  it('blocks with invalid_input on a non-finite base distance', () => {
+    const r = resolveExtrapolatedDistance(Number.NaN, WITHIN, RANGES)
+    expect(r.state).toBe('blocked')
+    if (r.state !== 'blocked') throw new Error('expected block')
+    expect(r.reason).toBe('invalid_input')
+    expect(r.assessment).toBeNull()
+  })
+
+  it('blocks with invalid_input on a non-finite condition', () => {
+    const r = resolveExtrapolatedDistance(1000, conditions({ mass: Number.POSITIVE_INFINITY }), RANGES)
+    expect(r.state).toBe('blocked')
+    if (r.state !== 'blocked') throw new Error('expected block')
+    expect(r.reason).toBe('invalid_input')
+  })
+
+  it('blocks with invalid_input when a range is structurally invalid', () => {
+    const badRanges: EnvelopeRanges = { ...RANGES, mass: { min: 2000, max: 1000 } }
+    const r = resolveExtrapolatedDistance(1000, WITHIN, badRanges)
+    expect(r.state).toBe('blocked')
+    if (r.state !== 'blocked') throw new Error('expected block')
+    expect(r.reason).toBe('invalid_input')
+    expect(r.assessment).toBeNull()
+  })
+})

--- a/frontend/src/core/logic/performance.extrapolation.ts
+++ b/frontend/src/core/logic/performance.extrapolation.ts
@@ -1,0 +1,302 @@
+/**
+ * Conservative extrapolation control for POH performance distances.
+ * P1 Safety Core — pure TypeScript, no framework dependencies.
+ *
+ * Sibling to {@link ./performance.poh-distance}. The trilinear engine *clamps*
+ * an out-of-envelope operating point to the nearest POH boundary and only
+ * reports a boolean clamp flag; it never decides whether that excursion is
+ * survivable. This module is that decision layer:
+ *
+ *   - Beyond the certified envelope toward *worse* conditions (higher mass, PA,
+ *     or temperature) extrapolation is permitted only up to a fixed 10% of the
+ *     boundary value, with a fixed +20% distance penalty applied to the clamped
+ *     boundary distance (REQ-PF-010 / H-007, H-012).
+ *   - Past that 10% band computation is BLOCKED — no distance is returned at all
+ *     (REQ-PF-010 / H-012).
+ *   - Toward *better* conditions (below the envelope minimum) no benefit is
+ *     granted: the distance is floored at the best-case POH value and can never
+ *     come out shorter than the documented minimum (REQ-PF-011 / H-013,
+ *     "Minimum Distance Rule").
+ *   - Any permitted extrapolation flags the result as requiring explicit
+ *     pilot-in-command acknowledgment before it may be used (REQ-PF-012 / H-012).
+ *
+ * Monotonicity assumption: for all four POH distance types required distance is
+ * non-decreasing in mass, pressure altitude, and temperature — so "above the
+ * axis maximum" is always the conservative-penalty direction and "below the
+ * axis minimum" is always the benefit (floor) direction.
+ *
+ * @see ./performance.poh-distance
+ * @see docs/requirements/performance.md
+ */
+
+import type { PohDistanceConditions, PerformanceCube3D } from './performance.poh-distance'
+
+// ── Immutable safety constants ───────────────────────────────────────────────
+
+// @IMP-PF-CORE-006@ (FROM: @REQ-PF-010@)
+/**
+ * Maximum permitted extrapolation past a POH axis boundary, as a fraction of
+ * that boundary value (10%). Beyond this, computation is blocked.
+ */
+export const EXTRAPOLATION_CAP_FRACTION = 0.1
+
+/** Fixed safety penalty applied to any extrapolated distance (+20%). */
+export const EXTRAPOLATION_PENALTY_FRACTION = 0.2
+
+/**
+ * Frozen aggregate of the two governing constants. These are fixed by
+ * regulation intent and MUST NOT be made user-configurable — the freeze makes
+ * accidental runtime mutation fail loudly in strict mode.
+ */
+export const EXTRAPOLATION_LIMITS = Object.freeze({
+  capFraction: EXTRAPOLATION_CAP_FRACTION,
+  penaltyFraction: EXTRAPOLATION_PENALTY_FRACTION,
+} as const)
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/** Inclusive min/max of one POH interpolation axis. */
+export interface AxisRange {
+  /** Lowest tabulated break-point on the axis. */
+  readonly min: number
+  /** Highest tabulated break-point on the axis. */
+  readonly max: number
+}
+
+/** The three POH interpolation axes, paired with the requested operating point. */
+export interface EnvelopeRanges {
+  /** Mass axis range (kg). */
+  readonly mass: AxisRange
+  /** Pressure altitude axis range (ft). */
+  readonly pressureAltitude: AxisRange
+  /** Temperature axis range (°C). */
+  readonly temperature: AxisRange
+}
+
+/** Where a requested value sits relative to one axis. */
+export type ExcursionDirection = 'within' | 'worse' | 'better'
+
+/** Classification of a single axis excursion. */
+export interface AxisExcursion {
+  readonly direction: ExcursionDirection
+  /**
+   * Excursion past the axis maximum, as a fraction of that maximum. Zero unless
+   * `direction === 'worse'`; `Infinity` when the maximum is not strictly
+   * positive (no finite extrapolation band can be defined → always blocked).
+   */
+  readonly worseFraction: number
+  /** True when a `worse` excursion exceeds {@link EXTRAPOLATION_CAP_FRACTION}. */
+  readonly beyondCap: boolean
+}
+
+/** Overall extrapolation state for an operating point. */
+export type ExtrapolationState = 'within_envelope' | 'extrapolated' | 'blocked'
+
+/** Result of {@link assessExtrapolation}. */
+export interface ExtrapolationAssessment {
+  readonly state: ExtrapolationState
+  /** True iff `state === 'extrapolated'` — the REQ-PF-012 acknowledgment gate. */
+  readonly requiresAcknowledgment: boolean
+  /** True when at least one axis was floored at its best-case POH value. */
+  readonly benefitCapped: boolean
+  /** Distance multiplier: `1.2` when extrapolated, otherwise `1`. Never < 1. */
+  readonly penaltyFactor: number
+  readonly axes: {
+    readonly mass: AxisExcursion
+    readonly pressureAltitude: AxisExcursion
+    readonly temperature: AxisExcursion
+  }
+}
+
+/** A usable extrapolation result with a concrete distance. */
+export interface ExtrapolationResolvedOk {
+  readonly state: 'within_envelope' | 'extrapolated'
+  /** Penalised distance (m). Never shorter than `baseDistance`. */
+  readonly distance: number
+  readonly requiresAcknowledgment: boolean
+  readonly benefitCapped: boolean
+  readonly assessment: ExtrapolationAssessment
+}
+
+/** A blocked extrapolation result — by construction it carries no distance. */
+export interface ExtrapolationResolvedBlocked {
+  readonly state: 'blocked'
+  readonly reason: 'extrapolation_exceeds_cap' | 'invalid_input'
+  readonly message: string
+  /** Present for `extrapolation_exceeds_cap`; `null` when inputs were unusable. */
+  readonly assessment: ExtrapolationAssessment | null
+}
+
+export type ExtrapolationResolved = ExtrapolationResolvedOk | ExtrapolationResolvedBlocked
+
+// ── Axis classification ──────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-007@ (FROM: @REQ-PF-010@, @REQ-PF-011@)
+/**
+ * Classify where `value` sits relative to one POH axis.
+ *
+ * Precondition: `value` is finite and `range.min <= range.max` with finite
+ * bounds — a structural violation throws `[PF-EXTRAP]` (mirrors the sibling
+ * engine's fail-loud contract for malformed grids).
+ */
+export function classifyAxisExcursion(value: number, range: AxisRange): AxisExcursion {
+  const { min, max } = range
+  if (!Number.isFinite(value)) {
+    throw new Error('[PF-EXTRAP] axis value must be a finite number.')
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    throw new Error('[PF-EXTRAP] axis range bounds must be finite numbers.')
+  }
+  if (min > max) {
+    throw new Error(`[PF-EXTRAP] axis range min (${min}) must not exceed max (${max}).`)
+  }
+
+  if (value > max) {
+    // A 10% band is only meaningful relative to a strictly positive bound; a
+    // non-positive maximum (degenerate/sea-level axis) admits no extrapolation.
+    const worseFraction = max > 0 ? (value - max) / max : Number.POSITIVE_INFINITY
+    return { direction: 'worse', worseFraction, beyondCap: worseFraction > EXTRAPOLATION_CAP_FRACTION }
+  }
+  if (value < min) {
+    return { direction: 'better', worseFraction: 0, beyondCap: false }
+  }
+  return { direction: 'within', worseFraction: 0, beyondCap: false }
+}
+
+// ── Aggregate assessment ─────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-008@ (FROM: @REQ-PF-010@, @REQ-PF-011@, @REQ-PF-012@)
+/**
+ * Assess the combined extrapolation state across all three axes.
+ *
+ * Aggregation is conservative: a single axis beyond the cap blocks the whole
+ * computation; any worse-but-within-cap axis marks the result extrapolated
+ * (penalty + acknowledgment); a below-minimum axis only flags `benefitCapped`.
+ *
+ * Precondition (same as {@link classifyAxisExcursion}): finite conditions and
+ * valid ranges. The fail-safe wrapper is {@link resolveExtrapolatedDistance}.
+ */
+export function assessExtrapolation(
+  conditions: PohDistanceConditions,
+  ranges: EnvelopeRanges,
+): ExtrapolationAssessment {
+  const mass = classifyAxisExcursion(conditions.mass, ranges.mass)
+  const pressureAltitude = classifyAxisExcursion(conditions.pressureAltitude, ranges.pressureAltitude)
+  const temperature = classifyAxisExcursion(conditions.temperature, ranges.temperature)
+  const axes = { mass, pressureAltitude, temperature }
+  const list = [mass, pressureAltitude, temperature]
+
+  const blocked = list.some((a) => a.direction === 'worse' && a.beyondCap)
+  const extrapolated = !blocked && list.some((a) => a.direction === 'worse')
+  const benefitCapped = list.some((a) => a.direction === 'better')
+
+  const state: ExtrapolationState = blocked
+    ? 'blocked'
+    : extrapolated
+      ? 'extrapolated'
+      : 'within_envelope'
+
+  return {
+    state,
+    requiresAcknowledgment: extrapolated,
+    benefitCapped,
+    penaltyFactor: extrapolated ? 1 + EXTRAPOLATION_PENALTY_FRACTION : 1,
+    axes,
+  }
+}
+
+// ── Penalty application ──────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-009@ (FROM: @REQ-PF-010@, @REQ-PF-011@)
+/**
+ * Apply an assessment's penalty to a base (clamped) POH distance.
+ *
+ * The `Math.max` floor is belt-and-braces enforcement of REQ-PF-011: with
+ * `penaltyFactor >= 1` always, the result can never undercut `baseDistance`.
+ * Throws `[PF-EXTRAP]` on a non-finite `baseDistance`.
+ */
+export function applyExtrapolationPenalty(
+  baseDistance: number,
+  assessment: ExtrapolationAssessment,
+): number {
+  if (!Number.isFinite(baseDistance)) {
+    throw new Error('[PF-EXTRAP] baseDistance must be a finite number.')
+  }
+  return Math.max(baseDistance, baseDistance * assessment.penaltyFactor)
+}
+
+// ── Cube → ranges helper ─────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-010@ (FROM: @REQ-PF-010@)
+/**
+ * Derive {@link EnvelopeRanges} from a {@link PerformanceCube3D} so the
+ * extrapolation layer can compose directly with the trilinear engine's cubes.
+ */
+export function cubeEnvelopeRanges(cube: PerformanceCube3D): EnvelopeRanges {
+  return {
+    mass: { min: cube.massAxis[0]!, max: cube.massAxis[cube.massAxis.length - 1]! },
+    pressureAltitude: { min: cube.altitudeAxis[0]!, max: cube.altitudeAxis[cube.altitudeAxis.length - 1]! },
+    temperature: { min: cube.temperatureAxis[0]!, max: cube.temperatureAxis[cube.temperatureAxis.length - 1]! },
+  }
+}
+
+// ── Fail-safe facade ─────────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-011@ (FROM: @REQ-PF-010@, @REQ-PF-011@, @REQ-PF-012@)
+/**
+ * Resolve a base (clamped) POH distance into either a usable penalised distance
+ * or a typed `blocked` result — never throws, never returns a distance for a
+ * blocked operating point.
+ *
+ * This is the safety boundary of the module: a `blocked` state cannot, by
+ * construction of {@link ExtrapolationResolved}, carry a distance into a
+ * Go/No-Go decision.
+ */
+export function resolveExtrapolatedDistance(
+  baseDistance: number,
+  conditions: PohDistanceConditions,
+  ranges: EnvelopeRanges,
+): ExtrapolationResolved {
+  if (
+    !Number.isFinite(baseDistance) ||
+    !Number.isFinite(conditions.mass) ||
+    !Number.isFinite(conditions.pressureAltitude) ||
+    !Number.isFinite(conditions.temperature)
+  ) {
+    return {
+      state: 'blocked',
+      reason: 'invalid_input',
+      message: 'baseDistance and all conditions must be finite numbers.',
+      assessment: null,
+    }
+  }
+
+  let assessment: ExtrapolationAssessment
+  try {
+    assessment = assessExtrapolation(conditions, ranges)
+  } catch (err) {
+    return {
+      state: 'blocked',
+      reason: 'invalid_input',
+      message: err instanceof Error ? err.message : String(err),
+      assessment: null,
+    }
+  }
+
+  if (assessment.state === 'blocked') {
+    return {
+      state: 'blocked',
+      reason: 'extrapolation_exceeds_cap',
+      message: `Operating point exceeds the ${EXTRAPOLATION_CAP_FRACTION * 100}% extrapolation boundary; computation blocked.`,
+      assessment,
+    }
+  }
+
+  return {
+    state: assessment.state,
+    distance: applyExtrapolationPenalty(baseDistance, assessment),
+    requiresAcknowledgment: assessment.requiresAcknowledgment,
+    benefitCapped: assessment.benefitCapped,
+    assessment,
+  }
+}

--- a/trace/implementation/pf.yaml
+++ b/trace/implementation/pf.yaml
@@ -41,3 +41,52 @@ PF Core — POH Distance (3-D Trilinear) Facade
       - REQ-AC-005
     files:
       - frontend/src/core/logic/performance.poh-distance.ts
+
+PF Core — Conservative Extrapolation Control
+  IMP-PF-CORE-006
+    title: Immutable extrapolation cap (10%) and penalty (20%) constants
+    files:
+      - frontend/src/core/logic/performance.extrapolation.ts
+    req:
+      - REQ-PF-010
+
+  IMP-PF-CORE-007
+    title: classifyAxisExcursion — per-axis envelope excursion + 10% cap classification
+    files:
+      - frontend/src/core/logic/performance.extrapolation.ts
+    req:
+      - REQ-PF-010
+      - REQ-PF-011
+
+  IMP-PF-CORE-008
+    title: assessExtrapolation — combined extrapolation state + acknowledgment gate
+    files:
+      - frontend/src/core/logic/performance.extrapolation.ts
+    req:
+      - REQ-PF-010
+      - REQ-PF-011
+      - REQ-PF-012
+
+  IMP-PF-CORE-009
+    title: applyExtrapolationPenalty — +20% penalty with Minimum Distance floor
+    files:
+      - frontend/src/core/logic/performance.extrapolation.ts
+    req:
+      - REQ-PF-010
+      - REQ-PF-011
+
+  IMP-PF-CORE-010
+    title: cubeEnvelopeRanges — derive axis ranges from a performance cube
+    files:
+      - frontend/src/core/logic/performance.extrapolation.ts
+    req:
+      - REQ-PF-010
+
+  IMP-PF-CORE-011
+    title: resolveExtrapolatedDistance — fail-safe extrapolation facade (block/penalise/floor)
+    files:
+      - frontend/src/core/logic/performance.extrapolation.ts
+    req:
+      - REQ-PF-010
+      - REQ-PF-011
+      - REQ-PF-012

--- a/trace/unit_test/pf.yaml
+++ b/trace/unit_test/pf.yaml
@@ -289,3 +289,16 @@ PF Core — POH Distance (Trilinear / Pivot / Verified Gate) (Unit)
       - IMP-PF-CORE-005
     files:
       - frontend/src/core/logic/performance.poh-distance.spec.ts
+
+PF Core — Conservative Extrapolation Control (Unit)
+  UT-PF-CORE-042
+    title: Extrapolation control — 10% cap, +20% penalty, Minimum Distance floor, acknowledgment state, immutable constants
+    files:
+      - frontend/src/core/logic/performance.extrapolation.spec.ts
+    impl:
+      - IMP-PF-CORE-006
+      - IMP-PF-CORE-007
+      - IMP-PF-CORE-008
+      - IMP-PF-CORE-009
+      - IMP-PF-CORE-010
+      - IMP-PF-CORE-011


### PR DESCRIPTION
### Summary

Implements the P1 Safety-Core **conservative extrapolation control** (sibling to the existing trilinear POH-distance engine):

- **10% extrapolation cap**, measured relative to the POH axis boundary value (worse direction = higher mass / pressure altitude / temperature). Computation is **blocked** past the cap — a blocked result carries no distance by construction.
- **Fixed +20% distance penalty** applied to any within-cap (worse-direction) extrapolation.
- **Minimum Distance floor** (benefit direction, below the envelope minimum): the result is never shorter than the best-case POH value.
- **`requiresAcknowledgment`** result state for any permitted extrapolation.
- Cap (10%) and penalty (20%) are **immutable, non-user-configurable** constants (`Object.freeze`).

Cap semantics are pinned to **UJ-C-001**: 11,100 ft over a 10,000 ft max → blocked (11%); 54 °C over a 50 °C max → extrapolated; 57 °C → blocked.

New files: `frontend/src/core/logic/performance.extrapolation.ts` (+ `.spec.ts`, 30 tests). Placed in the established `core/logic/performance.*` namespace rather than the literal `core/performance/` path written in the ticket.

### Related Issues

- Closes #308
- Refs #299 — parent feature stays **open**; see *What remains* below.

### Issue State Management (Post-Merge)
- [x] If merging to `develop`: Issue #308 auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items
- **Requirements Implemented/Affected:** `REQ-PF-010`, `REQ-PF-011`, `REQ-PF-012` (math core implemented; statuses left `Approved` — see *What remains*). Hazards `H-007`, `H-012`, `H-013`.

### Documentation Updates
- [x] **Requirements:** `N/A` (Reason: REQ-PF-010/011/012 already authored; status intentionally unchanged — the user-facing acknowledgment UI + E2E that complete these REQs remain under #299).
- [x] **Architecture:** `N/A` (Reason: no change to P1 interface conventions; reuses existing `performance.*` module/result patterns — no ADR-triggering surface change).
- [x] **Risk Management:** `N/A` (Reason: H-007/H-012/H-013 already mapped to these REQs in the hazard register; this PR implements the mitigation in code, no register edit needed).
- [x] **Journeys:** `N/A` (Reason: UJ-C-001 already traces REQ-PF-010/012; E2E authoring belongs to #299).
- [x] **Code Docs:** `N/A` (Reason: `CHANGELOG.md` is reserved for the release process per the implement-issue workflow; the module is self-documenting and trace-tagged).

### Safety Considerations
- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved (the trilinear engine's clamping is composed, not changed).
- [x] P1 isolation maintained (pure TS, zero `vue`/`pinia`/`vue-router` imports; type-only imports from sibling P1 module; verified under `vitest.config.p1.ts`).

### Quality & Testing Checklist
- [x] **Target Branch:** targets `develop`.
- [x] **Unit Tests:** added (`performance.extrapolation.spec.ts`, 30 cases) and passing — full unit suite 1622 ✓.
- [x] **Integration Tests:** passing (74 ✓); no integration surface changed by this P1-only module.
- [x] **Manual Testing:** `N/A` (Reason: pure P1 math with no UI; behaviour is fully covered by deterministic unit tests; manual testing is mandatory only for `main`).
- [x] **DoD:** all five #308 DoD items met and ticked on the issue. (Parent #299 DoD is **not** asserted here — it is `Refs`, not `Closes`.)
- [x] **Review:** self-review of code, tests, and trace registries performed.
- [x] **ADR:** `N/A` (Reason: no change to the fundamental operation of a P1 module, no new top-level `src/` directory; existing isolation rules unchanged).

### Formal Review Request (FRR) — P1 Safety Core
Per CONTRIBUTING §7 / ADR-317-DEV, this machine-authored P1 change is a **Draft** and requires **Lead-Developer** sign-off (the automated reviewer cannot satisfy that gate).

| Field | Detail |
| :-- | :-- |
| **REQ** | REQ-PF-010 (cap + 20% penalty), REQ-PF-011 (Minimum Distance Rule), REQ-PF-012 (acknowledgment state) |
| **Hazards** | H-007, H-012 (extrapolation errors), H-013 (optimistic low-end extrapolation) |
| **Output impact** | Gates/penalises POH distances that feed the Go/No-Go advisory; `blocked` states cannot carry a distance into a decision (fail-safe by type). |
| **Pure-TS guarantee** | Yes — no framework deps; only a type-only import from `performance.poh-distance`. |
| **Deterministic guarantee** | Yes — pure functions, no I/O, no `Date`/random; identical inputs → identical outputs. |
| **Zod plan** | No new external input boundary — inputs are SI scalars already validated upstream (`aircraft.schema`). Defensive finiteness/range guards added; non-finite/invalid inputs fail safe to `blocked: invalid_input`. |
| **Formula** | Worse excursion fraction `f = (v − max) / max` for `v > max` (`max > 0`); within cap iff `f ≤ 0.10`. Penalised distance `d' = max(d, 1.20·d)`; benefit direction floors to `d` (never `< d`). |
| **Unit normalization** | Operates on the engine's SI/native axis units (kg, ft, °C → m); no conversion introduced. |
| **Test plan** | 30 unit tests across `classifyAxisExcursion`, `assessExtrapolation`, `applyExtrapolationPenalty`, `cubeEnvelopeRanges`, `resolveExtrapolatedDistance`. |
| **Edge cases (≥3)** | exactly at 10% cap → within; just past cap → blocked; below-min benefit → floored; non-positive axis max → blocked; non-finite value/bounds → throw/`invalid_input`; `min > max` → `invalid_input`. |
| **ADR need** | None — no P1 interface-convention or workflow change. |

**P1 coverage (new file):** 100% statements / 97.22% branch / 100% functions / 100% lines (≥ 90% gate). The single uncovered branch is the defensive `String(err)` non-Error fallback, mirroring the sibling `poh-distance.ts`.

### What remains (parent #299 stays open)
This task delivers only the **P1 math core**. The parent feature's remaining DoD is **not** done here and cannot be truthfully attested, so #299 is referenced (not closed):
- **Pilot-acknowledgment enforcement UI** — the core exposes `requiresAcknowledgment`; the actual "result not accepted without confirmation" UX is unbuilt (`modules/performance/` is currently empty).
- **E2E for UJ-C-001 and UJ-E-003** — requires the performance view/workflow, out of scope for this P1-only module.

Because of these, REQ-PF-010/011/012 are left at status `Approved` (now with downstream `IMP` links, clearing the pending-requirements gate); they will flip to `Implemented` when #299's UI + E2E land.

### Out-of-band notes (CI run)
- **Project board:** not updated — the CI App token lacks `project` scope and #308 is not on the board; board status is left to the workflow/ready-gate.
- **Trace:** `IMP-PF-CORE-006..011`, `UT-PF-CORE-042` added; `trace sync --apply` + structural ratchet clean (no new violations).
- **Local pipeline (all green):** `pnpm lint`, `type-check`, `test:unit` (1622), `test:integration` (74), `build`, P1 coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
