### PR TITLE
feat: [Task]: CAA SSL 07 estimation + computed-flag propagation (P1) (#310)

### DIFF
--- a/frontend/src/core/adapters/performance.estimation.adapter.spec.ts
+++ b/frontend/src/core/adapters/performance.estimation.adapter.spec.ts
@@ -1,0 +1,51 @@
+// @UT-PF-CORE-046@ (FROM: @IMP-PF-CORE-025@, @IMP-PF-CORE-026@)
+
+import { describe, it, expect } from 'vitest'
+import { applyEstimation, EstimationInputSchema } from './performance.estimation.adapter'
+
+describe('applyEstimation — happy path', () => {
+  it('estimates a missing 50 ft distance from validated input', () => {
+    const result = applyEstimation({ takeoffRoll: 300, landingRoll: 200 })
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') throw new Error('expected success')
+    expect(result.anyEstimated).toBe(true)
+    expect(result.distances.takeoffDistance50ft.provenance).toBe('estimated')
+    expect(result.distances.takeoffDistance50ft.value).toBeCloseTo(570, 10)
+  })
+
+  it('passes fully-published POH data through unestimated', () => {
+    const result = applyEstimation({
+      takeoffRoll: 300,
+      takeoffDistance50ft: 600,
+      landingRoll: 250,
+      landingDistance50ft: 450,
+    })
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') throw new Error('expected success')
+    expect(result.anyEstimated).toBe(false)
+  })
+})
+
+describe('applyEstimation — Zod boundary rejects unsafe input (never throws)', () => {
+  it.each([
+    ['null', null],
+    ['a string', 'TOR=300'],
+    ['a non-finite distance', { takeoffRoll: Number.POSITIVE_INFINITY, landingRoll: 200 }],
+    ['a NaN distance', { takeoffRoll: Number.NaN, landingRoll: 200 }],
+    ['a zero distance', { takeoffRoll: 0, landingRoll: 200 }],
+    ['a negative distance', { takeoffRoll: -5, landingRoll: 200 }],
+    ['an absurdly large distance', { takeoffRoll: 1_000_000, landingRoll: 200 }],
+    ['a non-numeric field', { takeoffRoll: '300', landingRoll: 200 }],
+  ])('returns invalid_input for %s', (_label, input) => {
+    const result = applyEstimation(input)
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') throw new Error('expected failure')
+    expect(result.reason).toBe('invalid_input')
+  })
+})
+
+describe('EstimationInputSchema', () => {
+  it('accepts an empty object (all gaps) — resolution failure is decided downstream, not at the schema', () => {
+    expect(EstimationInputSchema.safeParse({}).success).toBe(true)
+  })
+})

--- a/frontend/src/core/adapters/performance.estimation.adapter.ts
+++ b/frontend/src/core/adapters/performance.estimation.adapter.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+import {
+  estimateBaseDistances,
+  type EstimationInput,
+  type EstimationResult,
+} from '../logic/performance.estimation'
+
+// @IMP-PF-CORE-026@ (FROM: @REQ-SYS-011@, @REQ-SYS-012@, @REQ-PF-005@)
+// Every distance is `.finite()` and `.gt(0)`: bare `z.number()` accepts ±Infinity
+// and 0, which would propagate a non-physical base value (and, via the ratio, a
+// non-physical estimate) into the Go/No-Go advisory. The generous SI ceiling
+// rejects absurd magnitudes before they reach the math. All values are
+// SI-normalised (metres) at the store boundary; each is optional because a gap
+// is the very case CAA SSL 07 estimation exists to fill (REQ-PF-005).
+const MAX_DISTANCE_M = 100_000
+const optionalDistance = () => z.number().finite().gt(0).max(MAX_DISTANCE_M).optional()
+
+export const EstimationInputSchema = z.object({
+  takeoffRoll: optionalDistance(),
+  takeoffDistance50ft: optionalDistance(),
+  landingRoll: optionalDistance(),
+  landingDistance50ft: optionalDistance(),
+})
+
+// @IMP-PF-CORE-025@ (FROM: @REQ-PF-005@, @REQ-PF-017@, @REQ-SYS-011@)
+/**
+ * Validate raw input with Zod, then resolve the four base distances (estimating
+ * a missing 50 ft distance via CAA SSL 07). On a validation failure it returns a
+ * typed `invalid_input` failure — it never throws.
+ */
+export function applyEstimation(input: unknown): EstimationResult {
+  const parsed = EstimationInputSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      status: 'failure',
+      reason: 'invalid_input',
+      message: 'Estimation input failed schema validation (finite, strictly-positive distances required).',
+    }
+  }
+  return estimateBaseDistances(parsed.data satisfies EstimationInput)
+}

--- a/frontend/src/core/logic/__tests__/performance.estimation.int.spec.ts
+++ b/frontend/src/core/logic/__tests__/performance.estimation.int.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration tests for CAA SSL 07 estimation across the persistence /
+ * transmission boundary and into the safety-factor pipeline — proving the data
+ * provenance contract of REQ-PF-005 / REQ-PF-017:
+ *
+ *   applyEstimation (Zod boundary, gap → estimate)
+ *     → structuredClone (IndexedDB persistence) + JSON (REST transmission)
+ *     → toBaseDistances → applySafetyFactors (Go/No-Go gate)
+ *
+ * The unit specs prove the estimator in isolation; this file proves an estimated
+ * value is never silently laundered into authoritative POH data — its
+ * `provenance: 'estimated'` marker survives every serialisation hop and the
+ * Go/No-Go computation, so a record read back from storage or the wire still
+ * shows the pilot the figure was a generic factor, not certified airframe data.
+ *
+ * The boundary is intentionally P1↔P1 (no Vue/Pinia): IndexedDB persists via the
+ * structured-clone algorithm and the sync transport serialises to JSON, so a
+ * structured-clone + JSON round-trip is a faithful proxy for both hops.
+ *
+ * @see ../performance.estimation.ts
+ * @see ../../adapters/performance.estimation.adapter.ts
+ */
+// @IT-PF-CORE-004@ (FROM: @IMP-PF-CORE-022@, @IMP-PF-CORE-025@, @IMP-PF-CORE-020@)
+
+import { describe, it, expect } from 'vitest'
+import { applyEstimation } from '../../adapters/performance.estimation.adapter'
+import { toBaseDistances, type EstimationSuccess } from '../performance.estimation'
+import { applySafetyFactors } from '../../adapters/performance.safety-factor.adapter'
+
+/** Older POH: take-off and landing rolls only — both 50 ft distances are gaps. */
+const ROLL_ONLY_PROFILE = {
+  takeoffRoll: 300,
+  landingRoll: 250,
+}
+
+/** Persistence (IndexedDB structured-clone) followed by transmission (JSON). */
+function persistAndTransmit<T>(record: T): T {
+  return JSON.parse(JSON.stringify(structuredClone(record))) as T
+}
+
+function succeed(result: ReturnType<typeof applyEstimation>): EstimationSuccess {
+  expect(result.status).toBe('success')
+  if (result.status !== 'success') throw new Error('expected success')
+  return result
+}
+
+describe('estimated-value provenance across persistence + transmission', () => {
+  it('retains the estimated flag and method after a structured-clone + JSON round-trip', () => {
+    const original = succeed(applyEstimation(ROLL_ONLY_PROFILE))
+    const restored = persistAndTransmit(original)
+
+    expect(restored.anyEstimated).toBe(true)
+    expect(restored.distances.takeoffDistance50ft.provenance).toBe('estimated')
+    expect(restored.distances.takeoffDistance50ft.method).toBe('caa-ssl-07')
+    expect(restored.distances.landingDistance50ft.provenance).toBe('estimated')
+    // The persisted record is byte-for-byte equal to what the pilot saw.
+    expect(restored).toEqual(original)
+  })
+
+  it('never presents an estimated value as authoritative POH data', () => {
+    const restored = persistAndTransmit(succeed(applyEstimation(ROLL_ONLY_PROFILE)))
+    const isAuthoritativePoh = (d: { provenance: string }) => d.provenance === 'poh'
+
+    // Published rolls stay authoritative; derived 50 ft distances do not.
+    expect(isAuthoritativePoh(restored.distances.takeoffRoll)).toBe(true)
+    expect(isAuthoritativePoh(restored.distances.takeoffDistance50ft)).toBe(false)
+    expect(isAuthoritativePoh(restored.distances.landingDistance50ft)).toBe(false)
+  })
+
+  it('keeps a published 50 ft distance authoritative through the round-trip', () => {
+    const restored = persistAndTransmit(
+      succeed(applyEstimation({ ...ROLL_ONLY_PROFILE, takeoffDistance50ft: 640 })),
+    )
+    expect(restored.distances.takeoffDistance50ft.provenance).toBe('poh')
+    expect(restored.distances.takeoffDistance50ft.value).toBe(640)
+    // The unpublished landing distance is still estimated alongside it.
+    expect(restored.distances.landingDistance50ft.provenance).toBe('estimated')
+  })
+})
+
+describe('estimated distances flow into the Go/No-Go pipeline without losing provenance', () => {
+  it('feeds the estimated base distances to applySafetyFactors while the flag stays on the persisted record', () => {
+    const persisted = persistAndTransmit(succeed(applyEstimation(ROLL_ONLY_PROFILE)))
+
+    const pipeline = applySafetyFactors({
+      base: toBaseDistances(persisted.distances),
+      factors: { friction: 1, slope: 1, densityAltitude: 1, wind: 1 },
+      osf: { preset: 'easa-standard' },
+      available: { takeoff: 2000, landing: 2000 },
+    })
+
+    expect(pipeline.status).toBe('success')
+    if (pipeline.status !== 'success') throw new Error('expected pipeline success')
+    // The estimated TOD (300 × 1.9 = 570) is the value the pipeline scaled by the
+    // OSF for the take-off required distance — proving the estimate actually
+    // drives Go/No-Go (unit correction factors leave only the OSF acting)…
+    expect(persisted.distances.takeoffDistance50ft.value).toBeCloseTo(570, 10)
+    expect(pipeline.takeoff.fullRequired).toBeCloseTo(570 * pipeline.takeoff.appliedOsf, 6)
+    // …yet the record retained alongside it still flags that figure as estimated.
+    expect(persisted.distances.takeoffDistance50ft.provenance).toBe('estimated')
+  })
+})

--- a/frontend/src/core/logic/performance.estimation.spec.ts
+++ b/frontend/src/core/logic/performance.estimation.spec.ts
@@ -1,0 +1,168 @@
+// @UT-PF-CORE-045@ (FROM: @IMP-PF-CORE-021@, @IMP-PF-CORE-022@, @IMP-PF-CORE-023@, @IMP-PF-CORE-024@)
+
+import { describe, it, expect } from 'vitest'
+import {
+  CAA_SSL_07_RATIOS,
+  ESTIMATION_METHOD_LABEL,
+  estimateObstacleDistance,
+  estimateBaseDistances,
+  toBaseDistances,
+  type EstimationSuccess,
+} from './performance.estimation'
+
+function expectSuccess(result: ReturnType<typeof estimateBaseDistances>): EstimationSuccess {
+  expect(result.status).toBe('success')
+  if (result.status !== 'success') throw new Error('expected success')
+  return result
+}
+
+const FULL_POH = {
+  takeoffRoll: 300,
+  takeoffDistance50ft: 600,
+  landingRoll: 250,
+  landingDistance50ft: 450,
+}
+
+describe('CAA SSL 07 constants', () => {
+  it('pins the take-off and landing conversion ratios from CAA SSL 07', () => {
+    expect(CAA_SSL_07_RATIOS.takeoff).toBe(1.9)
+    expect(CAA_SSL_07_RATIOS.landing).toBe(1.67)
+  })
+
+  it('freezes the ratios so they cannot be mutated at runtime', () => {
+    expect(Object.isFrozen(CAA_SSL_07_RATIOS)).toBe(true)
+  })
+
+  it('exposes the verbatim provenance label for UI and export', () => {
+    expect(ESTIMATION_METHOD_LABEL).toBe('ESTIMATED (CAA SSL 07)')
+  })
+})
+
+describe('estimateObstacleDistance', () => {
+  it('derives TOD from TOR via ×1.9', () => {
+    expect(estimateObstacleDistance('takeoff', 300)).toBeCloseTo(570, 10)
+  })
+
+  it('derives LD from LR via ×1.67', () => {
+    expect(estimateObstacleDistance('landing', 200)).toBeCloseTo(334, 10)
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'throws on a non-finite roll (%s)',
+    (roll) => {
+      expect(() => estimateObstacleDistance('takeoff', roll)).toThrow(/finite/)
+    },
+  )
+
+  it.each([0, -1, -250])('throws on a non-positive roll (%s)', (roll) => {
+    expect(() => estimateObstacleDistance('landing', roll)).toThrow(/strictly positive/)
+  })
+})
+
+describe('estimateBaseDistances — POH precedence', () => {
+  it('marks every distance as POH when all four are published', () => {
+    const { distances, anyEstimated } = expectSuccess(estimateBaseDistances(FULL_POH))
+    expect(anyEstimated).toBe(false)
+    for (const d of Object.values(distances)) {
+      expect(d.provenance).toBe('poh')
+      expect(d.method).toBeNull()
+    }
+    expect(distances.takeoffDistance50ft.value).toBe(600)
+    expect(distances.landingDistance50ft.value).toBe(450)
+  })
+
+  it('prefers a published 50 ft distance over the estimate when both roll and distance exist', () => {
+    const { distances, anyEstimated } = expectSuccess(
+      estimateBaseDistances({ ...FULL_POH, takeoffDistance50ft: 999 }),
+    )
+    expect(anyEstimated).toBe(false)
+    expect(distances.takeoffDistance50ft.provenance).toBe('poh')
+    expect(distances.takeoffDistance50ft.value).toBe(999)
+  })
+})
+
+describe('estimateBaseDistances — estimation', () => {
+  it('estimates a missing TOD from TOR and flags only it', () => {
+    const { distances, anyEstimated } = expectSuccess(
+      estimateBaseDistances({
+        takeoffRoll: 300,
+        landingRoll: 250,
+        landingDistance50ft: 450,
+      }),
+    )
+    expect(anyEstimated).toBe(true)
+    expect(distances.takeoffRoll.provenance).toBe('poh')
+    expect(distances.takeoffDistance50ft.provenance).toBe('estimated')
+    expect(distances.takeoffDistance50ft.method).toBe('caa-ssl-07')
+    expect(distances.takeoffDistance50ft.value).toBeCloseTo(570, 10)
+    expect(distances.landingDistance50ft.provenance).toBe('poh')
+  })
+
+  it('estimates a missing LD from LR via ×1.67', () => {
+    const { distances } = expectSuccess(
+      estimateBaseDistances({
+        takeoffRoll: 300,
+        takeoffDistance50ft: 600,
+        landingRoll: 200,
+      }),
+    )
+    expect(distances.landingDistance50ft.provenance).toBe('estimated')
+    expect(distances.landingDistance50ft.value).toBeCloseTo(334, 10)
+  })
+
+  it('estimates both 50 ft distances when only the rolls are published', () => {
+    const { distances, anyEstimated } = expectSuccess(
+      estimateBaseDistances({ takeoffRoll: 300, landingRoll: 200 }),
+    )
+    expect(anyEstimated).toBe(true)
+    expect(distances.takeoffDistance50ft.provenance).toBe('estimated')
+    expect(distances.landingDistance50ft.provenance).toBe('estimated')
+  })
+})
+
+describe('estimateBaseDistances — typed failures (never throws)', () => {
+  it('reports insufficient_data when the take-off roll is missing', () => {
+    const result = estimateBaseDistances({ takeoffDistance50ft: 600, landingRoll: 200 })
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') throw new Error('expected failure')
+    expect(result.reason).toBe('insufficient_data')
+  })
+
+  it('reports insufficient_data when the landing roll is missing', () => {
+    const result = estimateBaseDistances({ takeoffRoll: 300, landingDistance50ft: 450 })
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') throw new Error('expected failure')
+    expect(result.reason).toBe('insufficient_data')
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, -10])(
+    'reports invalid_input for a present-but-malformed value (%s)',
+    (bad) => {
+      const result = estimateBaseDistances({ takeoffRoll: bad, landingRoll: 200 })
+      expect(result.status).toBe('failure')
+      if (result.status !== 'failure') throw new Error('expected failure')
+      expect(result.reason).toBe('invalid_input')
+    },
+  )
+
+  it('reports invalid_input for a malformed published 50 ft distance', () => {
+    const result = estimateBaseDistances({ takeoffRoll: 300, takeoffDistance50ft: -1, landingRoll: 200 })
+    expect(result.status).toBe('failure')
+    if (result.status !== 'failure') throw new Error('expected failure')
+    expect(result.reason).toBe('invalid_input')
+  })
+})
+
+describe('toBaseDistances', () => {
+  it('flattens provenance-tagged distances to the plain SI base distances', () => {
+    const { distances } = expectSuccess(
+      estimateBaseDistances({ takeoffRoll: 300, landingRoll: 200 }),
+    )
+    expect(toBaseDistances(distances)).toEqual({
+      takeoffRoll: 300,
+      takeoffDistance50ft: estimateObstacleDistance('takeoff', 300),
+      landingRoll: 200,
+      landingDistance50ft: estimateObstacleDistance('landing', 200),
+    })
+  })
+})

--- a/frontend/src/core/logic/performance.estimation.ts
+++ b/frontend/src/core/logic/performance.estimation.ts
@@ -1,0 +1,243 @@
+/**
+ * CAA SSL 07 missing-distance estimation.
+ * P1 Safety Core — pure TypeScript, no framework dependencies.
+ *
+ * Sibling to {@link ./performance.poh-distance}. When an aircraft POH omits the
+ * 50 ft obstacle-clearance distance for a phase but publishes the ground roll,
+ * the missing base value is estimated from the roll using the fixed UK CAA
+ * Safety Sense Leaflet 07 conversion factors (REQ-PF-005):
+ *
+ *   Take-off:  TOD = TOR × 1.9
+ *   Landing:   LD  = LR  × 1.67
+ *
+ * The estimate is a conservative, airframe-generic substitute — never certified
+ * data. Every resolved distance therefore carries an explicit provenance marker
+ * (`'poh'` vs `'estimated'`) so an estimated value can never be silently treated
+ * as authoritative POH data downstream, in persistence, or in transmission
+ * (REQ-PF-017). A POH-published value always takes precedence over the estimate.
+ *
+ * Direction: estimation runs ground-roll → obstacle-distance only. The CAA SSL
+ * 07 factors are defined in that direction; inverting them (distance → roll)
+ * would shorten the result and is optimistic-unsafe, so a missing ground roll
+ * yields a typed `insufficient_data` failure rather than a fabricated value.
+ *
+ * @see docs/requirements/performance.md
+ * @see ./performance.poh-distance
+ */
+
+import type {
+  PerformanceBaseDistances,
+  PerformanceOperation,
+} from '../domain/performance.math-types'
+
+// ── Immutable CAA SSL 07 conversion ratios ───────────────────────────────────
+
+// @IMP-PF-CORE-024@ (FROM: @REQ-PF-005@)
+/**
+ * UK CAA Safety Sense Leaflet 07 ground-roll → obstacle-distance conversion
+ * factors. Fixed by regulation intent; MUST NOT be made user-configurable. The
+ * freeze makes accidental runtime mutation fail loudly in strict mode.
+ */
+export const CAA_SSL_07_RATIOS = Object.freeze({
+  takeoff: 1.9,
+  landing: 1.67,
+} as const)
+
+/**
+ * Stable provenance label surfaced to the pilot and carried into export
+ * documentation (REQ-PF-017). The UI/export layer renders this verbatim; it is
+ * defined here so on-screen and on-paper provenance share a single source.
+ */
+export const ESTIMATION_METHOD_LABEL = 'ESTIMATED (CAA SSL 07)' as const
+
+// ── Provenance model ─────────────────────────────────────────────────────────
+
+/** Where a resolved base distance came from. */
+export type DistanceProvenance = 'poh' | 'estimated'
+
+/** Conversion method tag; `null` for authoritative POH values. */
+export type EstimationMethod = 'caa-ssl-07' | null
+
+/**
+ * A single base distance plus its data provenance — the serialisable unit that
+ * is persisted (IndexedDB) and transmitted (REQ-PF-017). Plain data only, so it
+ * round-trips through the structured-clone and JSON boundaries unchanged.
+ */
+export interface ProvenancedDistance {
+  /** Base distance in metres (pre-Operational-Safety-Factor). */
+  readonly value: number
+  /** `'poh'` for authoritative published data; `'estimated'` for a CAA SSL 07 derivation. */
+  readonly provenance: DistanceProvenance
+  /** Conversion method — present only when `provenance === 'estimated'`; `null` for POH. */
+  readonly method: EstimationMethod
+}
+
+/** The four base distances, each carrying its provenance. */
+export interface EstimatedBaseDistances {
+  readonly takeoffRoll: ProvenancedDistance
+  readonly takeoffDistance50ft: ProvenancedDistance
+  readonly landingRoll: ProvenancedDistance
+  readonly landingDistance50ft: ProvenancedDistance
+}
+
+/** Optionally-published POH base values; an absent field is a gap to be resolved. */
+export interface EstimationInput {
+  /** Published take-off ground-roll base distance (m), when present. */
+  readonly takeoffRoll?: number
+  /** Published take-off 50 ft distance base value (m), when present. */
+  readonly takeoffDistance50ft?: number
+  /** Published landing ground-roll base distance (m), when present. */
+  readonly landingRoll?: number
+  /** Published landing 50 ft distance base value (m), when present. */
+  readonly landingDistance50ft?: number
+}
+
+/** Successful resolution of all four base distances. */
+export interface EstimationSuccess {
+  readonly status: 'success'
+  readonly distances: EstimatedBaseDistances
+  /** True when at least one obstacle distance was CAA SSL 07-estimated. */
+  readonly anyEstimated: boolean
+}
+
+/** Why no result was produced. Caller-visible — never escapes as an exception. */
+export type EstimationFailureReason = 'insufficient_data' | 'invalid_input'
+
+/** Typed failure surface — pure data, no exceptions. */
+export interface EstimationFailure {
+  readonly status: 'failure'
+  readonly reason: EstimationFailureReason
+  /** Free-text diagnostic for the pilot UI / logs. Never includes raw user data. */
+  readonly message: string
+}
+
+export type EstimationResult = EstimationSuccess | EstimationFailure
+
+// ── Pure estimator ───────────────────────────────────────────────────────────
+
+function ratioFor(operation: PerformanceOperation): number {
+  return operation === 'takeoff' ? CAA_SSL_07_RATIOS.takeoff : CAA_SSL_07_RATIOS.landing
+}
+
+// @IMP-PF-CORE-023@ (FROM: @REQ-PF-005@)
+/**
+ * Estimate the 50 ft obstacle-clearance distance for `operation` from its ground
+ * roll via the CAA SSL 07 factor (TOD = TOR × 1.9, LD = LR × 1.67).
+ *
+ * Throws `[PF-ESTIMATE]` on a non-finite or non-positive roll — a zero/negative
+ * roll has no physical meaning and must never silently yield a fabricated
+ * distance. The fail-safe boundary that converts this to a typed result is
+ * {@link estimateBaseDistances} (and the Zod-validated `applyEstimation`).
+ */
+export function estimateObstacleDistance(
+  operation: PerformanceOperation,
+  groundRoll: number,
+): number {
+  if (!Number.isFinite(groundRoll)) {
+    throw new Error('[PF-ESTIMATE] ground roll must be a finite number.')
+  }
+  if (groundRoll <= 0) {
+    throw new Error('[PF-ESTIMATE] ground roll must be strictly positive.')
+  }
+  return groundRoll * ratioFor(operation)
+}
+
+// ── Provenance constructors ──────────────────────────────────────────────────
+
+function poh(value: number): ProvenancedDistance {
+  return { value, provenance: 'poh', method: null }
+}
+
+function estimated(value: number): ProvenancedDistance {
+  return { value, provenance: 'estimated', method: 'caa-ssl-07' }
+}
+
+/** Present-but-malformed values are a hard error — never silently dropped. */
+function isMalformed(value: number | undefined): boolean {
+  return value !== undefined && !(Number.isFinite(value) && value > 0)
+}
+
+/** Narrowing guard for a published (present) field; its validity is enforced by {@link isMalformed}. */
+function isPresent(value: number | undefined): value is number {
+  return value !== undefined
+}
+
+type PhaseResolution =
+  | {
+      status: 'ok'
+      groundRoll: ProvenancedDistance
+      obstacleDistance50ft: ProvenancedDistance
+    }
+  | EstimationFailure
+
+function resolvePhase(
+  operation: PerformanceOperation,
+  roll: number | undefined,
+  obstacle: number | undefined,
+): PhaseResolution {
+  if (isMalformed(roll) || isMalformed(obstacle)) {
+    return {
+      status: 'failure',
+      reason: 'invalid_input',
+      message: `${operation} base distances must be finite, strictly-positive numbers when present.`,
+    }
+  }
+  if (!isPresent(roll)) {
+    return {
+      status: 'failure',
+      reason: 'insufficient_data',
+      message: `${operation} ground roll is required; it cannot be estimated from the 50 ft distance.`,
+    }
+  }
+  const obstacleDistance50ft = isPresent(obstacle)
+    ? poh(obstacle)
+    : estimated(estimateObstacleDistance(operation, roll))
+  return { status: 'ok', groundRoll: poh(roll), obstacleDistance50ft }
+}
+
+// ── Facade ───────────────────────────────────────────────────────────────────
+
+// @IMP-PF-CORE-022@ (FROM: @REQ-PF-005@, @REQ-PF-017@)
+/**
+ * Resolve the four base distances, estimating a missing 50 ft distance from its
+ * ground roll (CAA SSL 07) and tagging every value with its provenance.
+ *
+ * Pure and total: identical inputs always produce identical outputs, no I/O, and
+ * it never throws — malformed or insufficient input yields a typed `failure`.
+ * POH-published values always take precedence over the estimate, so an estimate
+ * is never substituted for authoritative data.
+ */
+export function estimateBaseDistances(input: EstimationInput): EstimationResult {
+  const takeoff = resolvePhase('takeoff', input.takeoffRoll, input.takeoffDistance50ft)
+  if (takeoff.status === 'failure') return takeoff
+  const landing = resolvePhase('landing', input.landingRoll, input.landingDistance50ft)
+  if (landing.status === 'failure') return landing
+
+  const distances: EstimatedBaseDistances = {
+    takeoffRoll: takeoff.groundRoll,
+    takeoffDistance50ft: takeoff.obstacleDistance50ft,
+    landingRoll: landing.groundRoll,
+    landingDistance50ft: landing.obstacleDistance50ft,
+  }
+  const anyEstimated =
+    distances.takeoffDistance50ft.provenance === 'estimated' ||
+    distances.landingDistance50ft.provenance === 'estimated'
+
+  return { status: 'success', distances, anyEstimated }
+}
+
+// @IMP-PF-CORE-021@ (FROM: @REQ-PF-005@)
+/**
+ * Extract the plain SI base distances for the downstream safety-factor pipeline.
+ * The provenance markers stay on {@link EstimatedBaseDistances} so the pipeline
+ * consumes only numbers while the caller retains the estimated/POH flags for
+ * persistence, transmission, and UI marking.
+ */
+export function toBaseDistances(distances: EstimatedBaseDistances): PerformanceBaseDistances {
+  return {
+    takeoffRoll: distances.takeoffRoll.value,
+    takeoffDistance50ft: distances.takeoffDistance50ft.value,
+    landingRoll: distances.landingRoll.value,
+    landingDistance50ft: distances.landingDistance50ft.value,
+  }
+}

--- a/trace/implementation/pf.yaml
+++ b/trace/implementation/pf.yaml
@@ -172,3 +172,51 @@ PF Core — Safety-Factor Pipeline
       - REQ-PF-015
       - REQ-PF-016
       - REQ-SYS-011
+
+PF Core — CAA SSL 07 Missing-Distance Estimation
+  IMP-PF-CORE-026
+    title: EstimationInputSchema — Zod boundary for optional POH base distances
+    files:
+      - frontend/src/core/adapters/performance.estimation.adapter.ts
+    req:
+      - REQ-SYS-011
+      - REQ-SYS-012
+      - REQ-PF-005
+
+  IMP-PF-CORE-025
+    title: applyEstimation — validated estimation entry point, invalid_input on parse failure
+    files:
+      - frontend/src/core/adapters/performance.estimation.adapter.ts
+    req:
+      - REQ-PF-005
+      - REQ-PF-017
+      - REQ-SYS-011
+
+  IMP-PF-CORE-024
+    title: CAA SSL 07 conversion ratios (frozen) and provenance model
+    files:
+      - frontend/src/core/logic/performance.estimation.ts
+    req:
+      - REQ-PF-005
+
+  IMP-PF-CORE-023
+    title: estimateObstacleDistance — CAA SSL 07 ground-roll → 50 ft distance estimator
+    files:
+      - frontend/src/core/logic/performance.estimation.ts
+    req:
+      - REQ-PF-005
+
+  IMP-PF-CORE-022
+    title: estimateBaseDistances — provenance-tagged estimation facade (POH precedence)
+    files:
+      - frontend/src/core/logic/performance.estimation.ts
+    req:
+      - REQ-PF-005
+      - REQ-PF-017
+
+  IMP-PF-CORE-021
+    title: toBaseDistances — flatten provenanced distances to plain SI base distances
+    files:
+      - frontend/src/core/logic/performance.estimation.ts
+    req:
+      - REQ-PF-005

--- a/trace/integration_test/pf.yaml
+++ b/trace/integration_test/pf.yaml
@@ -24,3 +24,13 @@ PF Core — Conservative Extrapolation Control (Integration)
     impl:
       - IMP-PF-CORE-003
       - IMP-PF-CORE-011
+
+PF Core — CAA SSL 07 Missing-Distance Estimation (Integration)
+  IT-PF-CORE-004
+    title: applyEstimation → structured-clone/JSON round-trip → applySafetyFactors — estimated flag survives persistence/transmission and is never treated as authoritative POH data
+    files:
+      - frontend/src/core/logic/__tests__/performance.estimation.int.spec.ts
+    impl:
+      - IMP-PF-CORE-022
+      - IMP-PF-CORE-025
+      - IMP-PF-CORE-020

--- a/trace/unit_test/pf.yaml
+++ b/trace/unit_test/pf.yaml
@@ -324,3 +324,22 @@ PF Core — Safety-Factor Pipeline (Unit)
     impl:
       - IMP-PF-CORE-019
       - IMP-PF-CORE-020
+
+PF Core — CAA SSL 07 Missing-Distance Estimation (Unit)
+  UT-PF-CORE-046
+    title: applyEstimation Zod boundary — estimate, POH passthrough, invalid_input rejection
+    files:
+      - frontend/src/core/adapters/performance.estimation.adapter.spec.ts
+    impl:
+      - IMP-PF-CORE-025
+      - IMP-PF-CORE-026
+
+  UT-PF-CORE-045
+    title: CAA SSL 07 estimation — ratios, roll→distance vectors, POH precedence, typed failures
+    files:
+      - frontend/src/core/logic/performance.estimation.spec.ts
+    impl:
+      - IMP-PF-CORE-021
+      - IMP-PF-CORE-022
+      - IMP-PF-CORE-023
+      - IMP-PF-CORE-024


### PR DESCRIPTION
### Summary

CAA SSL 07 missing-distance estimation in the P1 Safety Core (closes the P1 half of #301).

- New `frontend/src/core/logic/performance.estimation.ts`: derives a missing 50 ft obstacle-clearance distance from the published ground roll via the fixed UK CAA Safety Sense Leaflet 07 factors — `TOD = TOR × 1.9`, `LD = LR × 1.67` — applied **before** any Operational Safety Factor (REQ-PF-005).
- Every resolved base distance carries an explicit provenance marker (`provenance: 'poh' | 'estimated'`, `method: 'caa-ssl-07' | null`). A POH-published value always takes precedence; an estimate is **never** silently substituted for authoritative POH data (REQ-PF-017 data layer).
- The result is plain serialisable data, so the estimated flag survives the IndexedDB (structured-clone) and transmission (JSON) boundaries unchanged.
- New `performance.estimation.adapter.ts`: Zod boundary (`applyEstimation`) returns a typed `invalid_input` failure on bad input — never throws.
- Unit + integration specs; 100% line/branch/function on the new P1 code.

**Scope direction (safety):** estimation runs ground roll → 50 ft distance only (the case UJ-C-003 describes). A missing ground roll yields a typed `insufficient_data` failure rather than a fabricated value, since inverting the ratio shortens the result and is optimistic-unsafe.

### Related Issues

- Closes #310
- Ref #301 (parent stays open — see *What remains*)

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: #310 auto-closed by `Closes #`; verify its Issue Label becomes `fixed` & Project Status `Done`. Parent #301 stays **open**.

### Affected Items

- **Requirements Implemented/Affected:** `REQ-PF-005` (estimation algorithm — implemented in P1; status left `Approved`, see note), `REQ-PF-017` (data-provenance layer implemented; UI/export marker pending with #311)

### Documentation Updates

- [x] **Requirements:** `N/A` — REQ-PF-005 / REQ-PF-017 already exist; status intentionally **not** advanced to `Implemented` (REQ-PF-005 reverse direction is deliberately unsupported; REQ-PF-017 UI/export marking is pending), per the "partial/follow-up remains → do not change status" rule.
- [x] **Architecture:** `N/A` — additive sibling P1 module following the existing extrapolation / safety-factor pattern; no new contract or interface-surface change.
- [x] **Risk Management:** `N/A` — no new hazard. The provenance flag is the barrier against estimated values being mistaken for certified data (over-confidence in margins).
- [x] **Journeys:** `N/A` — UJ-C-003 already documents this flow; its E2E lands with the Performance UI (#311).
- [x] **Code Docs:** `N/A` — JSDoc added inline; `CHANGELOG.md` deliberately not touched here (reserved for the release process per `CLAUDE.md`).

### Safety Considerations

- [x] Checked Safety Traceability Matrix — REQ-PF-005/017 → IMP-PF-CORE-021…026 → UT-PF-CORE-045/046 / IT-PF-CORE-004; `trace/` registries updated same-commit.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved — POH precedence + explicit provenance prevent silent substitution of estimates.
- [x] P1 isolation maintained — imports are `zod` + `src/core/` only; no Vue/Pinia/router/module/shared/store imports. `test:p1` (632) green.

### Quality & Testing Checklist

- [x] **Target Branch:** targets `develop`.
- [x] **Unit Tests:** added & passing — `performance.estimation.spec.ts`, `performance.estimation.adapter.spec.ts` (100% line/branch/function on new files; suite 1737 green).
- [x] **Integration Tests:** passing — `performance.estimation.int.spec.ts` (persistence/transmission round-trip + Go/No-Go composition; suite 91 green).
- [x] **Manual Testing:** `N/A` — pure P1 logic, no UI surface in this change; not targeting `main`.
- [x] **DoD:** all Definition of Done items from #310 are met and attested (every box ticked on the issue).
- [x] **Review:** self-review of code, tests, and traceability performed.
- [x] **ADR:** Not required — additive sibling module, no P1 interface/dependency change.

---

### FRR — Formal Review Request (P1 / safety-critical)

Recorded for Lead-Developer sign-off (no interactive approval in the unattended run; the autonomous PR is a Draft per ADR-317-DEV and still requires human P1 approval).

- **REQ / H:** REQ-PF-005, REQ-PF-017. No direct `H-` link; indirectly mitigates over-confidence from estimated data treated as certified.
- **Output impact:** produces the missing TOD/LD base value feeding the safety-factor pipeline; each distance carries a provenance flag so an estimate can never be silently treated as authoritative POH data.
- **Pure-TS / deterministic:** no framework imports (`zod` + `src/core/` only); pure functions, no I/O, no `Date`/random — identical inputs → identical outputs.
- **Zod plan:** `EstimationInputSchema` validates each optional distance `.finite().gt(0).max(100_000)`; `applyEstimation(unknown)` returns typed `invalid_input` on parse failure, never throws.
- **Formula:** `TOD = TOR × 1.9`, `LD = LR × 1.67` (UK CAA SSL 07), applied to base values **before** any OSF. POH values take precedence over the estimate.
- **Unit normalization:** all distances are SI metres (consistent with the perf core); ratios dimensionless; no conversion performed here.
- **Edge cases (≥3):** non-finite roll → throw/`invalid_input`; zero/negative roll → rejected; POH value present alongside roll → POH wins (no substitution); both roll & distance missing → `insufficient_data` (no fabrication); exact vectors TOR 300→570, LR 200→334.
- **ADR need:** none (additive sibling module).

### What remains (parent #301 stays open)

The pilot-facing visible `[ESTIMATED] (CAA SSL 07)` marker (UI + export) and the UJ-C-003 E2E require a Performance UI, which does not yet exist (`src/modules/performance/` is empty). That work is already tracked by the open Performance UI task **#311** ("…[ESTIMATED] marker…"). #301 should be closed once #311 surfaces the marker and the UJ-C-003 E2E is in place. This PR therefore `Ref`s #301 rather than closing it (its DoD UI/E2E boxes are genuinely not yet met).

### Operator notes

- **Project board:** the CI token lacks project scope, so this run could not move #310 to *In Verification* on the *AeroDash Dashboard*. Please move it manually (and to *Done* on merge).
