### PR TITLE
feat: [Task]: Performance module UI — results, margin, [ESTIMATED] marker, ack prompt, WARN/CRIT (#311)

### DIFF
--- a/docs/architecture/notification_schema.md
+++ b/docs/architecture/notification_schema.md
@@ -76,6 +76,9 @@ This register lists all defined notifications in the system to ensure uniqueness
 | `CRIT-WX-001`  | Wind Limit Exceeded                | `CRITICAL` | [REQ-WX-009](../requirements/weather_meterological_data.md#REQ-WX-009) | If any wind or gust component exceeds a hard `Limit` of the aircraft.                                                                                                                    |
 | `CRIT-PF-002`  | Runway Insufficient                | `CRITICAL` | [REQ-PF-015](../requirements/performance.md#REQ-PF-015)                | If the Operational Required Distance exceeds the published Available Distance (TORA/LDA).                                                                                                |
 | `WARN-PF-002`  | Safety Factor Low                  | `WARNING`  | [REQ-PF-016](../requirements/performance.md#REQ-PF-016)                | If the user-selected Operational Safety Factor is lower than the greater of the POH-mandated factor and the regulatory baseline (Takeoff: 1.25, Landing: 1.43).                          |
+| `WARN-PF-003`  | Extrapolated Performance Data      | `WARNING`  | [REQ-PF-012](../requirements/performance.md#REQ-PF-012)                | When an operating point is extrapolated within the 10% band (REQ-PF-010): a +20% penalty is applied and Pilot-in-Command acknowledgment is required before the result may be used.       |
+| `ERR-PF-001`   | Extrapolation Beyond Limit         |  `ERROR`   | [REQ-PF-010](../requirements/performance.md#REQ-PF-010)                | When an operating point exceeds the 10% extrapolation cap; the computation is blocked and no distance is produced.                                                                       |
+| `ERR-PF-002`   | Performance Data Unavailable       |  `ERROR`   | [REQ-PF-001](../requirements/performance.md#REQ-PF-001)                | When the selected profile is not Verified, is missing a required POH phase, or has a malformed performance grid, so no distance can be computed.                                         |
 | `INFO-SYS-001` | Update Available                   |   `INFO`   | [REQ-SYS-005](../requirements/system.md#REQ-SYS-005)                   | When a new software version is detected.                                                                                                                                                 |
 | `ERR-SYS-001`  | Invalid Input: {field} ({code})    |  `ERROR`   | [REQ-SYS-012](../requirements/system.md#REQ-SYS-012)                   | When module input validation (Zod schema) fails before core logic (REQ-SYS-011). Dynamic: field = field path, code = validation code.                                                    |
 | `WARN-UI-001`  | Input Out of Range                 | `WARNING`  | [REQ-UI-008](../requirements/user_interface.md#REQ-UI-008)             | When numeric inputs are outside standard operational ranges.                                                                                                                             |
@@ -206,6 +209,41 @@ This section defines the complete JSON payload for each notification. These payl
   "severity": "WARNING",
   "message": "Safety Factor Low",
   "context": "Performance.SafetyFactor"
+}
+```
+
+#### WARN-PF-003 — Extrapolated Performance Data
+
+```json
+{
+  "id": "WARN-PF-003",
+  "severity": "WARNING",
+  "message": "Extrapolated Performance Data",
+  "context": "Performance",
+  "persistent": true
+}
+```
+
+#### ERR-PF-001 — Extrapolation Beyond Limit
+
+```json
+{
+  "id": "ERR-PF-001",
+  "severity": "ERROR",
+  "message": "Extrapolation Beyond Limit",
+  "context": "Performance",
+  "persistent": true
+}
+```
+
+#### ERR-PF-002 — Performance Data Unavailable
+
+```json
+{
+  "id": "ERR-PF-002",
+  "severity": "ERROR",
+  "message": "Performance Data Unavailable",
+  "context": "Performance"
 }
 ```
 

--- a/docs/requirements/performance.md
+++ b/docs/requirements/performance.md
@@ -66,7 +66,7 @@ This document defines the performance behavior using the **EARS** (Easy Approach
 **Requirement:** The system shall calculate the Safety Margin as an absolute value (Available Runway minus Operational Required Distance) and as a percentage.
 **Rationale:** Intuitive Go/No-Go decision making.
 **Priority:** P2
-**Status:** Approved
+**Status:** Implemented
 **Design Reference:** n/a
 
 <!-- @REQ-PF-008@ -->

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -117,6 +117,7 @@ const navItems: NavItem[] = [
   { id: 'home',        label: 'Home',        path: '/',            icon: 'home' },
   { id: 'flight-prep', label: 'Flight Prep', path: '/mass-balance', icon: 'prep' },
   { id: 'fleet',       label: 'Fleet',       path: '/fleet',       icon: 'fleet' },
+  { id: 'performance', label: 'Performance', path: '/performance', icon: 'perf' },
   { id: 'weather',     label: 'Weather',     path: '/weather',     icon: 'wx',   soon: true },
   { id: 'fuel',        label: 'Fuel',        path: '/fuel',        icon: 'fuel', soon: true },
   { id: 'airport',     label: 'Airport DB',  path: '/airport',     icon: 'ap',   soon: true },
@@ -251,6 +252,12 @@ const themeLabel = computed(() =>
                 <circle cx="10" cy="10" r="7" stroke="currentColor" stroke-width="1.5" />
                 <path d="M10 3v14M3 10h14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                 <ellipse cx="10" cy="10" rx="4" ry="7" stroke="currentColor" stroke-width="1.5" />
+              </svg>
+              <!-- Performance (gauge) -->
+              <svg v-else-if="item.icon === 'perf'" width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path d="M3.5 15a7 7 0 1113 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M10 12l3.5-3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="10" cy="12" r="1.2" fill="currentColor" />
               </svg>
               <!-- Privacy (shield) -->
               <svg v-else-if="item.icon === 'privacy'" width="20" height="20" viewBox="0 0 20 20" fill="none">

--- a/frontend/src/modules/performance/__tests__/performance-fixtures.ts
+++ b/frontend/src/modules/performance/__tests__/performance-fixtures.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared test fixtures for the performance module.
+ *
+ * Builds a schema-valid, Verified aircraft whose POH performance tables form a
+ * regular linear 3-D grid. The envelope maxima are chosen to match the UJ-C-001
+ * narrative numbers (temperature 50 °C, pressure altitude 10 000 ft) so the
+ * extrapolation thresholds in the journey hold exactly: 54 °C is inside the 10%
+ * band (extrapolated), 57 °C and 11 100 ft are beyond it (blocked).
+ */
+
+import { AircraftProfileSchema, type AircraftProfile } from '@/core/adapters/aircraft.schema'
+import type { FlightPhase, PerformanceDataPoint } from '@/core/domain/aircraft.types'
+
+export const MASS_AXIS = [600, 1000] as const
+export const ALT_AXIS = [0, 10_000] as const
+export const TEMP_AXIS = [0, 50] as const
+
+/** Linear distance model per phase: B + M·(massFrac) + A·(altFrac) + T·(tempFrac). */
+interface PhaseModel {
+  base: number
+  mass: number
+  alt: number
+  temp: number
+}
+
+const PHASE_MODELS: Record<FlightPhase, PhaseModel> = {
+  TakeoffRoll: { base: 250, mass: 150, alt: 200, temp: 100 },
+  TakeoffDistance50ft: { base: 450, mass: 200, alt: 350, temp: 150 },
+  LandingRoll: { base: 200, mass: 80, alt: 120, temp: 60 },
+  LandingDistance50ft: { base: 380, mass: 120, alt: 220, temp: 100 },
+}
+
+/** Exact (interpolation-faithful) distance for the linear grid model. */
+export function modelDistance(phase: FlightPhase, mass: number, pa: number, temp: number): number {
+  const m = PHASE_MODELS[phase]
+  const massFrac = (mass - MASS_AXIS[0]) / (MASS_AXIS[1] - MASS_AXIS[0])
+  const altFrac = (pa - ALT_AXIS[0]) / (ALT_AXIS[1] - ALT_AXIS[0])
+  const tempFrac = (temp - TEMP_AXIS[0]) / (TEMP_AXIS[1] - TEMP_AXIS[0])
+  return m.base + m.mass * massFrac + m.alt * altFrac + m.temp * tempFrac
+}
+
+function buildDataPoints(phase: FlightPhase): PerformanceDataPoint[] {
+  const points: PerformanceDataPoint[] = []
+  for (const temperature of TEMP_AXIS) {
+    for (const pressureAltitude of ALT_AXIS) {
+      for (const mass of MASS_AXIS) {
+        points.push({
+          mass,
+          pressureAltitude,
+          temperature,
+          distance: modelDistance(phase, mass, pressureAltitude, temperature),
+        })
+      }
+    }
+  }
+  return points
+}
+
+const ALL_PHASES: FlightPhase[] = [
+  'TakeoffRoll',
+  'TakeoffDistance50ft',
+  'LandingRoll',
+  'LandingDistance50ft',
+]
+
+export interface BuildOptions {
+  status?: 'draft' | 'verified'
+  registration?: string
+  /** Phases to include — omit one to exercise the `profile_incomplete` path. */
+  phases?: FlightPhase[]
+  /** Optional POH-mandated safety factors (drives the `poh-afm` preset / WARN threshold). */
+  safetyFactors?: { takeoff: number; landing: number }
+}
+
+/** Construct a schema-valid performance-capable aircraft profile. */
+export function buildPerformanceAircraft(opts: BuildOptions = {}): AircraftProfile {
+  const phases = opts.phases ?? ALL_PHASES
+  const raw = {
+    id: '00000000-0000-4000-a000-000000000311',
+    ownerId: '00000000-0000-4000-a000-0000000003ff',
+    registration: opts.registration ?? 'D-EPER',
+    manufacturer: 'Tecnam',
+    model: 'P2008 JC',
+    icaoTypeDesignator: 'P208',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Leading edge of wing root',
+    referenceDatumLocation: 'Station 0 m',
+    shareCode: null,
+    status: opts.status ?? 'verified',
+    schemaVersion: 1,
+    powertrain: 'combustion',
+    passengerProfiles: [],
+    weighingReports: [
+      { bem: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+    ],
+    loadPoints: [
+      {
+        name: 'Pilot & Passenger',
+        arm: 1.145,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 630,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.841, mass: 432 },
+          { armOrMoment: 1.841, mass: 630 },
+          { armOrMoment: 1.978, mass: 630 },
+          { armOrMoment: 1.978, mass: 432 },
+        ],
+      },
+    ],
+    safetyFactors: opts.safetyFactors,
+    performanceProfiles: phases.map((flightPhase) => ({
+      flightPhase,
+      dataPoints: buildDataPoints(flightPhase),
+    })),
+  }
+  return AircraftProfileSchema.parse(raw)
+}
+
+/** Mid-envelope conditions that stay inside the POH grid (no extrapolation). */
+export const WITHIN_ENVELOPE_CONDITIONS = { mass: 800, pressureAltitude: 5000, temperature: 25 }
+
+/** Hot conditions inside the 10% extrapolation band (requires acknowledgment). */
+export const EXTRAPOLATED_CONDITIONS = { mass: 800, pressureAltitude: 5000, temperature: 54 }
+
+/** Conditions beyond the 10% temperature cap (computation blocked). */
+export const BLOCKED_TEMP_CONDITIONS = { mass: 800, pressureAltitude: 5000, temperature: 57 }

--- a/frontend/src/modules/performance/components/EstimatedMarker.vue
+++ b/frontend/src/modules/performance/components/EstimatedMarker.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+// @IMP-PF-VIEW-001@ (FROM: @REQ-PF-017@)
+</script>
+
+<template>
+  <span class="estimated-marker" role="note" aria-label="Estimated value, derived via CAA SSL 07">
+    <span class="estimated-marker__tag">[ESTIMATED]</span>
+    <span class="estimated-marker__source">(CAA SSL 07)</span>
+  </span>
+</template>
+
+<style scoped>
+.estimated-marker {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: baseline;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #92400e;
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.35rem;
+  white-space: nowrap;
+}
+
+.estimated-marker__source {
+  font-weight: 400;
+  font-size: 0.7rem;
+  opacity: 0.85;
+}
+</style>

--- a/frontend/src/modules/performance/components/ExtrapolationAcknowledgment.vue
+++ b/frontend/src/modules/performance/components/ExtrapolationAcknowledgment.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+// @IMP-PF-VIEW-002@ (FROM: @REQ-PF-012@)
+defineEmits<{ acknowledge: [] }>()
+</script>
+
+<template>
+  <div class="extrapolation-ack" role="alert">
+    <p class="extrapolation-ack__title">⚠ Extrapolated performance data</p>
+    <p class="extrapolation-ack__body">
+      The entered conditions are beyond the POH/AFM performance charts. A fixed +20% conservative
+      penalty has been applied. This result is <strong>not usable</strong> until you confirm it as
+      Pilot-in-Command.
+    </p>
+    <button
+      type="button"
+      class="extrapolation-ack__btn"
+      @click="$emit('acknowledge')"
+    >
+      Pilot-in-Command acknowledges extrapolated data
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.extrapolation-ack {
+  border: 2px solid #f59e0b;
+  background: #fffbeb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+.extrapolation-ack__title {
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+  color: #92400e;
+}
+
+.extrapolation-ack__body {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.extrapolation-ack__btn {
+  font-weight: 600;
+  color: #fff;
+  background: #b45309;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.extrapolation-ack__btn:hover {
+  background: #92400e;
+}
+</style>

--- a/frontend/src/modules/performance/components/PerformanceResultsTable.vue
+++ b/frontend/src/modules/performance/components/PerformanceResultsTable.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+// @IMP-PF-VIEW-003@ (FROM: @REQ-PF-001@, @REQ-PF-007@, @REQ-PF-017@)
+import { computed } from 'vue'
+import { formatMassConservative, formatFuelConservative } from '@/core/logic/display-rounding'
+import EstimatedMarker from './EstimatedMarker.vue'
+import type { PerformanceResultView } from '@/modules/performance/stores/performance.types'
+
+const props = defineProps<{ result: PerformanceResultView }>()
+
+interface DistanceRow {
+  key: string
+  label: string
+  abbr: string
+  base: number
+  required: number
+  estimated: boolean
+  /** Full-distance rows (TOD / LD) carry the runway available + margin. */
+  available: number | null
+  marginAbsolute: number | null
+  marginPercent: number | null
+  insufficient: boolean
+}
+
+const rows = computed<DistanceRow[]>(() => {
+  const r = props.result
+  return [
+    {
+      key: 'tor',
+      label: 'Take-off run',
+      abbr: 'TOR',
+      base: r.base.takeoffRoll,
+      required: r.takeoff.groundRollRequired,
+      estimated: r.estimated.takeoffRoll,
+      available: null,
+      marginAbsolute: null,
+      marginPercent: null,
+      insufficient: false,
+    },
+    {
+      key: 'tod',
+      label: 'Take-off distance (50 ft)',
+      abbr: 'TOD',
+      base: r.base.takeoffDistance50ft,
+      required: r.takeoff.fullRequired,
+      estimated: r.estimated.takeoffDistance50ft,
+      available: r.takeoff.available,
+      marginAbsolute: r.takeoff.marginAbsolute,
+      marginPercent: r.takeoff.marginPercent,
+      insufficient: r.takeoff.insufficient,
+    },
+    {
+      key: 'lr',
+      label: 'Landing run',
+      abbr: 'LR',
+      base: r.base.landingRoll,
+      required: r.landing.groundRollRequired,
+      estimated: r.estimated.landingRoll,
+      available: null,
+      marginAbsolute: null,
+      marginPercent: null,
+      insufficient: false,
+    },
+    {
+      key: 'ld',
+      label: 'Landing distance (50 ft)',
+      abbr: 'LD',
+      base: r.base.landingDistance50ft,
+      required: r.landing.fullRequired,
+      estimated: r.estimated.landingDistance50ft,
+      available: r.landing.available,
+      marginAbsolute: r.landing.marginAbsolute,
+      marginPercent: r.landing.marginPercent,
+      insufficient: r.landing.insufficient,
+    },
+  ]
+})
+
+/** Distances round UP (pessimistic); margins round DOWN (pessimistic) — REQ-UQ-004. */
+function metres(v: number): string {
+  return `${formatMassConservative(v, 0)} m`
+}
+function marginMetres(v: number): string {
+  return `${formatFuelConservative(v, 0)} m`
+}
+function marginPct(v: number | null): string {
+  return v === null ? '—' : `${formatFuelConservative(v, 1)}%`
+}
+</script>
+
+<template>
+  <table class="perf-results">
+    <caption class="perf-results__caption">
+      Required distances and safety margin
+    </caption>
+    <thead>
+      <tr>
+        <th scope="col">Phase</th>
+        <th scope="col">POH base</th>
+        <th scope="col">Operational required</th>
+        <th scope="col">Available</th>
+        <th scope="col">Margin</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        v-for="row in rows"
+        :key="row.key"
+        :class="{ 'perf-results__row--insufficient': row.insufficient }"
+        :data-phase="row.key"
+      >
+        <th scope="row">
+          <span class="perf-results__abbr">{{ row.abbr }}</span>
+          <span class="perf-results__label">{{ row.label }}</span>
+          <EstimatedMarker v-if="row.estimated" class="perf-results__estimated" />
+        </th>
+        <td>{{ metres(row.base) }}</td>
+        <td class="perf-results__required">{{ metres(row.required) }}</td>
+        <td>{{ row.available === null ? '—' : metres(row.available) }}</td>
+        <td class="perf-results__margin">
+          <template v-if="row.marginAbsolute === null">—</template>
+          <template v-else>
+            <span :class="{ 'perf-results__margin--negative': row.insufficient }">
+              {{ marginMetres(row.marginAbsolute) }}
+            </span>
+            <span class="perf-results__margin-pct">({{ marginPct(row.marginPercent) }})</span>
+            <span v-if="row.insufficient" class="perf-results__flag" role="img" aria-label="insufficient">
+              ✕ insufficient
+            </span>
+          </template>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style scoped>
+.perf-results {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.perf-results__caption {
+  text-align: left;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.perf-results th,
+.perf-results td {
+  text-align: right;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.perf-results thead th {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #6b7280;
+}
+
+.perf-results tbody th {
+  text-align: left;
+  font-weight: 500;
+}
+
+.perf-results__abbr {
+  font-weight: 700;
+  margin-right: 0.4rem;
+}
+
+.perf-results__label {
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.perf-results__estimated {
+  margin-left: 0.4rem;
+}
+
+.perf-results__required {
+  font-weight: 600;
+}
+
+.perf-results__row--insufficient {
+  background: #fef2f2;
+}
+
+.perf-results__margin--negative {
+  color: #b91c1c;
+  font-weight: 700;
+}
+
+.perf-results__margin-pct {
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin-left: 0.25rem;
+}
+
+.perf-results__flag {
+  display: block;
+  color: #b91c1c;
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+</style>

--- a/frontend/src/modules/performance/components/__tests__/EstimatedMarker.spec.ts
+++ b/frontend/src/modules/performance/components/__tests__/EstimatedMarker.spec.ts
@@ -1,0 +1,19 @@
+// @UT-PF-VIEW-001@ (FROM: @IMP-PF-VIEW-001@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EstimatedMarker from '../EstimatedMarker.vue'
+
+describe('EstimatedMarker', () => {
+  it('renders the CAA SSL 07 estimation marker with a text label (not colour-only)', () => {
+    const wrapper = mount(EstimatedMarker)
+    expect(wrapper.text()).toContain('[ESTIMATED]')
+    expect(wrapper.text()).toContain('(CAA SSL 07)')
+  })
+
+  it('exposes an accessible note label', () => {
+    const wrapper = mount(EstimatedMarker)
+    const marker = wrapper.get('[role="note"]')
+    expect(marker.attributes('aria-label')).toMatch(/CAA SSL 07/i)
+  })
+})

--- a/frontend/src/modules/performance/components/__tests__/ExtrapolationAcknowledgment.spec.ts
+++ b/frontend/src/modules/performance/components/__tests__/ExtrapolationAcknowledgment.spec.ts
@@ -1,0 +1,20 @@
+// @UT-PF-VIEW-002@ (FROM: @IMP-PF-VIEW-002@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ExtrapolationAcknowledgment from '../ExtrapolationAcknowledgment.vue'
+
+describe('ExtrapolationAcknowledgment', () => {
+  it('presents the Pilot-in-Command acknowledgment as an alert', () => {
+    const wrapper = mount(ExtrapolationAcknowledgment)
+    expect(wrapper.get('[role="alert"]')).toBeTruthy()
+    expect(wrapper.text()).toMatch(/Pilot-in-Command acknowledges extrapolated data/i)
+    expect(wrapper.text()).toMatch(/\+20%/)
+  })
+
+  it('emits "acknowledge" when the pilot confirms', async () => {
+    const wrapper = mount(ExtrapolationAcknowledgment)
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.emitted('acknowledge')).toHaveLength(1)
+  })
+})

--- a/frontend/src/modules/performance/components/__tests__/PerformanceResultsTable.spec.ts
+++ b/frontend/src/modules/performance/components/__tests__/PerformanceResultsTable.spec.ts
@@ -1,0 +1,90 @@
+// @UT-PF-VIEW-003@ (FROM: @IMP-PF-VIEW-003@)
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PerformanceResultsTable from '../PerformanceResultsTable.vue'
+import EstimatedMarker from '../EstimatedMarker.vue'
+import type { PerformanceResultView } from '../../stores/performance.types'
+
+function makeResult(overrides: Partial<PerformanceResultView> = {}): PerformanceResultView {
+  return {
+    base: { takeoffRoll: 475, takeoffDistance50ft: 800, landingRoll: 330, landingDistance50ft: 600 },
+    estimated: {
+      takeoffRoll: false,
+      takeoffDistance50ft: false,
+      landingRoll: false,
+      landingDistance50ft: false,
+    },
+    takeoff: {
+      groundRollRequired: 593.75,
+      fullRequired: 1000,
+      available: 900,
+      marginAbsolute: -100,
+      marginPercent: -10,
+      insufficient: true,
+      appliedOsf: 1.25,
+    },
+    landing: {
+      groundRollRequired: 471.9,
+      fullRequired: 858,
+      available: 1000,
+      marginAbsolute: 142,
+      marginPercent: 16.55,
+      insufficient: false,
+      appliedOsf: 1.43,
+    },
+    goNoGo: false,
+    finalized: true,
+    extrapolation: { requiresAcknowledgment: false, benefitCapped: false, penaltyApplied: false },
+    clamped: false,
+    ...overrides,
+  }
+}
+
+describe('PerformanceResultsTable', () => {
+  it('renders all four distance variables (TOR / TOD / LR / LD)', () => {
+    const wrapper = mount(PerformanceResultsTable, { props: { result: makeResult() } })
+    const text = wrapper.text()
+    expect(text).toContain('TOR')
+    expect(text).toContain('TOD')
+    expect(text).toContain('LR')
+    expect(text).toContain('LD')
+  })
+
+  it('shows the safety margin as both absolute distance and percentage', () => {
+    const wrapper = mount(PerformanceResultsTable, { props: { result: makeResult() } })
+    const ld = wrapper.get('[data-phase="ld"]')
+    expect(ld.text()).toContain('142 m')
+    expect(ld.text()).toContain('16.5%')
+  })
+
+  it('flags an insufficient runway on the affected row', () => {
+    const wrapper = mount(PerformanceResultsTable, { props: { result: makeResult() } })
+    const tod = wrapper.get('[data-phase="tod"]')
+    expect(tod.text()).toMatch(/insufficient/i)
+    expect(tod.classes()).toContain('perf-results__row--insufficient')
+  })
+
+  it('renders the [ESTIMATED] marker only on estimated values (REQ-PF-017)', () => {
+    const wrapper = mount(PerformanceResultsTable, {
+      props: {
+        result: makeResult({
+          estimated: {
+            takeoffRoll: false,
+            takeoffDistance50ft: true,
+            landingRoll: false,
+            landingDistance50ft: false,
+          },
+        }),
+      },
+    })
+    expect(wrapper.findAllComponents(EstimatedMarker)).toHaveLength(1)
+    expect(wrapper.get('[data-phase="tod"]').text()).toContain('[ESTIMATED]')
+    expect(wrapper.get('[data-phase="tor"]').text()).not.toContain('[ESTIMATED]')
+  })
+
+  it('shows no estimated marker when every value is POH-authoritative', () => {
+    const wrapper = mount(PerformanceResultsTable, { props: { result: makeResult() } })
+    expect(wrapper.findAllComponents(EstimatedMarker)).toHaveLength(0)
+  })
+})

--- a/frontend/src/modules/performance/stores/__tests__/performance.store.int.spec.ts
+++ b/frontend/src/modules/performance/stores/__tests__/performance.store.int.spec.ts
@@ -1,0 +1,77 @@
+// @IT-PF-STORE-001@ (FROM: @IMP-PF-STORE-005@)
+
+// P1 ↔ P2 data-contract handshake: the store orchestrates the real POH-distance,
+// extrapolation and safety-factor cores over a schema-validated AircraftProfile
+// and projects them to the Go/No-Go view-model. The exhaustive branch coverage
+// lives in performance.store.spec.ts; this asserts the end-to-end contract holds
+// against the unmocked core (UJ-C-001 numerics included).
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePerformanceStore } from '../performance.store'
+import {
+  buildPerformanceAircraft,
+  WITHIN_ENVELOPE_CONDITIONS,
+  EXTRAPOLATED_CONDITIONS,
+  BLOCKED_TEMP_CONDITIONS,
+} from '../../__tests__/performance-fixtures'
+
+function enter(
+  store: ReturnType<typeof usePerformanceStore>,
+  c: { mass: number; pressureAltitude: number; temperature: number },
+  available: { takeoff: number; landing: number },
+): void {
+  store.updateCondition('mass', c.mass)
+  store.updateCondition('pressureAltitude', c.pressureAltitude)
+  store.updateCondition('temperature', c.temperature)
+  store.setAvailable('takeoff', available.takeoff)
+  store.setAvailable('landing', available.landing)
+}
+
+describe('performance store ↔ P1 core (integration)', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('produces a GO advisory with the correct margin from real POH math', () => {
+    const store = usePerformanceStore()
+    store.loadProfile(buildPerformanceAircraft())
+    enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+
+    expect(store.uiState).toBe('GO')
+    expect(store.result!.takeoff.fullRequired).toBeCloseTo(1000, 6)
+    expect(store.result!.takeoff.marginAbsolute).toBeCloseTo(200, 6)
+  })
+
+  it('raises CRIT-PF-002 and blocks Go when the runway is insufficient', () => {
+    const store = usePerformanceStore()
+    store.loadProfile(buildPerformanceAircraft())
+    enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 900, landing: 1000 })
+
+    expect(store.uiState).toBe('NO_GO')
+    expect(store.result!.goNoGo).toBe(false)
+    expect(store.notifications.some((n) => n.id === 'CRIT-PF-002')).toBe(true)
+  })
+
+  it('gates an extrapolated result behind acknowledgment, then finalizes (UJ-C-001)', () => {
+    const store = usePerformanceStore()
+    store.loadProfile(buildPerformanceAircraft())
+    enter(store, EXTRAPOLATED_CONDITIONS, { takeoff: 2000, landing: 2000 })
+
+    expect(store.uiState).toBe('PENDING_ACK')
+    expect(store.result!.finalized).toBe(false)
+    store.acknowledgeExtrapolation()
+    expect(store.result!.finalized).toBe(true)
+    expect(store.result!.goNoGo).toBe(true)
+    // Finalized GO advisory, with the extrapolation caution still standing.
+    expect(store.uiState).toBe('WARNING')
+  })
+
+  it('blocks computation beyond the 10% extrapolation cap (UJ-C-001)', () => {
+    const store = usePerformanceStore()
+    store.loadProfile(buildPerformanceAircraft())
+    enter(store, BLOCKED_TEMP_CONDITIONS, { takeoff: 2000, landing: 2000 })
+
+    expect(store.uiState).toBe('BLOCKED')
+    expect(store.result).toBeNull()
+    expect(store.notifications.some((n) => n.id === 'ERR-PF-001')).toBe(true)
+  })
+})

--- a/frontend/src/modules/performance/stores/__tests__/performance.store.spec.ts
+++ b/frontend/src/modules/performance/stores/__tests__/performance.store.spec.ts
@@ -1,0 +1,237 @@
+// @UT-PF-STORE-001@ (FROM: @IMP-PF-STORE-002@)
+// @UT-PF-STORE-002@ (FROM: @IMP-PF-STORE-005@)
+// @UT-PF-STORE-003@ (FROM: @IMP-PF-STORE-006@)
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePerformanceStore } from '../performance.store'
+import {
+  buildPerformanceAircraft,
+  WITHIN_ENVELOPE_CONDITIONS,
+  EXTRAPOLATED_CONDITIONS,
+  BLOCKED_TEMP_CONDITIONS,
+} from '../../__tests__/performance-fixtures'
+
+type Store = ReturnType<typeof usePerformanceStore>
+
+function enter(
+  store: Store,
+  c: { mass: number; pressureAltitude: number; temperature: number },
+  available: { takeoff: number; landing: number },
+): void {
+  store.updateCondition('mass', c.mass)
+  store.updateCondition('pressureAltitude', c.pressureAltitude)
+  store.updateCondition('temperature', c.temperature)
+  store.setAvailable('takeoff', available.takeoff)
+  store.setAvailable('landing', available.landing)
+}
+
+describe('usePerformanceStore', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  describe('lifecycle & input completeness', () => {
+    it('starts INITIAL', () => {
+      const store = usePerformanceStore()
+      expect(store.uiState).toBe('INITIAL')
+      expect(store.result).toBeNull()
+      expect(store.notifications).toEqual([])
+    })
+
+    it('is UNCONFIGURED with a profile but incomplete inputs', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      expect(store.uiState).toBe('UNCONFIGURED')
+      store.updateCondition('mass', 800)
+      store.updateCondition('pressureAltitude', 5000)
+      store.updateCondition('temperature', 25)
+      store.setAvailable('takeoff', 1200)
+      expect(store.uiState).toBe('UNCONFIGURED')
+      expect(store.inputsComplete).toBe(false)
+    })
+
+    it('custom OSF preset without a multiplier is incomplete', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      store.setOsfPreset('custom')
+      expect(store.uiState).toBe('UNCONFIGURED')
+      store.setCustomOsf(1.3)
+      expect(store.result).not.toBeNull()
+    })
+
+    it('clearProfile resets to INITIAL', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      store.clearProfile()
+      expect(store.uiState).toBe('INITIAL')
+      expect(store.profile).toBeNull()
+      expect(store.result).toBeNull()
+    })
+  })
+
+  describe('POH distances, factors & margin (REQ-PF-004/006/007)', () => {
+    it('produces correct base + operational required distances under EASA OSF', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+
+      const r = store.result!
+      expect(r.base.takeoffRoll).toBeCloseTo(475, 6)
+      expect(r.base.takeoffDistance50ft).toBeCloseTo(800, 6)
+      expect(r.base.landingRoll).toBeCloseTo(330, 6)
+      expect(r.base.landingDistance50ft).toBeCloseTo(600, 6)
+      expect(r.takeoff.fullRequired).toBeCloseTo(1000, 6)
+      expect(r.landing.fullRequired).toBeCloseTo(858, 6)
+    })
+
+    it('GO with absolute + percentage margin when runway is sufficient', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      expect(store.uiState).toBe('GO')
+      expect(store.result!.goNoGo).toBe(true)
+      expect(store.result!.takeoff.marginAbsolute).toBeCloseTo(200, 6)
+      expect(store.result!.takeoff.marginPercent).toBeCloseTo(20, 6)
+    })
+
+    it('friction/slope correct only the ground roll; DA/wind the full distance', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 5000, landing: 5000 })
+      store.setFactor('friction', 1.2)
+
+      // TOR base 475 → ground roll ×1.2 ×OSF1.25 = 712.5
+      expect(store.result!.takeoff.groundRollRequired).toBeCloseTo(712.5, 4)
+      // TOD: airborne 325 unaffected by friction; (475×1.2 + 325)×1.25 = 1118.75
+      expect(store.result!.takeoff.fullRequired).toBeCloseTo(1118.75, 4)
+    })
+  })
+
+  describe('CRIT-PF-002 / WARN-PF-002 surfacing (REQ-PF-015/016)', () => {
+    it('NO_GO + CRIT-PF-002 when required exceeds available', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 900, landing: 1000 })
+      expect(store.uiState).toBe('NO_GO')
+      expect(store.notifications.some((n) => n.id === 'CRIT-PF-002')).toBe(true)
+      expect(store.hasCriticalNotification).toBe(true)
+    })
+
+    it('WARNING + WARN-PF-002 when OSF below the recommended minimum', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 2000, landing: 2000 })
+      store.setOsfPreset('custom')
+      store.setCustomOsf(1.1)
+      expect(store.uiState).toBe('WARNING')
+      expect(store.notifications.some((n) => n.id === 'WARN-PF-002')).toBe(true)
+    })
+
+    it('poh-afm preset reads the profile factors and clears the WARN', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft({ safetyFactors: { takeoff: 1.5, landing: 1.6 } }))
+      store.setOsfPreset('poh-afm')
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 5000, landing: 5000 })
+      expect(store.osfInput.pohMandatedFactor).toEqual({ takeoff: 1.5, landing: 1.6 })
+      expect(store.result!.takeoff.fullRequired).toBeCloseTo(1200, 6)
+      expect(store.notifications.some((n) => n.id === 'WARN-PF-002')).toBe(false)
+    })
+  })
+
+  describe('extrapolation control (REQ-PF-010/011/012, UJ-C-001)', () => {
+    it('PENDING_ACK with +20% penalty and WARN-PF-003 inside the 10% band', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, EXTRAPOLATED_CONDITIONS, { takeoff: 2000, landing: 2000 })
+      expect(store.uiState).toBe('PENDING_ACK')
+      expect(store.result!.extrapolation.requiresAcknowledgment).toBe(true)
+      expect(store.result!.extrapolation.penaltyApplied).toBe(true)
+      expect(store.result!.finalized).toBe(false)
+      expect(store.awaitingAcknowledgment).toBe(true)
+      expect(store.notifications.some((n) => n.id === 'WARN-PF-003')).toBe(true)
+    })
+
+    it('acknowledgment finalizes the result; the extrapolation warning persists', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, EXTRAPOLATED_CONDITIONS, { takeoff: 2000, landing: 2000 })
+      store.acknowledgeExtrapolation()
+      expect(store.result!.finalized).toBe(true)
+      expect(store.result!.goNoGo).toBe(true)
+      // Finalized, but the standing WARN-PF-003 keeps the state at WARNING.
+      expect(store.uiState).toBe('WARNING')
+      expect(store.awaitingAcknowledgment).toBe(false)
+    })
+
+    it('a later input change re-arms the acknowledgment gate', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, EXTRAPOLATED_CONDITIONS, { takeoff: 2000, landing: 2000 })
+      store.acknowledgeExtrapolation()
+      store.updateCondition('temperature', 53)
+      expect(store.uiState).toBe('PENDING_ACK')
+    })
+
+    it('acknowledgeExtrapolation is a no-op when nothing is pending', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      store.acknowledgeExtrapolation()
+      expect(store.uiState).toBe('GO')
+    })
+
+    it('floors below-envelope conditions at the POH best case without ack (REQ-PF-011)', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, { mass: 800, pressureAltitude: 5000, temperature: -10 }, { takeoff: 2000, landing: 2000 })
+      expect(store.result!.extrapolation.benefitCapped).toBe(true)
+      expect(store.result!.extrapolation.requiresAcknowledgment).toBe(false)
+      // -10 °C floors to the 0 °C POH boundary value (800,5000,0) = 725 m.
+      expect(store.result!.base.takeoffDistance50ft).toBeCloseTo(725, 6)
+    })
+
+    it('BLOCKED + ERR-PF-001 beyond the 10% temperature cap', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, BLOCKED_TEMP_CONDITIONS, { takeoff: 2000, landing: 2000 })
+      expect(store.uiState).toBe('BLOCKED')
+      expect(store.result).toBeNull()
+      expect(store.notifications.some((n) => n.id === 'ERR-PF-001')).toBe(true)
+    })
+
+    it('BLOCKED beyond the altitude cap', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, { mass: 800, pressureAltitude: 11_100, temperature: 25 }, { takeoff: 2000, landing: 2000 })
+      expect(store.uiState).toBe('BLOCKED')
+    })
+  })
+
+  describe('failure surfaces', () => {
+    it('rejects a Draft profile (ERR-PF-002)', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft({ status: 'draft' }))
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      expect(store.uiState).toBe('BLOCKED')
+      expect(store.notifications.some((n) => n.id === 'ERR-PF-002')).toBe(true)
+    })
+
+    it('rejects a profile missing a required POH phase (ERR-PF-002)', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft({ phases: ['TakeoffRoll', 'TakeoffDistance50ft'] }))
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      expect(store.uiState).toBe('BLOCKED')
+      expect(store.notifications.some((n) => n.id === 'ERR-PF-002')).toBe(true)
+    })
+
+    it('rejects a non-positive correction factor (ERR-SYS-001)', () => {
+      const store = usePerformanceStore()
+      store.loadProfile(buildPerformanceAircraft())
+      enter(store, WITHIN_ENVELOPE_CONDITIONS, { takeoff: 1200, landing: 1000 })
+      store.setFactor('friction', 0)
+      expect(store.uiState).toBe('BLOCKED')
+      expect(store.notifications.some((n) => n.id === 'ERR-SYS-001')).toBe(true)
+    })
+  })
+})

--- a/frontend/src/modules/performance/stores/performance.store.ts
+++ b/frontend/src/modules/performance/stores/performance.store.ts
@@ -1,0 +1,379 @@
+/**
+ * Performance — Pinia Store.
+ *
+ * P2 orchestration layer for the v0.4.0 Performance Math Core. It owns no
+ * safety math: every distance, penalty, margin and violation is produced by a
+ * pure `src/core/` function. The store's job is to (1) gather pilot input,
+ * (2) sequence the three P1 facades — POH distances → conservative
+ * extrapolation control → safety-factor pipeline — and (3) project the typed
+ * results into a view-model plus the centralised notification contract.
+ *
+ * Architecture (mirrors the M&B store):
+ *   Layer 1 — Raw input state (profile, conditions, runway, OSF, factors, ack)
+ *   Layer 2 — Derived getters (osfInput, inputsComplete, severity flags)
+ *   Layer 3 — Notification capture (replaced wholesale on every run)
+ *   Layer 4 — State machine pointer (single `evaluateState()` mutator)
+ *
+ * @see docs/architecture/notification_schema.md
+ * @see docs/journeys/03_performance_safety.md
+ */
+
+import { defineStore } from 'pinia'
+import {
+  computePohDistances,
+  pivotDataPointsToCube,
+  type PohDistanceConditions,
+} from '@/core/logic/performance.poh-distance'
+import {
+  cubeEnvelopeRanges,
+  resolveExtrapolatedDistance,
+} from '@/core/logic/performance.extrapolation'
+import { applySafetyFactors } from '@/core/adapters/performance.safety-factor.adapter'
+import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import type { FlightPhase } from '@/core/domain/aircraft.types'
+import type {
+  OperationalSafetyFactorInput,
+  PerformanceCorrectionFactors,
+} from '@/core/domain/performance.math-types'
+import type {
+  AvailableDistancesInput,
+  Notification,
+  OsfPreset,
+  PerformanceConditionsInput,
+  PerformanceResultView,
+  PerformanceUiState,
+} from './performance.types'
+
+/** The four POH phases keyed to their view-model distance fields. */
+const PHASE_TO_KEY = {
+  TakeoffRoll: 'takeoffRoll',
+  TakeoffDistance50ft: 'takeoffDistance50ft',
+  LandingRoll: 'landingRoll',
+  LandingDistance50ft: 'landingDistance50ft',
+} as const satisfies Record<FlightPhase, keyof PerformanceResultView['base']>
+
+/** Default correction factors: 1.0 = no correction (pilot adjusts per conditions). */
+function neutralFactors(): PerformanceCorrectionFactors {
+  return { friction: 1, slope: 1, densityAltitude: 1, wind: 1 }
+}
+
+function note(
+  id: string,
+  severity: Notification['severity'],
+  message: string,
+  persistent = false,
+): Notification {
+  return { id, severity, message, context: 'Performance', persistent, dismissible: true }
+}
+
+export const usePerformanceStore = defineStore('performance', {
+  // ── Layer 1 — Raw input state ──────────────────────────────────────────────
+  state: () => ({
+    uiState: 'INITIAL' as PerformanceUiState,
+    profile: null as AircraftProfile | null,
+    conditions: {
+      mass: null,
+      pressureAltitude: null,
+      temperature: null,
+    } as PerformanceConditionsInput,
+    available: { takeoff: null, landing: null } as AvailableDistancesInput,
+    factors: neutralFactors() as PerformanceCorrectionFactors,
+    osfPreset: 'easa-standard' as OsfPreset,
+    /** Custom OSF multiplier — only consulted when `osfPreset === 'custom'`. */
+    customOsf: null as number | null,
+    /** Pilot-in-Command acknowledgment of an extrapolated result (REQ-PF-012). */
+    acknowledged: false,
+    notifications: [] as Notification[],
+    result: null as PerformanceResultView | null,
+  }),
+
+  // ── Layer 2 — Derived getters ──────────────────────────────────────────────
+  getters: {
+    // @IMP-PF-STORE-002@ (FROM: @REQ-PF-006@, @REQ-PF-016@)
+    /** Build the P1 OSF input from the selected preset + the profile's POH factors. */
+    osfInput(): OperationalSafetyFactorInput {
+      const poh = this.profile?.safetyFactors
+      return {
+        preset: this.osfPreset,
+        customMultiplier:
+          this.osfPreset === 'custom' && this.customOsf !== null ? this.customOsf : undefined,
+        pohMandatedFactor: poh ? { takeoff: poh.takeoff, landing: poh.landing } : undefined,
+      }
+    },
+
+    /** True once every mandatory input needed for a computation is present and finite. */
+    inputsComplete(): boolean {
+      const c = this.conditions
+      const a = this.available
+      const finite = (v: number | null): v is number => v !== null && Number.isFinite(v)
+      const customOk = this.osfPreset !== 'custom' || finite(this.customOsf)
+      return (
+        finite(c.mass) &&
+        finite(c.pressureAltitude) &&
+        finite(c.temperature) &&
+        finite(a.takeoff) &&
+        finite(a.landing) &&
+        customOk
+      )
+    },
+
+    hasCriticalNotification(): boolean {
+      return this.notifications.some((n) => n.severity === 'CRITICAL')
+    },
+    hasErrorNotification(): boolean {
+      return this.notifications.some((n) => n.severity === 'ERROR')
+    },
+    hasWarningNotification(): boolean {
+      return this.notifications.some((n) => n.severity === 'WARNING')
+    },
+
+    /** True when an extrapolated result is still awaiting acknowledgment (REQ-PF-012). */
+    awaitingAcknowledgment(): boolean {
+      return this.result?.extrapolation.requiresAcknowledgment === true && !this.acknowledged
+    },
+  },
+
+  // ── Layers 3 & 4 — Actions ─────────────────────────────────────────────────
+  actions: {
+    // @IMP-PF-STORE-003@ (FROM: @REQ-PF-001@, @REQ-AC-005@)
+    /** Load a (Verified) aircraft profile and recompute from current inputs. */
+    loadProfile(profile: AircraftProfile): void {
+      this.profile = profile
+      this.acknowledged = false
+      this._runCalculation()
+      this.evaluateState()
+    },
+
+    updateCondition<K extends keyof PerformanceConditionsInput>(
+      key: K,
+      value: number | null,
+    ): void {
+      this.conditions[key] = value
+      this._recompute()
+    },
+
+    setAvailable<K extends keyof AvailableDistancesInput>(key: K, value: number | null): void {
+      this.available[key] = value
+      this._recompute()
+    },
+
+    setFactor<K extends keyof PerformanceCorrectionFactors>(key: K, value: number): void {
+      this.factors[key] = value
+      this._recompute()
+    },
+
+    setOsfPreset(preset: OsfPreset): void {
+      this.osfPreset = preset
+      this._recompute()
+    },
+
+    setCustomOsf(value: number | null): void {
+      this.customOsf = value
+      this._recompute()
+    },
+
+    // @IMP-PF-STORE-004@ (FROM: @REQ-PF-012@)
+    /**
+     * Record the Pilot-in-Command's acknowledgment of an extrapolated result.
+     * No recomputation — acknowledgment only lifts the finalization gate; the
+     * numbers are unchanged. Any later input change clears it (see `_recompute`).
+     */
+    acknowledgeExtrapolation(): void {
+      if (!this.awaitingAcknowledgment) return
+      this.acknowledged = true
+      if (this.result) this.result.finalized = true
+      this.evaluateState()
+    },
+
+    clearProfile(): void {
+      this.profile = null
+      this.acknowledged = false
+      this.notifications = []
+      this.result = null
+      this.uiState = 'INITIAL'
+    },
+
+    /** Re-run after any input change. Changing inputs always invalidates a prior ack. */
+    _recompute(): void {
+      this.acknowledged = false
+      this._runCalculation()
+      this.evaluateState()
+    },
+
+    // @IMP-PF-STORE-005@ (FROM: @REQ-PF-004@, @REQ-PF-006@, @REQ-PF-007@, @REQ-PF-010@, @REQ-PF-011@, @REQ-PF-012@, @REQ-PF-015@, @REQ-PF-016@, @REQ-PF-017@)
+    /**
+     * Sequence the three P1 facades and capture the result + notifications.
+     * Pure orchestration — every numeric value comes from `src/core/`.
+     */
+    _runCalculation(): void {
+      if (!this.profile) {
+        this.notifications = []
+        this.result = null
+        return
+      }
+      if (!this.inputsComplete) {
+        this.notifications = []
+        this.result = null
+        return
+      }
+
+      const conditions: PohDistanceConditions = {
+        mass: this.conditions.mass!,
+        pressureAltitude: this.conditions.pressureAltitude!,
+        temperature: this.conditions.temperature!,
+      }
+
+      // ── 1. Base POH distances (enforces the Verified-profile gate) ──────────
+      const poh = computePohDistances(this.profile, conditions)
+      if (poh.status === 'failure') {
+        this.notifications = [
+          note('ERR-PF-002', 'ERROR', `Performance data unavailable: ${poh.message}`),
+        ]
+        this.result = null
+        return
+      }
+
+      // ── 2. Conservative extrapolation control, per phase ────────────────────
+      const byPhase = new Map<FlightPhase, { distance: number; ranges: ReturnType<typeof cubeEnvelopeRanges> }>()
+      const perf = this.profile.performanceProfiles ?? []
+      try {
+        for (const pp of perf) {
+          if (!(pp.flightPhase in PHASE_TO_KEY)) continue
+          const cube = pivotDataPointsToCube(pp.dataPoints)
+          const key = PHASE_TO_KEY[pp.flightPhase]
+          byPhase.set(pp.flightPhase, {
+            distance: poh.distances[key],
+            ranges: cubeEnvelopeRanges(cube),
+          })
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        this.notifications = [note('ERR-PF-002', 'ERROR', `Performance data unavailable: ${message}`)]
+        this.result = null
+        return
+      }
+
+      const penalised: PerformanceResultView['base'] = {
+        takeoffRoll: poh.distances.takeoffRoll,
+        takeoffDistance50ft: poh.distances.takeoffDistance50ft,
+        landingRoll: poh.distances.landingRoll,
+        landingDistance50ft: poh.distances.landingDistance50ft,
+      }
+      let requiresAcknowledgment = false
+      let benefitCapped = false
+      let penaltyApplied = false
+
+      for (const [phase, { distance, ranges }] of byPhase) {
+        const resolved = resolveExtrapolatedDistance(distance, conditions, ranges)
+        if (resolved.state === 'blocked') {
+          // A single phase beyond the 10% cap blocks the whole computation —
+          // no distance may reach a Go/No-Go decision (REQ-PF-010, UJ-C-001).
+          this.notifications = [note('ERR-PF-001', 'ERROR', resolved.message, true)]
+          this.result = null
+          return
+        }
+        penalised[PHASE_TO_KEY[phase]] = resolved.distance
+        requiresAcknowledgment ||= resolved.requiresAcknowledgment
+        benefitCapped ||= resolved.benefitCapped
+        penaltyApplied ||= resolved.state === 'extrapolated'
+      }
+
+      // ── 3. Safety-factor pipeline → operational distances + Go/No-Go ────────
+      const sf = applySafetyFactors({
+        base: penalised,
+        factors: this.factors,
+        osf: this.osfInput,
+        available: { takeoff: this.available.takeoff!, landing: this.available.landing! },
+      })
+      if (sf.status === 'failure') {
+        this.notifications = [
+          note('ERR-SYS-001', 'ERROR', 'Performance inputs failed validation — verify entries.'),
+        ]
+        this.result = null
+        return
+      }
+
+      // ── 4. Project violations + extrapolation state into notifications ──────
+      const notifications: Notification[] = []
+      if (requiresAcknowledgment) {
+        notifications.push(
+          note(
+            'WARN-PF-003',
+            'WARNING',
+            'Performance data extrapolated beyond POH limits — a +20% penalty was applied. Pilot-in-Command acknowledgment required before use.',
+            true,
+          ),
+        )
+      }
+      for (const v of sf.violations) {
+        const op = v.operation === 'takeoff' ? 'take-off' : 'landing'
+        if (v.notificationId === 'CRIT-PF-002') {
+          notifications.push(
+            note('CRIT-PF-002', 'CRITICAL', `Runway insufficient for required ${op} distance.`),
+          )
+        } else if (v.notificationId === 'WARN-PF-002') {
+          notifications.push(
+            note(
+              'WARN-PF-002',
+              'WARNING',
+              `Operational safety factor for ${op} is below the recommended minimum.`,
+            ),
+          )
+        }
+      }
+
+      const finalized = !requiresAcknowledgment || this.acknowledged
+      this.notifications = notifications
+      this.result = {
+        base: penalised,
+        // CAA SSL 07 estimation (REQ-PF-005) is a sibling feature; until it
+        // lands the store reads only authoritative POH values, so no marker.
+        estimated: {
+          takeoffRoll: false,
+          takeoffDistance50ft: false,
+          landingRoll: false,
+          landingDistance50ft: false,
+        },
+        takeoff: sf.takeoff,
+        landing: sf.landing,
+        goNoGo: sf.goNoGo,
+        finalized,
+        extrapolation: { requiresAcknowledgment, benefitCapped, penaltyApplied },
+        clamped: Object.values(poh.clamping).some(
+          (c) => c.massClamped || c.altitudeClamped || c.temperatureClamped,
+        ),
+      }
+    },
+
+    // @IMP-PF-STORE-006@ (FROM: @DES-ARCH-003@, @DES-ARCH-005@)
+    /** Deterministic state resolution — the only writer of `uiState`. */
+    evaluateState(): void {
+      if (!this.profile) {
+        this.uiState = 'INITIAL'
+        return
+      }
+      if (!this.inputsComplete || !this.result) {
+        // No result with notifications still means a hard failure (BLOCKED).
+        if (this.hasErrorNotification) {
+          this.uiState = 'BLOCKED'
+          return
+        }
+        this.uiState = 'UNCONFIGURED'
+        return
+      }
+      if (this.awaitingAcknowledgment) {
+        this.uiState = 'PENDING_ACK'
+        return
+      }
+      if (this.hasCriticalNotification) {
+        this.uiState = 'NO_GO'
+        return
+      }
+      if (this.hasWarningNotification) {
+        this.uiState = 'WARNING'
+        return
+      }
+      this.uiState = 'GO'
+    },
+  },
+})

--- a/frontend/src/modules/performance/stores/performance.types.ts
+++ b/frontend/src/modules/performance/stores/performance.types.ts
@@ -1,0 +1,96 @@
+/**
+ * Performance module — UI state & view-model types.
+ * P2 Feature Module. Re-exports the P1 safety-core result vocabulary and adds
+ * the presentation-only shapes the store hands to the view. No safety math is
+ * defined here — every numeric result originates in `src/core/`.
+ */
+
+import type {
+  OperationalDistanceSet,
+  OperationalSafetyFactorInput,
+  OsfPreset,
+  PerformanceCorrectionFactors,
+} from '@/core/domain/performance.math-types'
+import type { Notification } from '@/core/domain/notification.types'
+
+// @IMP-PF-STORE-001@ (FROM: @REQ-PF-007@, @REQ-PF-017@)
+export type {
+  Notification,
+  OperationalDistanceSet,
+  OperationalSafetyFactorInput,
+  OsfPreset,
+  PerformanceCorrectionFactors,
+}
+
+/**
+ * Performance UI state machine pointer. `evaluateState()` is the sole writer.
+ * Priority (high → low): BLOCKED, PENDING_ACK, NO_GO, WARNING, GO.
+ */
+export type PerformanceUiState =
+  | 'INITIAL' // no Verified performance-capable aircraft loaded
+  | 'UNCONFIGURED' // mandatory conditions / runway distances not yet entered
+  | 'BLOCKED' // computation refused (beyond extrapolation cap, or unusable input)
+  | 'PENDING_ACK' // extrapolated result awaiting Pilot-in-Command acknowledgment
+  | 'NO_GO' // blocking violation present (CRIT-PF-002 runway insufficient)
+  | 'WARNING' // advisory violation present (WARN-PF-002 low OSF)
+  | 'GO' // all clear
+
+/** Raw pilot-entered environmental conditions, already in SI (kg, ft, °C). */
+export interface PerformanceConditionsInput {
+  mass: number | null
+  pressureAltitude: number | null
+  temperature: number | null
+}
+
+/** Manually-entered published runway distances (m): TORA / LDA. */
+export interface AvailableDistancesInput {
+  takeoff: number | null
+  landing: number | null
+}
+
+/** The four base POH distances after extrapolation handling (m). */
+export interface BaseDistanceView {
+  takeoffRoll: number
+  takeoffDistance50ft: number
+  landingRoll: number
+  landingDistance50ft: number
+}
+
+/**
+ * Per-distance provenance flag — true when the value was derived via the CAA
+ * SSL 07 estimation (REQ-PF-005) rather than read from the POH, and must carry
+ * the visible `[ESTIMATED]` marker (REQ-PF-017). The estimation engine itself
+ * is the CAA SSL 07 feature; until it lands, every flag is false and no marker
+ * renders.
+ */
+export interface EstimatedFlags {
+  takeoffRoll: boolean
+  takeoffDistance50ft: boolean
+  landingRoll: boolean
+  landingDistance50ft: boolean
+}
+
+/** Aggregate extrapolation state surfaced to the pilot (REQ-PF-010/011/012). */
+export interface ExtrapolationView {
+  /** REQ-PF-012 gate — an extrapolated result is not finalized until acknowledged. */
+  requiresAcknowledgment: boolean
+  /** REQ-PF-011 — at least one axis was floored at its best-case POH value. */
+  benefitCapped: boolean
+  /** REQ-PF-010 — the fixed +20% extrapolation penalty was applied. */
+  penaltyApplied: boolean
+}
+
+/** The complete view-model the store hands to the performance view. */
+export interface PerformanceResultView {
+  base: BaseDistanceView
+  estimated: EstimatedFlags
+  takeoff: OperationalDistanceSet
+  landing: OperationalDistanceSet
+  /** Aggregate Go/No-Go advisory from the safety-factor pipeline. */
+  goNoGo: boolean
+  /** True once the result may be acted on (no pending acknowledgment). */
+  finalized: boolean
+  extrapolation: ExtrapolationView
+  /** True when any phase clamped an out-of-envelope input to a POH boundary. */
+  clamped: boolean
+}

--- a/frontend/src/modules/performance/views/PerformanceView.vue
+++ b/frontend/src/modules/performance/views/PerformanceView.vue
@@ -1,0 +1,385 @@
+<script setup lang="ts">
+// @IMP-PF-VIEW-004@ (FROM: @REQ-PF-006@, @REQ-PF-007@, @REQ-PF-012@, @REQ-PF-013@, @REQ-PF-015@, @REQ-PF-016@)
+import { computed, onMounted, ref } from 'vue'
+import { useFleetStore } from '@/modules/aircraft/stores/fleet.store'
+import { usePerformanceStore } from '@/modules/performance/stores/performance.store'
+import type { AircraftProfile } from '@/core/adapters/aircraft.schema'
+import type { FlightPhase } from '@/core/domain/aircraft.types'
+import type { OsfPreset } from '@/modules/performance/stores/performance.types'
+import PerformanceResultsTable from '@/modules/performance/components/PerformanceResultsTable.vue'
+import ExtrapolationAcknowledgment from '@/modules/performance/components/ExtrapolationAcknowledgment.vue'
+
+const fleetStore = useFleetStore()
+const store = usePerformanceStore()
+
+const REQUIRED_PHASES: FlightPhase[] = [
+  'TakeoffRoll',
+  'TakeoffDistance50ft',
+  'LandingRoll',
+  'LandingDistance50ft',
+]
+
+const OSF_PRESETS: { value: OsfPreset; label: string }[] = [
+  { value: 'easa-standard', label: 'EASA Standard (1.25 / 1.43)' },
+  { value: 'poh-afm', label: 'POH / AFM specific' },
+  { value: 'short-field', label: 'Short field' },
+  { value: 'custom', label: 'Custom multiplier' },
+]
+
+const selectedId = ref('')
+
+/** A profile is usable for performance only when Verified and carrying all four POH phases. */
+function isPerfCapable(p: AircraftProfile): boolean {
+  if (p.status !== 'verified') return false
+  const present = new Set(
+    (p.performanceProfiles ?? []).filter((pp) => pp.dataPoints.length > 0).map((pp) => pp.flightPhase),
+  )
+  return REQUIRED_PHASES.every((ph) => present.has(ph))
+}
+
+const usableProfiles = computed(() => fleetStore.profiles.filter(isPerfCapable))
+const hasUsableFleet = computed(() => usableProfiles.value.length > 0)
+
+function optionLabel(p: AircraftProfile): string {
+  return `${p.registration} — ${p.manufacturer} ${p.model}`
+}
+
+const selectedLabel = computed(() => {
+  const p = usableProfiles.value.find((x) => x.id === selectedId.value)
+  return p ? optionLabel(p) : ''
+})
+
+onMounted(async () => {
+  if (fleetStore.fleetLoadState !== 'READY') {
+    await fleetStore.loadAll()
+  }
+})
+
+function onAircraftSelected(event: Event): void {
+  const id = (event.target as HTMLSelectElement).value
+  selectedId.value = id
+  const profile = usableProfiles.value.find((p) => p.id === id)
+  if (profile) {
+    store.loadProfile(profile)
+  } else {
+    store.clearProfile()
+  }
+}
+
+function numFromEvent(event: Event): number | null {
+  const raw = (event.target as HTMLInputElement).value
+  if (raw.trim() === '') return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+}
+
+function onCondition(key: 'mass' | 'pressureAltitude' | 'temperature', event: Event): void {
+  store.updateCondition(key, numFromEvent(event))
+}
+function onAvailable(key: 'takeoff' | 'landing', event: Event): void {
+  store.setAvailable(key, numFromEvent(event))
+}
+function onFactor(
+  key: 'friction' | 'slope' | 'densityAltitude' | 'wind',
+  event: Event,
+): void {
+  store.setFactor(key, numFromEvent(event) ?? 1)
+}
+function onOsfPreset(event: Event): void {
+  store.setOsfPreset((event.target as HTMLSelectElement).value as OsfPreset)
+}
+function onCustomOsf(event: Event): void {
+  store.setCustomOsf(numFromEvent(event))
+}
+
+const goNoGo = computed(() => {
+  const r = store.result
+  if (!r || !r.finalized) return null
+  return r.goNoGo
+})
+
+const stateClass = computed(() => `perf-view--${store.uiState.toLowerCase()}`)
+</script>
+
+<template>
+  <div class="perf-view" :class="stateClass">
+    <header class="perf-view__header">
+      <h1>Performance</h1>
+      <p class="perf-view__subtitle">POH take-off &amp; landing distances with safety factors.</p>
+    </header>
+
+    <!-- Aircraft selection -->
+    <section class="perf-card" aria-labelledby="perf-aircraft-heading">
+      <h2 id="perf-aircraft-heading" class="perf-card__title">Aircraft</h2>
+      <p v-if="!hasUsableFleet" class="perf-empty">
+        No Verified aircraft with performance data in your fleet. Add POH performance tables and
+        verify the profile to compute distances.
+      </p>
+      <div v-else class="perf-field">
+        <label for="perf-aircraft-select" class="perf-field__label">
+          {{ store.profile ? 'Aircraft' : 'Select aircraft' }}
+        </label>
+        <select
+          id="perf-aircraft-select"
+          :value="selectedId"
+          aria-label="Select aircraft"
+          class="perf-select"
+          @change="onAircraftSelected"
+        >
+          <option value="">— choose aircraft —</option>
+          <option v-for="p in usableProfiles" :key="p.id" :value="p.id">
+            {{ optionLabel(p) }}
+          </option>
+        </select>
+        <span v-if="selectedLabel" class="aircraft-label">{{ selectedLabel }}</span>
+      </div>
+    </section>
+
+    <!-- Conditions + runway form -->
+    <section v-if="store.profile" class="perf-card" aria-labelledby="perf-conditions-heading">
+      <h2 id="perf-conditions-heading" class="perf-card__title">Conditions</h2>
+      <div class="perf-grid">
+        <div class="perf-field">
+          <label for="perf-mass" class="perf-field__label">Mass (kg)</label>
+          <input id="perf-mass" type="number" inputmode="decimal" class="perf-input"
+            :value="store.conditions.mass ?? ''" @input="onCondition('mass', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-pa" class="perf-field__label">Pressure altitude (ft)</label>
+          <input id="perf-pa" type="number" inputmode="decimal" class="perf-input"
+            :value="store.conditions.pressureAltitude ?? ''" @input="onCondition('pressureAltitude', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-temp" class="perf-field__label">Temperature (°C)</label>
+          <input id="perf-temp" type="number" inputmode="decimal" class="perf-input"
+            :value="store.conditions.temperature ?? ''" @input="onCondition('temperature', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-tora" class="perf-field__label">Available take-off (TORA, m)</label>
+          <input id="perf-tora" type="number" inputmode="decimal" class="perf-input"
+            :value="store.available.takeoff ?? ''" @input="onAvailable('takeoff', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-lda" class="perf-field__label">Available landing (LDA, m)</label>
+          <input id="perf-lda" type="number" inputmode="decimal" class="perf-input"
+            :value="store.available.landing ?? ''" @input="onAvailable('landing', $event)" />
+        </div>
+      </div>
+
+      <h3 class="perf-card__subtitle">Operational safety factor</h3>
+      <div class="perf-grid">
+        <div class="perf-field">
+          <label for="perf-osf" class="perf-field__label">Preset</label>
+          <select id="perf-osf" class="perf-select" :value="store.osfPreset" @change="onOsfPreset">
+            <option v-for="o in OSF_PRESETS" :key="o.value" :value="o.value">{{ o.label }}</option>
+          </select>
+        </div>
+        <div v-if="store.osfPreset === 'custom'" class="perf-field">
+          <label for="perf-osf-custom" class="perf-field__label">Custom multiplier (1.00–3.00)</label>
+          <input id="perf-osf-custom" type="number" step="0.01" inputmode="decimal" class="perf-input"
+            :value="store.customOsf ?? ''" @input="onCustomOsf" />
+        </div>
+      </div>
+
+      <h3 class="perf-card__subtitle">Correction factors</h3>
+      <div class="perf-grid">
+        <div class="perf-field">
+          <label for="perf-friction" class="perf-field__label">Friction (ground roll)</label>
+          <input id="perf-friction" type="number" step="0.01" inputmode="decimal" class="perf-input"
+            :value="store.factors.friction" @input="onFactor('friction', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-slope" class="perf-field__label">Slope (ground roll)</label>
+          <input id="perf-slope" type="number" step="0.01" inputmode="decimal" class="perf-input"
+            :value="store.factors.slope" @input="onFactor('slope', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-da" class="perf-field__label">Density altitude (full)</label>
+          <input id="perf-da" type="number" step="0.01" inputmode="decimal" class="perf-input"
+            :value="store.factors.densityAltitude" @input="onFactor('densityAltitude', $event)" />
+        </div>
+        <div class="perf-field">
+          <label for="perf-wind" class="perf-field__label">Wind (full)</label>
+          <input id="perf-wind" type="number" step="0.01" inputmode="decimal" class="perf-input"
+            :value="store.factors.wind" @input="onFactor('wind', $event)" />
+        </div>
+      </div>
+    </section>
+
+    <!-- Notifications -->
+    <section v-if="store.notifications.length > 0" class="perf-notifications" aria-label="Performance alerts">
+      <div
+        v-for="n in store.notifications"
+        :key="`${n.id}-${n.message}`"
+        class="notification"
+        :class="`notification--${n.severity.toLowerCase()}`"
+      >
+        <span class="notification__id">{{ n.id }}</span>
+        <span class="notification__message">{{ n.message }}</span>
+      </div>
+    </section>
+
+    <!-- Extrapolation acknowledgment gate -->
+    <ExtrapolationAcknowledgment
+      v-if="store.awaitingAcknowledgment"
+      @acknowledge="store.acknowledgeExtrapolation()"
+    />
+
+    <!-- Results -->
+    <section v-if="store.result" class="perf-card" aria-labelledby="perf-results-heading">
+      <h2 id="perf-results-heading" class="perf-card__title">Results</h2>
+
+      <div v-if="goNoGo !== null" class="perf-advisory" :class="goNoGo ? 'perf-advisory--go' : 'perf-advisory--nogo'">
+        {{ goNoGo ? 'GO — runway sufficient' : 'NO-GO — runway insufficient' }}
+      </div>
+      <div v-else class="perf-advisory perf-advisory--pending">
+        Advisory withheld — acknowledge the extrapolated data to finalize.
+      </div>
+
+      <PerformanceResultsTable :result="store.result" />
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.perf-view {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.perf-view__header {
+  margin-bottom: 1rem;
+}
+
+.perf-view__subtitle {
+  color: #6b7280;
+  margin: 0.25rem 0 0;
+}
+
+.perf-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.perf-card__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+}
+
+.perf-card__subtitle {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.perf-empty {
+  color: #6b7280;
+}
+
+.perf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.perf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.perf-field__label {
+  font-size: 0.8rem;
+  color: #374151;
+}
+
+.perf-input,
+.perf-select {
+  min-height: 44px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 1rem;
+}
+
+.aircraft-label {
+  margin-top: 0.5rem;
+  font-weight: 600;
+}
+
+.perf-notifications {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.notification {
+  display: flex;
+  gap: 0.6rem;
+  align-items: baseline;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.375rem;
+  border-left: 4px solid #9ca3af;
+  background: #f3f4f6;
+}
+
+.notification__id {
+  font-weight: 700;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.notification--warning {
+  background: #fffbeb;
+  border-left-color: #f59e0b;
+  color: #92400e;
+}
+
+.notification--critical {
+  background: #fef2f2;
+  border-left-color: #dc2626;
+  color: #991b1b;
+}
+
+.notification--error {
+  background: #fef2f2;
+  border-left-color: #b91c1c;
+  color: #991b1b;
+}
+
+.notification--info {
+  background: #eff6ff;
+  border-left-color: #3b82f6;
+  color: #1e40af;
+}
+
+.perf-advisory {
+  font-weight: 700;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.perf-advisory--go {
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #34d399;
+}
+
+.perf-advisory--nogo {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #f87171;
+}
+
+.perf-advisory--pending {
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #f59e0b;
+}
+</style>

--- a/frontend/src/modules/performance/views/__tests__/PerformanceView.spec.ts
+++ b/frontend/src/modules/performance/views/__tests__/PerformanceView.spec.ts
@@ -1,0 +1,110 @@
+// @UT-PF-VIEW-004@ (FROM: @IMP-PF-VIEW-004@)
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('@/modules/aircraft/services/fleet.repository', () => ({
+  fleetRepository: {
+    findAllWithDiagnostics:
+      vi.fn<() => Promise<{ profiles: unknown[]; diagnostics: unknown[] }>>(),
+  },
+}))
+
+import { fleetRepository } from '@/modules/aircraft/services/fleet.repository'
+import PerformanceView from '../PerformanceView.vue'
+import PerformanceResultsTable from '../../components/PerformanceResultsTable.vue'
+import ExtrapolationAcknowledgment from '../../components/ExtrapolationAcknowledgment.vue'
+import { buildPerformanceAircraft } from '../../__tests__/performance-fixtures'
+
+const mockedRepo = vi.mocked(fleetRepository)
+const aircraft = buildPerformanceAircraft()
+
+function seedFleet(profiles: unknown[]): void {
+  mockedRepo.findAllWithDiagnostics.mockResolvedValue({
+    profiles: profiles as never,
+    diagnostics: [],
+  })
+}
+
+async function selectAircraftAndEnter(
+  wrapper: Awaited<ReturnType<typeof mount>>,
+  values: { mass: string; pa: string; temp: string; tora: string; lda: string },
+): Promise<void> {
+  await wrapper.get('select[aria-label="Select aircraft"]').setValue(aircraft.id)
+  await wrapper.get('#perf-mass').setValue(values.mass)
+  await wrapper.get('#perf-pa').setValue(values.pa)
+  await wrapper.get('#perf-temp').setValue(values.temp)
+  await wrapper.get('#perf-tora').setValue(values.tora)
+  await wrapper.get('#perf-lda').setValue(values.lda)
+}
+
+describe('PerformanceView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    seedFleet([])
+  })
+
+  it('shows an empty-state message when no Verified performance aircraft exist', async () => {
+    const wrapper = mount(PerformanceView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('No Verified aircraft with performance data')
+  })
+
+  it('computes and renders a GO advisory for a sufficient runway', async () => {
+    seedFleet([aircraft])
+    const wrapper = mount(PerformanceView)
+    await flushPromises()
+
+    await selectAircraftAndEnter(wrapper, {
+      mass: '800',
+      pa: '5000',
+      temp: '25',
+      tora: '1200',
+      lda: '1000',
+    })
+
+    expect(wrapper.findComponent(PerformanceResultsTable).exists()).toBe(true)
+    expect(wrapper.text()).toContain('GO — runway sufficient')
+  })
+
+  it('surfaces CRIT-PF-002 and a NO-GO advisory for an insufficient runway', async () => {
+    seedFleet([aircraft])
+    const wrapper = mount(PerformanceView)
+    await flushPromises()
+
+    await selectAircraftAndEnter(wrapper, {
+      mass: '800',
+      pa: '5000',
+      temp: '25',
+      tora: '900',
+      lda: '1000',
+    })
+
+    expect(wrapper.text()).toContain('NO-GO — runway insufficient')
+    expect(wrapper.find('.notification--critical').exists()).toBe(true)
+    expect(wrapper.text()).toContain('CRIT-PF-002')
+  })
+
+  it('withholds the advisory behind the extrapolation acknowledgment gate (UJ-C-001)', async () => {
+    seedFleet([aircraft])
+    const wrapper = mount(PerformanceView)
+    await flushPromises()
+
+    await selectAircraftAndEnter(wrapper, {
+      mass: '800',
+      pa: '5000',
+      temp: '54',
+      tora: '2000',
+      lda: '2000',
+    })
+
+    const ack = wrapper.findComponent(ExtrapolationAcknowledgment)
+    expect(ack.exists()).toBe(true)
+    expect(wrapper.text()).toContain('Advisory withheld')
+
+    await ack.get('button').trigger('click')
+    expect(wrapper.findComponent(ExtrapolationAcknowledgment).exists()).toBe(false)
+    expect(wrapper.text()).toContain('GO — runway sufficient')
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -30,6 +30,12 @@ const router = createRouter({
       name: 'fleet',
       component: FleetManagementView,
     },
+    // @IMP-UI-ROUTE-006@ (FROM: @REQ-PF-001@, @REQ-PF-007@)
+    {
+      path: '/performance',
+      name: 'performance',
+      component: () => import('@/modules/performance/views/PerformanceView.vue'),
+    },
     // @IMP-UI-ROUTE-003@ (FROM: @REQ-AC-001@, @REQ-UQ-003@)
     {
       path: '/fleet/new',

--- a/frontend/tests/e2e/features/phase-c-performance-safety/extrapolation-acknowledgment.feature
+++ b/frontend/tests/e2e/features/phase-c-performance-safety/extrapolation-acknowledgment.feature
@@ -1,0 +1,35 @@
+@phase-C @performance @performance-safety
+Feature: Conservative extrapolation control on the Performance page
+  As a pilot computing take-off and landing distances
+  I want the system to flag, penalise, or refuse out-of-envelope conditions
+  So that I never act on optimistic performance data beyond the POH charts
+
+  Background:
+    Given the pilot has a Verified aircraft "D-EPER" with published performance data
+    And the pilot opens the Performance page
+    And the pilot selects "D-EPER" for performance planning
+
+  # @E2E-C-001@ (FROM: @UJ-C-001@)
+  @UJ-C-001 @phase-C @e2e @E2E-C-001
+  Scenario: Hot conditions inside the 10% band are penalised and require acknowledgment
+    When the pilot enters conditions mass 800 kg, pressure altitude 5000 ft, temperature 54 °C
+    And the pilot sets the available runway to 2000 m
+    Then the result is flagged as extrapolated beyond the POH limits
+    And the advisory is withheld until the extrapolation is acknowledged
+
+    When the pilot acknowledges the extrapolated data as Pilot-in-Command
+    Then a runway-sufficiency advisory is shown
+
+  # @E2E-C-002@ (FROM: @UJ-C-001@)
+  @UJ-C-001 @phase-C @e2e @E2E-C-002
+  Scenario: Temperature beyond the extrapolation cap blocks the calculation
+    When the pilot enters conditions mass 800 kg, pressure altitude 5000 ft, temperature 57 °C
+    And the pilot sets the available runway to 2000 m
+    Then the calculation is blocked because conditions exceed the extrapolation boundary
+
+  # @E2E-C-003@ (FROM: @UJ-C-001@)
+  @UJ-C-001 @phase-C @e2e @E2E-C-003
+  Scenario: Pressure altitude beyond the extrapolation cap blocks the calculation
+    When the pilot enters conditions mass 800 kg, pressure altitude 11100 ft, temperature 25 °C
+    And the pilot sets the available runway to 2000 m
+    Then the calculation is blocked because conditions exceed the extrapolation boundary

--- a/frontend/tests/e2e/steps/performance-safety.steps.ts
+++ b/frontend/tests/e2e/steps/performance-safety.steps.ts
@@ -1,0 +1,217 @@
+/**
+ * Step definitions for the Performance & Safety (phase C) journey.
+ *
+ * A Verified aircraft carrying a regular POH performance grid is written
+ * directly into IndexedDB — the wizard cannot yet enter performance tables, and
+ * driving it per scenario would be slow. The grid maxima (temperature 50 °C,
+ * pressure altitude 10 000 ft) match the UJ-C-001 narrative so 54 °C lands
+ * inside the 10% extrapolation band and 57 °C / 11 100 ft fall beyond it.
+ * E2E trace tags live in the `.feature` file only (STC §B.3 / §3.4).
+ */
+
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+import { createBdd } from 'playwright-bdd'
+
+const { Given, When, Then } = createBdd()
+
+const FLEET_DB_NAME = 'aerodash-fleet'
+const FLEET_STORE_NAME = 'aircraft_profiles'
+
+interface PerfModel {
+  base: number
+  mass: number
+  alt: number
+  temp: number
+}
+
+const PERF_MODELS: Record<string, PerfModel> = {
+  TakeoffRoll: { base: 250, mass: 150, alt: 200, temp: 100 },
+  TakeoffDistance50ft: { base: 450, mass: 200, alt: 350, temp: 150 },
+  LandingRoll: { base: 200, mass: 80, alt: 120, temp: 60 },
+  LandingDistance50ft: { base: 380, mass: 120, alt: 220, temp: 100 },
+}
+
+const MASS_AXIS = [600, 1000]
+const ALT_AXIS = [0, 10_000]
+const TEMP_AXIS = [0, 50]
+
+function buildDataPoints(model: PerfModel): Array<{
+  mass: number
+  pressureAltitude: number
+  temperature: number
+  distance: number
+}> {
+  const points = []
+  for (const temperature of TEMP_AXIS) {
+    for (const pressureAltitude of ALT_AXIS) {
+      for (const mass of MASS_AXIS) {
+        const massFrac = (mass - MASS_AXIS[0]!) / (MASS_AXIS[1]! - MASS_AXIS[0]!)
+        const altFrac = pressureAltitude / ALT_AXIS[1]!
+        const tempFrac = temperature / TEMP_AXIS[1]!
+        points.push({
+          mass,
+          pressureAltitude,
+          temperature,
+          distance: model.base + model.mass * massFrac + model.alt * altFrac + model.temp * tempFrac,
+        })
+      }
+    }
+  }
+  return points
+}
+
+function buildVerifiedPerformanceProfile(registration: string): Record<string, unknown> {
+  return {
+    id: '00000000-0000-4000-a000-000000000311',
+    ownerId: '00000000-0000-4000-a000-0000000003ff',
+    registration,
+    manufacturer: 'Tecnam',
+    model: 'P2008 JC',
+    icaoTypeDesignator: 'P208',
+    sourceUnit: 'kg',
+    referenceDatumDescription: 'Leading edge of wing root',
+    referenceDatumLocation: 'Station 0 m',
+    shareCode: null,
+    status: 'verified',
+    schemaVersion: 1,
+    powertrain: 'combustion',
+    passengerProfiles: [],
+    weighingReports: [
+      { bem: 432, emptyCg: 1.882, weighingDate: '2025-01-01', validFrom: '2025-01-01' },
+    ],
+    loadPoints: [
+      {
+        name: 'Pilot & Passenger',
+        arm: 1.145,
+        armLookup: [],
+        operationalLimit: 110,
+        defaultQuantity: 0,
+        unit: 'kg',
+        allowableCategories: null,
+        fuelTank: null,
+      },
+    ],
+    certificationCategories: [
+      {
+        category: 'Normal',
+        mtom: 630,
+        maxZeroFuelMass: null,
+        graphType: 'arm',
+        envelope: [
+          { armOrMoment: 1.841, mass: 432 },
+          { armOrMoment: 1.841, mass: 630 },
+          { armOrMoment: 1.978, mass: 630 },
+          { armOrMoment: 1.978, mass: 432 },
+        ],
+      },
+    ],
+    performanceProfiles: Object.entries(PERF_MODELS).map(([flightPhase, model]) => ({
+      flightPhase,
+      dataPoints: buildDataPoints(model),
+    })),
+  }
+}
+
+const pendingSeeds = new WeakMap<Page, Record<string, unknown>[]>()
+
+function stageSeed(page: Page, profile: Record<string, unknown>): void {
+  const queue = pendingSeeds.get(page) ?? []
+  queue.push(profile)
+  pendingSeeds.set(page, queue)
+}
+
+async function flushSeeds(page: Page): Promise<void> {
+  const queue = pendingSeeds.get(page) ?? []
+  if (queue.length === 0) return
+  pendingSeeds.delete(page)
+  await page.evaluate(
+    ({ dbName, storeName, profiles }) =>
+      new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open(dbName)
+        req.onerror = () => reject(req.error ?? new Error('open failed'))
+        req.onsuccess = () => {
+          const db = req.result
+          if (!db.objectStoreNames.contains(storeName)) {
+            db.close()
+            reject(new Error(`Object store '${storeName}' not created yet`))
+            return
+          }
+          const tx = db.transaction(storeName, 'readwrite')
+          for (const p of profiles) tx.objectStore(storeName).put(p)
+          tx.oncomplete = () => {
+            db.close()
+            resolve()
+          }
+          tx.onerror = () => {
+            db.close()
+            reject(tx.error ?? new Error('tx failed'))
+          }
+        }
+      }),
+    { dbName: FLEET_DB_NAME, storeName: FLEET_STORE_NAME, profiles: queue },
+  )
+}
+
+Given(
+  'the pilot has a Verified aircraft {string} with published performance data',
+  async ({ page }, registration: string) => {
+    stageSeed(page, buildVerifiedPerformanceProfile(registration))
+  },
+)
+
+Given('the pilot opens the Performance page', async ({ page }) => {
+  await page.goto('/performance')
+  await expect(page.getByRole('heading', { level: 1, name: 'Performance' })).toBeVisible()
+  await flushSeeds(page)
+  await page.reload()
+  await expect(page.getByLabel('Select aircraft')).toBeVisible()
+})
+
+Given('the pilot selects {string} for performance planning', async ({ page }, registration: string) => {
+  const select = page.getByLabel('Select aircraft')
+  const option = select.locator('option', { hasText: registration })
+  const label = await option.textContent()
+  await select.selectOption({ label: label!.trim() })
+  await expect(page.getByText('Conditions', { exact: false })).toBeVisible()
+})
+
+When(
+  'the pilot enters conditions mass {int} kg, pressure altitude {int} ft, temperature {int} °C',
+  async ({ page }, mass: number, pa: number, temp: number) => {
+    await page.locator('#perf-mass').fill(String(mass))
+    await page.locator('#perf-pa').fill(String(pa))
+    await page.locator('#perf-temp').fill(String(temp))
+  },
+)
+
+When('the pilot sets the available runway to {int} m', async ({ page }, distance: number) => {
+  await page.locator('#perf-tora').fill(String(distance))
+  await page.locator('#perf-lda').fill(String(distance))
+})
+
+Then('the result is flagged as extrapolated beyond the POH limits', async ({ page }) => {
+  await expect(page.locator('.extrapolation-ack')).toBeVisible()
+  await expect(page.locator('.extrapolation-ack')).toContainText(/extrapolated/i)
+})
+
+Then('the advisory is withheld until the extrapolation is acknowledged', async ({ page }) => {
+  await expect(page.locator('.perf-advisory--pending')).toBeVisible()
+})
+
+When('the pilot acknowledges the extrapolated data as Pilot-in-Command', async ({ page }) => {
+  await page.locator('.extrapolation-ack__btn').click()
+})
+
+Then('a runway-sufficiency advisory is shown', async ({ page }) => {
+  await expect(page.locator('.extrapolation-ack')).toHaveCount(0)
+  await expect(page.locator('.perf-advisory--go, .perf-advisory--nogo')).toBeVisible()
+})
+
+Then(
+  'the calculation is blocked because conditions exceed the extrapolation boundary',
+  async ({ page }) => {
+    await expect(page.locator('.notification--error')).toBeVisible()
+    await expect(page.locator('.perf-results')).toHaveCount(0)
+  },
+)

--- a/trace/e2e/c.yaml
+++ b/trace/e2e/c.yaml
@@ -1,0 +1,21 @@
+C (auto)
+  E2E-C-001
+    title: Hot conditions inside the 10% band are penalised and require acknowledgment
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/extrapolation-acknowledgment.feature
+    uj:
+      - UJ-C-001
+
+  E2E-C-002
+    title: Temperature beyond the extrapolation cap blocks the calculation
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/extrapolation-acknowledgment.feature
+    uj:
+      - UJ-C-001
+
+  E2E-C-003
+    title: Pressure altitude beyond the extrapolation cap blocks the calculation
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/extrapolation-acknowledgment.feature
+    uj:
+      - UJ-C-001

--- a/trace/implementation/pf.yaml
+++ b/trace/implementation/pf.yaml
@@ -172,3 +172,93 @@ PF Core — Safety-Factor Pipeline
       - REQ-PF-015
       - REQ-PF-016
       - REQ-SYS-011
+
+PF (auto)
+  IMP-PF-VIEW-001
+    title: EstimatedMarker — visible [ESTIMATED] (CAA SSL 07) provenance badge
+    files:
+      - frontend/src/modules/performance/components/EstimatedMarker.vue
+    req:
+      - REQ-PF-017
+
+  IMP-PF-VIEW-002
+    title: ExtrapolationAcknowledgment — Pilot-in-Command acknowledgment prompt
+    files:
+      - frontend/src/modules/performance/components/ExtrapolationAcknowledgment.vue
+    req:
+      - REQ-PF-012
+
+  IMP-PF-VIEW-003
+    title: PerformanceResultsTable — TOR/TOD/LR/LD, operational required & safety margin
+    files:
+      - frontend/src/modules/performance/components/PerformanceResultsTable.vue
+    req:
+      - REQ-PF-001
+      - REQ-PF-007
+      - REQ-PF-017
+
+  IMP-PF-STORE-002
+    title: osfInput getter — OSF preset → P1 OperationalSafetyFactorInput
+    files:
+      - frontend/src/modules/performance/stores/performance.store.ts
+    req:
+      - REQ-PF-006
+      - REQ-PF-016
+
+  IMP-PF-STORE-003
+    title: loadProfile — load a Verified aircraft and recompute
+    files:
+      - frontend/src/modules/performance/stores/performance.store.ts
+    req:
+      - REQ-PF-001
+      - REQ-AC-005
+
+  IMP-PF-STORE-004
+    title: acknowledgeExtrapolation — lift the extrapolation finalization gate
+    files:
+      - frontend/src/modules/performance/stores/performance.store.ts
+    req:
+      - REQ-PF-012
+
+  IMP-PF-STORE-005
+    title: _runCalculation — orchestrate POH → extrapolation → safety-factor facades
+    files:
+      - frontend/src/modules/performance/stores/performance.store.ts
+    req:
+      - REQ-PF-004
+      - REQ-PF-006
+      - REQ-PF-007
+      - REQ-PF-010
+      - REQ-PF-011
+      - REQ-PF-012
+      - REQ-PF-015
+      - REQ-PF-016
+      - REQ-PF-017
+
+  IMP-PF-STORE-006
+    title: evaluateState — performance UI state-machine resolution
+    files:
+      - frontend/src/modules/performance/stores/performance.store.ts
+    des:
+      - DES-ARCH-003
+      - DES-ARCH-005
+
+  IMP-PF-STORE-001
+    title: Performance UI state-machine & result view-model types
+    files:
+      - frontend/src/modules/performance/stores/performance.types.ts
+    req:
+      - REQ-PF-007
+      - REQ-PF-017
+
+  IMP-PF-VIEW-004
+    title: PerformanceView — aircraft/conditions form, results, notifications, ack gate
+    files:
+      - frontend/src/modules/performance/views/PerformanceView.vue
+    req:
+      - REQ-PF-006
+      - REQ-PF-007
+      - REQ-PF-012
+      - REQ-PF-013
+      - REQ-PF-015
+      - REQ-PF-016

--- a/trace/implementation/ui.yaml
+++ b/trace/implementation/ui.yaml
@@ -156,6 +156,14 @@ UI (auto)
       - DES-ARCH-011
       - DES-ARCH-012
 
+  IMP-UI-ROUTE-006
+    title: Performance module route (/performance)
+    files:
+      - frontend/src/router/index.ts
+    req:
+      - REQ-PF-001
+      - REQ-PF-007
+
 UI — Contribution hub (#395)
   IMP-UI-SHARED-009
     title: Contribution environment helper — auto-detected environment string for the defect form

--- a/trace/integration_test/pf.yaml
+++ b/trace/integration_test/pf.yaml
@@ -24,3 +24,11 @@ PF Core — Conservative Extrapolation Control (Integration)
     impl:
       - IMP-PF-CORE-003
       - IMP-PF-CORE-011
+
+PF (auto)
+  IT-PF-STORE-001
+    title: performance store ↔ real P1 core — GO/No-Go, CRIT-PF-002, extrapolation ack, block
+    files:
+      - frontend/src/modules/performance/stores/__tests__/performance.store.int.spec.ts
+    impl:
+      - IMP-PF-STORE-005

--- a/trace/unit_test/pf.yaml
+++ b/trace/unit_test/pf.yaml
@@ -324,3 +324,53 @@ PF Core — Safety-Factor Pipeline (Unit)
     impl:
       - IMP-PF-CORE-019
       - IMP-PF-CORE-020
+
+PF (auto)
+  UT-PF-VIEW-001
+    title: EstimatedMarker renders the [ESTIMATED] (CAA SSL 07) text marker
+    files:
+      - frontend/src/modules/performance/components/__tests__/EstimatedMarker.spec.ts
+    impl:
+      - IMP-PF-VIEW-001
+
+  UT-PF-VIEW-002
+    title: ExtrapolationAcknowledgment emits acknowledge on Pilot-in-Command confirm
+    files:
+      - frontend/src/modules/performance/components/__tests__/ExtrapolationAcknowledgment.spec.ts
+    impl:
+      - IMP-PF-VIEW-002
+
+  UT-PF-VIEW-003
+    title: PerformanceResultsTable — distances, absolute+% margin, estimated marker, insufficient flag
+    files:
+      - frontend/src/modules/performance/components/__tests__/PerformanceResultsTable.spec.ts
+    impl:
+      - IMP-PF-VIEW-003
+
+  UT-PF-STORE-001
+    title: osfInput getter — OSF preset / POH-mandated factor resolution
+    files:
+      - frontend/src/modules/performance/stores/__tests__/performance.store.spec.ts
+    impl:
+      - IMP-PF-STORE-002
+
+  UT-PF-STORE-002
+    title: store orchestration — POH/extrapolation/safety-factor → view-model & notifications
+    files:
+      - frontend/src/modules/performance/stores/__tests__/performance.store.spec.ts
+    impl:
+      - IMP-PF-STORE-005
+
+  UT-PF-STORE-003
+    title: performance UI state-machine transitions (GO / NO_GO / WARNING / PENDING_ACK / BLOCKED)
+    files:
+      - frontend/src/modules/performance/stores/__tests__/performance.store.spec.ts
+    impl:
+      - IMP-PF-STORE-006
+
+  UT-PF-VIEW-004
+    title: PerformanceView — selection, compute, GO/NO-GO advisory, ack-gate rendering
+    files:
+      - frontend/src/modules/performance/views/__tests__/PerformanceView.spec.ts
+    impl:
+      - IMP-PF-VIEW-004


### PR DESCRIPTION
### Summary

Performance module UI (P2) for the v0.4.0 Performance Math Core — consumes the already-built P1 facades and performs no safety math itself.

- New `frontend/src/modules/performance/` module: Pinia store + view + components.
- Store orchestrates the three P1 facades — POH distances → conservative extrapolation control → safety-factor pipeline — and projects typed results to a view-model + the centralised notification contract.
- Renders TOR / TOD / LR / LD, operational required distances, and the safety margin as absolute distance **and** percentage (REQ-PF-007).
- Surfaces `CRIT-PF-002` (runway insufficient → NO-GO) and `WARN-PF-002` (low OSF) via the notification list (REQ-PF-015 / REQ-PF-016).
- Extrapolation acknowledgment gate: an extrapolated result is penalised (+20%) and **not finalized** until the Pilot-in-Command acknowledges it (REQ-PF-010 / REQ-PF-012); beyond the 10% cap the computation is blocked (`ERR-PF-001`).
- `[ESTIMATED] (CAA SSL 07)` marker component + conditional rendering wired into the results table (REQ-PF-017, UI side).
- `/performance` route + sidebar nav entry.
- New notification IDs documented in `notification_schema.md`: `WARN-PF-003`, `ERR-PF-001`, `ERR-PF-002`.

**Scope guard:** zero changes under `frontend/src/core/` — P1 isolation fully maintained.

### Related Issues

- Closes #311
- Closes #300

<!-- #311 is the last open child of feature #300 (sibling #309 already closed/fixed), so this PR closes the parent too. -->

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issues auto-closed by `Closes #` keyword; verify Issue Labels are `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-PF-007` (now **Implemented** — margin display completes the core+UI chain). Affected/surfaced: `REQ-PF-001`, `REQ-PF-004`, `REQ-PF-006`, `REQ-PF-010`, `REQ-PF-011`, `REQ-PF-012`, `REQ-PF-015`, `REQ-PF-016`, `REQ-PF-017`, `REQ-AC-005`.

### Documentation Updates

- [x] **Requirements:** Updated `REQ-PF-007` status → `Implemented` in `docs/requirements/performance.md`.
- [x] **Architecture:** Added `WARN-PF-003` / `ERR-PF-001` / `ERR-PF-002` to `docs/architecture/notification_schema.md` (register + detail blocks).
- [x] **Risk Management:** `N/A` (Reason: no hazard-register change; H-007/H-008/H-012/H-013/H-016 mitigations now surfaced in the UI, none modified).
- [x] **Journeys:** `N/A` for the journey docs themselves; E2E coverage added for `UJ-C-001` (3 scenarios) + trace registry `trace/e2e/c.yaml`.
- [x] **Code Docs:** Changelog `N/A` (Reason: reserved for the release process per CONTRIBUTING §6).

### Safety Considerations

- [x] Checked Safety Traceability Matrix (`pnpm trace sync --apply`; structural gate passes — no new violations).
- [x] No new hazards introduced.
- [x] Existing mitigations preserved (H-007/H-008/H-012/H-013/H-016 surfaced via UI; extrapolation/runway/OSF logic remains in P1).
- [x] P1 isolation maintained — **no new code in `frontend/src/core/`**; the module imports P1 facades only.

### Quality & Testing Checklist

- [x] **Target Branch:** Targets `develop`.
- [x] **Unit Tests:** Added/updated and passing (`pnpm test:unit` → 1735 passed). Performance module: store (`performance.store.spec.ts`), components (EstimatedMarker / ExtrapolationAcknowledgment / PerformanceResultsTable), view (`PerformanceView.spec.ts`).
- [x] **Integration Tests:** Passing (`pnpm test:integration` → 91 passed). `performance.store.int.spec.ts` exercises the store ↔ real P1 core handshake.
- [x] **Manual Testing:** `N/A` for `develop` (Reason: automated E2E `UJ-C-001` (3 chromium scenarios passing) + view tests cover the UI; manual is mandatory only for `main`).
- [x] **DoD:** All Definition of Done items from #311 and #300 are met — see attestation below.
- [x] **Review:** Self-reviewed code + docs.
- [x] **ADR:** `N/A` — no P1 interface change; the module composes existing P1 facades and mirrors the established mass-balance module pattern.

---

### DoD Attestation

**#300 — Safety-factor application, insufficient-runway rejection & margin display (parent feature)** — fully met:

- [x] Friction/slope applied to ground roll; DA/wind applied to full distance; OSF presets applied — P1 (`#309`) + UI wiring; verified by `performance.store.spec.ts` (correction-isolation case).
- [x] CRIT-PF-002 raised and Go/No-Go blocked when required > available runway — surfaced in store + view; verified unit + integration + view tests.
- [x] WARN-PF-002 raised when OSF below threshold — surfaced; verified.
- [x] Safety margin displayed as absolute distance and percentage — `PerformanceResultsTable`; verified.

**#311 — Performance module UI** — met, with one residue split:

- [x] Implementation is complete — full P2 UI built (store, view, components, route, nav).
- [x] Component/integration tests written and passing — see Quality checklist.
- [x] E2E feature files + step defs for UJ-C-001 and UJ-C-003 — **UJ-C-001 delivered and passing** (3 scenarios: penalise+acknowledge, temperature breach, altitude breach). The `[ESTIMATED]` marker UI for REQ-PF-017 is delivered and unit-tested. **UJ-C-003 (CAA SSL 07 flagging) residue is split to #301**: a real end-to-end estimated-value E2E requires the REQ-PF-005 P1 estimation engine, which is owned by #301 and is out of scope for this P2-only UI task (the issue itself states the UI "performs no safety math itself"). See *What remains*.
- [x] Linter/Formatter checks pass — `pnpm lint` clean (oxlint + eslint + structural trace gate + markdownlint).
- [x] I have checked for side effects on other modules — only additive: new module + 1 route + 1 nav item + 1 nav icon; no changes to existing modules or `src/core/`.

### What remains (split to #301)

The **CAA SSL 07 estimation engine** (REQ-PF-005, P1) does not yet exist; it is owned by the open feature **#301**. Without it the store reads only authoritative POH values, so the `[ESTIMATED]` marker (built and unit-tested here) currently never lights, and **UJ-C-003**'s end-to-end flag-through-the-real-engine E2E cannot be authored in a P2-only PR. When #301 lands the P1 estimation, it populates the per-distance `estimated` flag this module already consumes and adds the UJ-C-003 E2E. No code change to this module is expected beyond setting that flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
