### PR TITLE
feat: [Task]: Manual airport-entry module — surface-condition gate + editable overrides (#312)

### DIFF
--- a/docs/journeys/03_performance_safety.md
+++ b/docs/journeys/03_performance_safety.md
@@ -25,7 +25,7 @@ Focus: Behaviour at the limits of the performance envelope — extrapolation, ov
 
 **Outcome:** The pilot avoids taking an uncalculated risk in extreme conditions. Within the 10% extrapolation band, the system provides a highly conservative estimate with a penalty and requires acknowledgment. Beyond that, it refuses to calculate entirely.
 
-<!-- @UJ-C-002@ (FROM: @REQ-AP-003@, @REQ-AP-006@, @REQ-PF-008@, @REQ-PF-009@) -->
+<!-- @UJ-C-002@ (FROM: @REQ-AP-003@, @REQ-AP-004@, @REQ-AP-006@, @REQ-PF-008@, @REQ-PF-009@) -->
 
 ## <a name="UJ-C-002"></a>UJ-C-002: The "Unknown Airfield" (Manual Override)
 

--- a/docs/requirements/airport_database.md
+++ b/docs/requirements/airport_database.md
@@ -30,7 +30,7 @@ This document defines the airport database behavior using the **EARS** (Easy App
 **Requirement:** If an ICAO code is not found in the database, then the system shall set the Airport Mode to `ManualEntry`.
 **Rationale:** PIC authority to operate from unlisted or private strips.
 **Priority:** P1
-**Status:** Approved
+**Status:** Implemented
 **Design Reference:** n/a
 
 <!-- @REQ-AP-004@ (FROM: @H-009@) -->
@@ -39,7 +39,7 @@ This document defines the airport database behavior using the **EARS** (Easy App
 **Requirement:** When a runway is selected, the system shall require the user to select the current surface condition from a predefined list specific to the base surface type: <ol><li>Paved (e.g. Asphalt/Concrete): Dry, Wet, Standing Water, Slush, Snow, Ice</li> <li>Grass/Unpaved: Dry (Short grass ≤ 3cm), Long Grass (> 3cm to 8cm), Wet/Soft Ground, Damaged Turf, Snow/Ice</li></ol>
 **Rationale:** Conditions impact friction heavily. Grass runways require highly specific length/quality factors per standard POHs. Context-aware lists prevent impossible combinations (e.g. "Long Grass" on Asphalt).
 **Priority:** P1
-**Status:** Approved
+**Status:** Implemented
 **Design Reference:** n/a
 
 <!-- @REQ-AP-005@ (FROM: @H-015@) -->
@@ -57,7 +57,7 @@ This document defines the airport database behavior using the **EARS** (Easy App
 **Requirement:** The system shall provide editable input fields for all auto-populated airport and runway parameters to enable manual pilot overrides.
 **Rationale:** Accommodates temporary changes like displaced thresholds published via NOTAM.
 **Priority:** P1
-**Status:** Approved
+**Status:** Implemented
 **Design Reference:** n/a
 
 ---

--- a/frontend/src/modules/airport/components/SurfaceConditionSelect.vue
+++ b/frontend/src/modules/airport/components/SurfaceConditionSelect.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="surface-condition-select">
+    <label :for="selectId">Surface condition</label>
+    <select
+      :id="selectId"
+      :value="modelValue ?? ''"
+      :aria-invalid="modelValue === null"
+      @change="onChange(($event.target as HTMLSelectElement).value)"
+    >
+      <option value="" disabled>— Select surface condition —</option>
+      <option v-for="option in options" :key="option.id" :value="option.id">
+        {{ option.label }}
+      </option>
+    </select>
+    <p v-if="modelValue === null" class="surface-condition-hint" role="alert">
+      Required before performance can be computed.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+// @IMP-AP-VIEW-001@ (FROM: @REQ-AP-004@)
+import { computed } from 'vue'
+import type { BaseSurfaceType } from '../domain/airport.types'
+import { surfaceConditionsFor } from '../domain/surface-conditions'
+
+const props = defineProps<{
+  base: BaseSurfaceType
+  modelValue: string | null
+  selectId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | null): void
+}>()
+
+const options = computed(() => surfaceConditionsFor(props.base))
+
+function onChange(value: string): void {
+  emit('update:modelValue', value === '' ? null : value)
+}
+</script>
+
+<style scoped>
+.surface-condition-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.surface-condition-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #b91c1c;
+}
+</style>

--- a/frontend/src/modules/airport/components/__tests__/SurfaceConditionSelect.spec.ts
+++ b/frontend/src/modules/airport/components/__tests__/SurfaceConditionSelect.spec.ts
@@ -1,0 +1,48 @@
+// @UT-AP-VIEW-001@ (FROM: @IMP-AP-VIEW-001@)
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SurfaceConditionSelect from '../SurfaceConditionSelect.vue'
+
+describe('SurfaceConditionSelect', () => {
+  it('renders the paved condition list for a paved runway (REQ-AP-004)', () => {
+    const wrapper = mount(SurfaceConditionSelect, {
+      props: { base: 'paved', modelValue: null, selectId: 'sc' },
+    })
+    const labels = wrapper.findAll('option').map((o) => o.text())
+    expect(labels).toContain('Dry')
+    expect(labels).toContain('Standing Water')
+    expect(labels.some((l) => l.includes('Long Grass'))).toBe(false)
+  })
+
+  it('renders the grass condition list for a grass runway', () => {
+    const wrapper = mount(SurfaceConditionSelect, {
+      props: { base: 'grass', modelValue: null, selectId: 'sc' },
+    })
+    const labels = wrapper.findAll('option').map((o) => o.text())
+    expect(labels.some((l) => l.includes('Long Grass'))).toBe(true)
+  })
+
+  it('shows a required hint until a condition is selected', () => {
+    const wrapper = mount(SurfaceConditionSelect, {
+      props: { base: 'paved', modelValue: null, selectId: 'sc' },
+    })
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true)
+  })
+
+  it('emits the selected id on change and hides the hint', async () => {
+    const wrapper = mount(SurfaceConditionSelect, {
+      props: { base: 'paved', modelValue: 'paved-dry', selectId: 'sc' },
+    })
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+    await wrapper.find('select').setValue('paved-wet')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['paved-wet'])
+  })
+
+  it('emits null when the placeholder option is re-selected', async () => {
+    const wrapper = mount(SurfaceConditionSelect, {
+      props: { base: 'paved', modelValue: 'paved-dry', selectId: 'sc' },
+    })
+    await wrapper.find('select').setValue('')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([null])
+  })
+})

--- a/frontend/src/modules/airport/domain/__tests__/compute-gate.spec.ts
+++ b/frontend/src/modules/airport/domain/__tests__/compute-gate.spec.ts
@@ -1,0 +1,65 @@
+// @UT-AP-STORE-002@ (FROM: @IMP-AP-STORE-002@)
+import { describe, it, expect } from 'vitest'
+import type { ManualAirportEntry, ManualRunwayOverrides } from '../airport.types'
+import { evaluateComputeGate } from '../compute-gate'
+
+function buildEntry(runway: Partial<ManualRunwayOverrides> = {}): ManualAirportEntry {
+  return {
+    id: 'test-id',
+    icao: 'ZZZZ',
+    name: '',
+    elevationFt: null,
+    schemaVersion: 1,
+    runway: {
+      designator: '09',
+      magneticHeadingDeg: 90,
+      baseSurfaceType: 'grass',
+      slopePercent: null,
+      toraM: 600,
+      todaM: null,
+      asdaM: null,
+      ldaM: null,
+      surfaceConditionId: 'grass-dry',
+      ...runway,
+    },
+  }
+}
+
+describe('evaluateComputeGate', () => {
+  it('allows computation when a valid surface condition and a runway length are present', () => {
+    const result = evaluateComputeGate(buildEntry())
+    expect(result.allowed).toBe(true)
+    expect(result.blockers).toEqual([])
+    expect(result.message).toBe('')
+  })
+
+  it('blocks when no surface condition is selected (REQ-AP-004 mandatory gate)', () => {
+    const result = evaluateComputeGate(buildEntry({ surfaceConditionId: null }))
+    expect(result.allowed).toBe(false)
+    expect(result.blockers).toContain('SURFACE_CONDITION_REQUIRED')
+    expect(result.message).toMatch(/surface condition/i)
+  })
+
+  it('blocks when the surface condition does not match the base surface type', () => {
+    const result = evaluateComputeGate(
+      buildEntry({ baseSurfaceType: 'paved', surfaceConditionId: 'grass-long' }),
+    )
+    expect(result.allowed).toBe(false)
+    expect(result.blockers).toContain('SURFACE_CONDITION_INVALID')
+  })
+
+  it('blocks when the runway length (TORA) is missing or non-positive', () => {
+    expect(evaluateComputeGate(buildEntry({ toraM: null })).blockers).toContain(
+      'RUNWAY_LENGTH_REQUIRED',
+    )
+    expect(evaluateComputeGate(buildEntry({ toraM: 0 })).blockers).toContain(
+      'RUNWAY_LENGTH_REQUIRED',
+    )
+  })
+
+  it('aggregates every outstanding precondition at once', () => {
+    const result = evaluateComputeGate(buildEntry({ surfaceConditionId: null, toraM: null }))
+    expect(result.blockers).toEqual(['SURFACE_CONDITION_REQUIRED', 'RUNWAY_LENGTH_REQUIRED'])
+    expect(result.message.split(' ').length).toBeGreaterThan(3)
+  })
+})

--- a/frontend/src/modules/airport/domain/__tests__/surface-conditions.spec.ts
+++ b/frontend/src/modules/airport/domain/__tests__/surface-conditions.spec.ts
@@ -1,0 +1,66 @@
+// @UT-AP-STORE-001@ (FROM: @IMP-AP-STORE-001@)
+import { describe, it, expect } from 'vitest'
+import {
+  surfaceConditionsFor,
+  isValidSurfaceCondition,
+  surfaceConditionLabel,
+} from '../surface-conditions'
+
+describe('surfaceConditionsFor', () => {
+  it('returns the six paved conditions required by REQ-AP-004', () => {
+    const ids = surfaceConditionsFor('paved').map((o) => o.id)
+    expect(ids).toEqual([
+      'paved-dry',
+      'paved-wet',
+      'paved-standing-water',
+      'paved-slush',
+      'paved-snow',
+      'paved-ice',
+    ])
+  })
+
+  it('returns the five grass/unpaved conditions required by REQ-AP-004', () => {
+    const ids = surfaceConditionsFor('grass').map((o) => o.id)
+    expect(ids).toEqual([
+      'grass-dry',
+      'grass-long',
+      'grass-wet-soft',
+      'grass-damaged-turf',
+      'grass-snow-ice',
+    ])
+  })
+
+  it('labels the long-grass option with its length band', () => {
+    const long = surfaceConditionsFor('grass').find((o) => o.id === 'grass-long')
+    expect(long?.label).toContain('Long Grass')
+  })
+})
+
+describe('isValidSurfaceCondition', () => {
+  it('accepts a condition that belongs to the base surface type', () => {
+    expect(isValidSurfaceCondition('paved', 'paved-wet')).toBe(true)
+    expect(isValidSurfaceCondition('grass', 'grass-long')).toBe(true)
+  })
+
+  it('rejects a condition from the other surface type (no "Long Grass" on asphalt)', () => {
+    expect(isValidSurfaceCondition('paved', 'grass-long')).toBe(false)
+    expect(isValidSurfaceCondition('grass', 'paved-ice')).toBe(false)
+  })
+
+  it('rejects null and unknown ids', () => {
+    expect(isValidSurfaceCondition('paved', null)).toBe(false)
+    expect(isValidSurfaceCondition('paved', 'not-a-real-id')).toBe(false)
+  })
+})
+
+describe('surfaceConditionLabel', () => {
+  it('returns the pilot-facing label for a valid selection', () => {
+    expect(surfaceConditionLabel('paved', 'paved-dry')).toBe('Dry')
+  })
+
+  it('returns null for null, unknown, or cross-surface ids', () => {
+    expect(surfaceConditionLabel('paved', null)).toBeNull()
+    expect(surfaceConditionLabel('paved', 'grass-long')).toBeNull()
+    expect(surfaceConditionLabel('grass', 'unknown')).toBeNull()
+  })
+})

--- a/frontend/src/modules/airport/domain/airport.types.ts
+++ b/frontend/src/modules/airport/domain/airport.types.ts
@@ -1,0 +1,49 @@
+/**
+ * Manual airport-entry domain types.
+ * P2 Feature Module — plain TypeScript, no framework or P1 imports.
+ *
+ * @see docs/requirements/airport_database.md REQ-AP-003, REQ-AP-004, REQ-AP-006
+ */
+
+/** Whether the airport is resolved from a database or entered by hand (REQ-AP-003). */
+export type AirportMode = 'idle' | 'manual-entry'
+
+/** Base runway surface family — drives the context-aware condition list (REQ-AP-004). */
+export type BaseSurfaceType = 'paved' | 'grass'
+
+/** A selectable surface-condition option, specific to a {@link BaseSurfaceType}. */
+export interface SurfaceConditionOption {
+  /** Stable machine id, unique within a base surface type. */
+  readonly id: string
+  /** Pilot-facing label. */
+  readonly label: string
+}
+
+/**
+ * Editable runway parameters a pilot can override (REQ-AP-006).
+ * Distances in metres, heading in °M, slope in percent. A field is `null`
+ * until the pilot supplies it, so the compute gate can distinguish
+ * "not entered" from a real zero.
+ */
+export interface ManualRunwayOverrides {
+  designator: string
+  magneticHeadingDeg: number | null
+  baseSurfaceType: BaseSurfaceType
+  slopePercent: number | null
+  toraM: number | null
+  todaM: number | null
+  asdaM: number | null
+  ldaM: number | null
+  /** Selected surface-condition id; `null` until the mandatory selection is made (REQ-AP-004). */
+  surfaceConditionId: string | null
+}
+
+/** A persisted manual airport entry (REQ-AP-003, REQ-AP-006). */
+export interface ManualAirportEntry {
+  id: string
+  icao: string
+  name: string
+  elevationFt: number | null
+  runway: ManualRunwayOverrides
+  schemaVersion: number
+}

--- a/frontend/src/modules/airport/domain/compute-gate.ts
+++ b/frontend/src/modules/airport/domain/compute-gate.ts
@@ -1,0 +1,62 @@
+/**
+ * Pre-compute gate for a manually entered runway (REQ-AP-004, H-009).
+ * P2 Feature Module — pure function, no framework or P1 imports.
+ *
+ * Performance computation must not proceed until the pilot has selected a
+ * surface condition: an omitted condition selects the wrong friction factor
+ * and yields an incorrect required distance (H-009). The gate is fail-safe —
+ * it blocks rather than guessing a default.
+ */
+
+import type { ManualAirportEntry } from './airport.types'
+import { isValidSurfaceCondition } from './surface-conditions'
+
+/** Why a manual-runway computation is blocked. */
+export type ComputeBlockReason =
+  | 'SURFACE_CONDITION_REQUIRED'
+  | 'SURFACE_CONDITION_INVALID'
+  | 'RUNWAY_LENGTH_REQUIRED'
+
+export interface ComputeGateResult {
+  /** True only when every precondition is satisfied. */
+  allowed: boolean
+  /** All unmet preconditions; empty when allowed. */
+  blockers: readonly ComputeBlockReason[]
+  /** Pilot-facing inline rejection message; empty string when allowed. */
+  message: string
+}
+
+const MESSAGES: Readonly<Record<ComputeBlockReason, string>> = {
+  SURFACE_CONDITION_REQUIRED:
+    'Select the current runway surface condition before computing performance.',
+  SURFACE_CONDITION_INVALID:
+    'The selected surface condition is not valid for this runway surface type.',
+  RUNWAY_LENGTH_REQUIRED: 'Enter the available runway length (TORA) before computing performance.',
+}
+
+/**
+ * Evaluate whether a manual airport entry may proceed to performance
+ * computation. Returns the full blocker set so the UI can surface every
+ * outstanding precondition at once.
+ */
+// @IMP-AP-STORE-002@ (FROM: @REQ-AP-004@)
+export function evaluateComputeGate(entry: ManualAirportEntry): ComputeGateResult {
+  const blockers: ComputeBlockReason[] = []
+  const { runway } = entry
+
+  if (runway.surfaceConditionId === null) {
+    blockers.push('SURFACE_CONDITION_REQUIRED')
+  } else if (!isValidSurfaceCondition(runway.baseSurfaceType, runway.surfaceConditionId)) {
+    blockers.push('SURFACE_CONDITION_INVALID')
+  }
+
+  if (runway.toraM === null || runway.toraM <= 0) {
+    blockers.push('RUNWAY_LENGTH_REQUIRED')
+  }
+
+  return {
+    allowed: blockers.length === 0,
+    blockers,
+    message: blockers.map((reason) => MESSAGES[reason]).join(' '),
+  }
+}

--- a/frontend/src/modules/airport/domain/surface-conditions.ts
+++ b/frontend/src/modules/airport/domain/surface-conditions.ts
@@ -1,0 +1,51 @@
+/**
+ * Predefined surface-condition catalogue, keyed by base surface type (REQ-AP-004).
+ * P2 Feature Module — pure functions, no framework or P1 imports.
+ *
+ * Context-aware lists prevent impossible combinations (e.g. "Long Grass" on
+ * asphalt): a defect that offered the wrong friction class would feed an
+ * incorrect distance downstream (H-009), so the lists are fixed here, not
+ * free-text.
+ */
+
+import type { BaseSurfaceType, SurfaceConditionOption } from './airport.types'
+
+const PAVED_CONDITIONS: readonly SurfaceConditionOption[] = [
+  { id: 'paved-dry', label: 'Dry' },
+  { id: 'paved-wet', label: 'Wet' },
+  { id: 'paved-standing-water', label: 'Standing Water' },
+  { id: 'paved-slush', label: 'Slush' },
+  { id: 'paved-snow', label: 'Snow' },
+  { id: 'paved-ice', label: 'Ice' },
+]
+
+const GRASS_CONDITIONS: readonly SurfaceConditionOption[] = [
+  { id: 'grass-dry', label: 'Dry (short grass ≤ 3 cm)' },
+  { id: 'grass-long', label: 'Long Grass (> 3 cm to 8 cm)' },
+  { id: 'grass-wet-soft', label: 'Wet / Soft Ground' },
+  { id: 'grass-damaged-turf', label: 'Damaged Turf' },
+  { id: 'grass-snow-ice', label: 'Snow / Ice' },
+]
+
+const CATALOGUE: Readonly<Record<BaseSurfaceType, readonly SurfaceConditionOption[]>> = {
+  paved: PAVED_CONDITIONS,
+  grass: GRASS_CONDITIONS,
+}
+
+/** The surface-condition options valid for a given base surface type (REQ-AP-004). */
+// @IMP-AP-STORE-001@ (FROM: @REQ-AP-004@)
+export function surfaceConditionsFor(base: BaseSurfaceType): readonly SurfaceConditionOption[] {
+  return CATALOGUE[base]
+}
+
+/** True when `id` is a known condition for `base` — rejects cross-surface mismatches. */
+export function isValidSurfaceCondition(base: BaseSurfaceType, id: string | null): boolean {
+  if (id === null) return false
+  return CATALOGUE[base].some((option) => option.id === id)
+}
+
+/** Pilot-facing label for a selected condition, or `null` when it is not valid for `base`. */
+export function surfaceConditionLabel(base: BaseSurfaceType, id: string | null): string | null {
+  if (id === null) return null
+  return CATALOGUE[base].find((option) => option.id === id)?.label ?? null
+}

--- a/frontend/src/modules/airport/services/__tests__/airport.repository.int.spec.ts
+++ b/frontend/src/modules/airport/services/__tests__/airport.repository.int.spec.ts
@@ -1,0 +1,93 @@
+// @IT-AP-STORE-001@ (FROM: @IMP-AP-STORE-003@)
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import {
+  _resetAirportDbHandleForTest,
+  create,
+  update,
+  findById,
+  findAll,
+  deleteById,
+  deleteAll,
+  MANUAL_AIRPORT_SCHEMA_VERSION,
+} from '../airport.repository'
+import type { ManualAirportEntry } from '../../domain/airport.types'
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+  _resetAirportDbHandleForTest()
+})
+
+function buildEntry(overrides: Partial<ManualAirportEntry> = {}): ManualAirportEntry {
+  return {
+    id: '00000000-0000-4000-a000-000000000001',
+    icao: 'ZZZZ',
+    name: 'Family Strip',
+    elevationFt: 350,
+    schemaVersion: MANUAL_AIRPORT_SCHEMA_VERSION,
+    runway: {
+      designator: '27',
+      magneticHeadingDeg: 270,
+      baseSurfaceType: 'grass',
+      slopePercent: 1.5,
+      toraM: 600,
+      todaM: 600,
+      asdaM: 600,
+      ldaM: 600,
+      surfaceConditionId: 'grass-dry',
+    },
+    ...overrides,
+  }
+}
+
+describe('airport.repository', () => {
+  it('persists a manual airport entry and reads it back unchanged', async () => {
+    const entry = buildEntry()
+    await create(entry)
+    expect(await findById(entry.id)).toEqual(entry)
+  })
+
+  it('persists override edits across a write/read cycle (REQ-AP-006)', async () => {
+    const entry = buildEntry()
+    await create(entry)
+    const edited = { ...entry, runway: { ...entry.runway, toraM: 720, surfaceConditionId: 'grass-long' } }
+    await update(edited)
+    const reread = await findById(entry.id)
+    expect(reread?.runway.toraM).toBe(720)
+    expect(reread?.runway.surfaceConditionId).toBe('grass-long')
+  })
+
+  it('lists all stored entries', async () => {
+    await create(buildEntry({ id: 'a' }))
+    await create(buildEntry({ id: 'b' }))
+    const all = await findAll()
+    expect(all.map((e) => e.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('deletes a single entry by id', async () => {
+    await create(buildEntry({ id: 'a' }))
+    await deleteById('a')
+    expect(await findById('a')).toBeUndefined()
+  })
+
+  it('clears every entry', async () => {
+    await create(buildEntry({ id: 'a' }))
+    await create(buildEntry({ id: 'b' }))
+    await deleteAll()
+    expect(await findAll()).toEqual([])
+  })
+
+  it('rejects a structurally invalid write rather than corrupting storage', async () => {
+    const bad = { ...buildEntry(), runway: { ...buildEntry().runway, baseSurfaceType: 'gravel' } }
+    await expect(create(bad as unknown as ManualAirportEntry)).rejects.toThrow(/structural/i)
+  })
+
+  it('returns undefined for an absent key', async () => {
+    expect(await findById('missing')).toBeUndefined()
+  })
+})

--- a/frontend/src/modules/airport/services/airport.repository.ts
+++ b/frontend/src/modules/airport/services/airport.repository.ts
@@ -1,0 +1,215 @@
+/**
+ * Airport Repository — native IndexedDB persistence for manual airport entries.
+ * P2 Feature Module — may use browser APIs, no Vue/Pinia or P1 imports.
+ *
+ * Database: aerodash-airports, version 1
+ * Object store: manual_airports, keyPath: id
+ *
+ * Documents are structurally validated on the way in (write) and on the way
+ * out (read). A stored row that fails validation — a corrupt or
+ * future-schema record after a PWA-cache rollback — is dropped from the
+ * in-memory result rather than failing the whole load, mirroring the fleet
+ * repository's partial-recovery contract.
+ *
+ * @see frontend/src/modules/aircraft/services/fleet.repository.ts
+ */
+
+import type {
+  BaseSurfaceType,
+  ManualAirportEntry,
+  ManualRunwayOverrides,
+} from '../domain/airport.types'
+
+/** Canonical IndexedDB database name — the single source of truth for manual airports. */
+export const DB_NAME = 'aerodash-airports'
+const DB_VERSION = 1
+const STORE_NAME = 'manual_airports'
+
+/** Current persisted manual-airport schema revision. */
+export const MANUAL_AIRPORT_SCHEMA_VERSION = 1
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+// Zod is reserved for the P1 Safety Core (CLAUDE.md), so the persistence
+// boundary is guarded with plain structural predicates instead.
+
+function isNullableFinite(value: unknown): value is number | null {
+  return value === null || (typeof value === 'number' && Number.isFinite(value))
+}
+
+function isBaseSurfaceType(value: unknown): value is BaseSurfaceType {
+  return value === 'paved' || value === 'grass'
+}
+
+function isRunwayOverrides(value: unknown): value is ManualRunwayOverrides {
+  if (value === null || typeof value !== 'object') return false
+  const r = value as Record<string, unknown>
+  return (
+    typeof r.designator === 'string' &&
+    isNullableFinite(r.magneticHeadingDeg) &&
+    isBaseSurfaceType(r.baseSurfaceType) &&
+    isNullableFinite(r.slopePercent) &&
+    isNullableFinite(r.toraM) &&
+    isNullableFinite(r.todaM) &&
+    isNullableFinite(r.asdaM) &&
+    isNullableFinite(r.ldaM) &&
+    (r.surfaceConditionId === null || typeof r.surfaceConditionId === 'string')
+  )
+}
+
+/** Structural guard for a stored manual airport entry. */
+export function isManualAirportEntry(value: unknown): value is ManualAirportEntry {
+  if (value === null || typeof value !== 'object') return false
+  const e = value as Record<string, unknown>
+  return (
+    typeof e.id === 'string' &&
+    e.id.length > 0 &&
+    typeof e.icao === 'string' &&
+    typeof e.name === 'string' &&
+    isNullableFinite(e.elevationFt) &&
+    typeof e.schemaVersion === 'number' &&
+    isRunwayOverrides(e.runway)
+  )
+}
+
+function assertManualAirportEntry(value: unknown): ManualAirportEntry {
+  if (!isManualAirportEntry(value)) {
+    throw new Error('Invalid manual airport entry: failed structural validation.')
+  }
+  return value
+}
+
+// ─── Singleton handle ──────────────────────────────────────────────────────────
+// Mirror the fleet repository: cache one open handle so a burst of concurrent
+// calls share a single connection, and release it on `onversionchange`
+// (a sibling tab upgrade must not be blocked) or `onclose` (browser eviction).
+
+let dbHandlePromise: Promise<IDBDatabase> | null = null
+
+function openDBOnce(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' })
+      }
+    }
+
+    request.onsuccess = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      db.onversionchange = (): void => {
+        db.close()
+        dbHandlePromise = null
+      }
+      db.onclose = (): void => {
+        dbHandlePromise = null
+      }
+      resolve(db)
+    }
+
+    request.onerror = (event) => {
+      reject(
+        new Error(
+          `Failed to open IndexedDB: ${(event.target as IDBOpenDBRequest).error?.message ?? 'unknown'}`,
+        ),
+      )
+    }
+  })
+}
+
+function openDB(): Promise<IDBDatabase> {
+  if (dbHandlePromise === null) {
+    dbHandlePromise = openDBOnce().catch((err: unknown) => {
+      dbHandlePromise = null
+      throw err
+    })
+  }
+  return dbHandlePromise
+}
+
+/** Test/teardown hook: drop the cached handle so the next `openDB()` reopens. */
+export function _resetAirportDbHandleForTest(): void {
+  dbHandlePromise = null
+}
+
+function withStore<T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openDB().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, mode)
+        const store = tx.objectStore(STORE_NAME)
+        const request = fn(store)
+        request.onsuccess = (event) => {
+          resolve((event.target as IDBRequest<T>).result)
+        }
+        request.onerror = (event) => {
+          reject(
+            new Error(
+              `IndexedDB operation failed: ${(event.target as IDBRequest<T>).error?.message ?? 'unknown'}`,
+            ),
+          )
+        }
+        tx.onerror = (event) => {
+          reject(
+            new Error(
+              `IndexedDB transaction failed: ${(event.target as IDBTransaction).error?.message ?? 'unknown'}`,
+            ),
+          )
+        }
+      }),
+  )
+}
+
+// ─── CRUD API ──────────────────────────────────────────────────────────────────
+
+/** Insert a new manual airport entry. Throws if it is structurally invalid. */
+// @IMP-AP-STORE-003@ (FROM: @REQ-AP-006@)
+export async function create(entry: ManualAirportEntry): Promise<void> {
+  const valid = assertManualAirportEntry(entry)
+  await withStore<IDBValidKey>('readwrite', (store) => store.add(valid))
+}
+
+/** Insert or replace a manual airport entry by id. Throws if invalid. */
+export async function update(entry: ManualAirportEntry): Promise<void> {
+  const valid = assertManualAirportEntry(entry)
+  await withStore<IDBValidKey>('readwrite', (store) => store.put(valid))
+}
+
+/** Retrieve one entry by id, or `undefined` when absent or unreadable. */
+export function findById(id: string): Promise<ManualAirportEntry | undefined> {
+  return withStore<unknown>('readonly', (store) => store.get(id) as IDBRequest<unknown>).then(
+    (doc) => (isManualAirportEntry(doc) ? doc : undefined),
+  )
+}
+
+/** Retrieve every readable entry; structurally invalid rows are skipped. */
+export function findAll(): Promise<ManualAirportEntry[]> {
+  return withStore<unknown[]>(
+    'readonly',
+    (store) => store.getAll() as IDBRequest<unknown[]>,
+  ).then((docs) => docs.filter(isManualAirportEntry))
+}
+
+/** Delete one entry by id. */
+export function deleteById(id: string): Promise<void> {
+  return withStore<undefined>('readwrite', (store) => store.delete(id)).then(() => undefined)
+}
+
+/** Delete every entry in the store. */
+export function deleteAll(): Promise<void> {
+  return withStore<undefined>('readwrite', (store) => store.clear()).then(() => undefined)
+}
+
+export const airportRepository = {
+  openDB,
+  create,
+  update,
+  findById,
+  findAll,
+  deleteById,
+  deleteAll,
+}

--- a/frontend/src/modules/airport/stores/__tests__/manual-airport.store.int.spec.ts
+++ b/frontend/src/modules/airport/stores/__tests__/manual-airport.store.int.spec.ts
@@ -1,0 +1,54 @@
+// @IT-AP-STORE-002@ (FROM: @IMP-AP-STORE-004@)
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { setActivePinia, createPinia } from 'pinia'
+import { useManualAirportStore } from '../manual-airport.store'
+import { _resetAirportDbHandleForTest } from '../../services/airport.repository'
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  })
+  _resetAirportDbHandleForTest()
+  setActivePinia(createPinia())
+})
+
+describe('manual airport store ↔ repository integration', () => {
+  it('persists overrides to IndexedDB and rehydrates them on reload (REQ-AP-006)', async () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateAirport({ name: 'Family Strip', elevationFt: 350 })
+    store.updateRunway({ designator: '27', toraM: 600 })
+    store.selectSurfaceCondition('paved-dry')
+    await store.saveEntry()
+
+    // Fresh store + fresh pinia, same IndexedDB factory → simulates a reload.
+    setActivePinia(createPinia())
+    const reloaded = useManualAirportStore()
+    await reloaded.loadAll()
+
+    expect(reloaded.loadState).toBe('READY')
+    expect(reloaded.savedEntries).toHaveLength(1)
+    const persisted = reloaded.savedEntries[0]!
+    expect(persisted.icao).toBe('ZZZZ')
+    expect(persisted.name).toBe('Family Strip')
+    expect(persisted.runway.toraM).toBe(600)
+    expect(persisted.runway.surfaceConditionId).toBe('paved-dry')
+  })
+
+  it('the manual-runway journey reaches a computable gate end to end (UJ-C-002)', async () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    expect(store.requestCompute().allowed).toBe(false)
+
+    store.updateRunway({ baseSurfaceType: 'grass', toraM: 600 })
+    store.selectSurfaceCondition('grass-dry')
+    expect(store.requestCompute().allowed).toBe(true)
+
+    await store.saveEntry()
+    expect(store.savedEntries).toHaveLength(1)
+  })
+})

--- a/frontend/src/modules/airport/stores/__tests__/manual-airport.store.spec.ts
+++ b/frontend/src/modules/airport/stores/__tests__/manual-airport.store.spec.ts
@@ -1,0 +1,183 @@
+// @UT-AP-STORE-003@ (FROM: @IMP-AP-STORE-004@)
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../services/airport.repository', () => ({
+  MANUAL_AIRPORT_SCHEMA_VERSION: 1,
+  airportRepository: {
+    update: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    findAll: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+  },
+}))
+
+import { airportRepository } from '../../services/airport.repository'
+import { useManualAirportStore } from '../manual-airport.store'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('searchByIcao (REQ-AP-003)', () => {
+  it('drops into manual-entry mode with the normalized ICAO when nothing is found', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao(' zzzz ')
+    expect(store.mode).toBe('manual-entry')
+    expect(store.entry?.icao).toBe('ZZZZ')
+  })
+
+  it('starts a fresh entry with no surface condition selected', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    expect(store.entry?.runway.surfaceConditionId).toBeNull()
+    expect(store.canCompute).toBe(false)
+  })
+})
+
+describe('airport-level overrides (REQ-AP-006)', () => {
+  it('applies name and elevation overrides to the current entry', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateAirport({ name: 'Family Strip', elevationFt: 350 })
+    expect(store.entry?.name).toBe('Family Strip')
+    expect(store.entry?.elevationFt).toBe(350)
+  })
+
+  it('ignores airport overrides when there is no active entry', () => {
+    const store = useManualAirportStore()
+    store.updateAirport({ name: 'Nowhere' })
+    expect(store.entry).toBeNull()
+  })
+})
+
+describe('override editing (REQ-AP-006)', () => {
+  it('applies runway overrides to the current entry', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateRunway({ toraM: 600, designator: '27' })
+    expect(store.entry?.runway.toraM).toBe(600)
+    expect(store.entry?.runway.designator).toBe('27')
+  })
+
+  it('ignores overrides when there is no active entry', () => {
+    const store = useManualAirportStore()
+    store.updateRunway({ toraM: 600 })
+    expect(store.entry).toBeNull()
+  })
+
+  it('clears an incompatible surface condition when the base surface type changes', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateRunway({ baseSurfaceType: 'grass' })
+    store.selectSurfaceCondition('grass-long')
+    store.updateRunway({ baseSurfaceType: 'paved' })
+    expect(store.entry?.runway.surfaceConditionId).toBeNull()
+  })
+})
+
+describe('selectSurfaceCondition (REQ-AP-004)', () => {
+  it('accepts a condition valid for the current base surface type', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.selectSurfaceCondition('paved-wet')
+    expect(store.entry?.runway.surfaceConditionId).toBe('paved-wet')
+  })
+
+  it('coerces an invalid cross-surface selection to none', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.selectSurfaceCondition('grass-long')
+    expect(store.entry?.runway.surfaceConditionId).toBeNull()
+  })
+})
+
+describe('requestCompute gate (REQ-AP-004, H-009)', () => {
+  it('blocks and records an inline rejection when the surface condition is missing', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateRunway({ toraM: 600 })
+    const result = store.requestCompute()
+    expect(result.allowed).toBe(false)
+    expect(store.rejection?.blockers).toContain('SURFACE_CONDITION_REQUIRED')
+  })
+
+  it('passes and clears the rejection once a valid condition and length are set', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateRunway({ toraM: 600 })
+    store.requestCompute()
+    store.selectSurfaceCondition('paved-dry')
+    const result = store.requestCompute()
+    expect(result.allowed).toBe(true)
+    expect(store.rejection).toBeNull()
+    expect(store.canCompute).toBe(true)
+  })
+
+  it('blocks compute when there is no active entry at all', () => {
+    const store = useManualAirportStore()
+    const result = store.requestCompute()
+    expect(result.allowed).toBe(false)
+    expect(store.rejection?.allowed).toBe(false)
+  })
+
+  it('clears a standing rejection on demand', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.requestCompute()
+    expect(store.rejection).not.toBeNull()
+    store.clearRejection()
+    expect(store.rejection).toBeNull()
+  })
+})
+
+describe('persistence + lifecycle', () => {
+  it('persists the current entry via the repository (REQ-AP-006)', async () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateRunway({ toraM: 600 })
+    await store.saveEntry()
+    expect(airportRepository.update).toHaveBeenCalledOnce()
+    expect(store.savedEntries).toHaveLength(1)
+  })
+
+  it('replaces the cached entry in place when the same runway is saved twice', async () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.updateRunway({ toraM: 600 })
+    await store.saveEntry()
+    store.updateRunway({ toraM: 720 })
+    await store.saveEntry()
+    expect(store.savedEntries).toHaveLength(1)
+    expect(store.savedEntries[0]?.runway.toraM).toBe(720)
+  })
+
+  it('does nothing when saving with no active entry', async () => {
+    const store = useManualAirportStore()
+    await store.saveEntry()
+    expect(airportRepository.update).not.toHaveBeenCalled()
+    expect(store.savedEntries).toHaveLength(0)
+  })
+
+  it('hydrates saved entries on loadAll', async () => {
+    const store = useManualAirportStore()
+    await store.loadAll()
+    expect(airportRepository.findAll).toHaveBeenCalledOnce()
+    expect(store.loadState).toBe('READY')
+  })
+
+  it('reports an error state when hydration fails', async () => {
+    vi.mocked(airportRepository.findAll).mockRejectedValueOnce(new Error('boom'))
+    const store = useManualAirportStore()
+    await store.loadAll()
+    expect(store.loadState).toBe('ERROR')
+    expect(store.loadError).toBe('boom')
+  })
+
+  it('resets back to the idle search state', () => {
+    const store = useManualAirportStore()
+    store.searchByIcao('ZZZZ')
+    store.reset()
+    expect(store.mode).toBe('idle')
+    expect(store.entry).toBeNull()
+  })
+})

--- a/frontend/src/modules/airport/stores/manual-airport.store.ts
+++ b/frontend/src/modules/airport/stores/manual-airport.store.ts
@@ -1,0 +1,195 @@
+/**
+ * Manual Airport Store — Pinia store for the manual airport-entry workflow.
+ * P2 Feature Module — orchestrates the airport repository + pure domain logic.
+ *
+ * Workflow: an ICAO lookup that finds nothing drops into manual-entry mode
+ * (REQ-AP-003); the pilot overrides runway parameters (REQ-AP-006) and must
+ * select a surface condition (REQ-AP-004) before performance computation is
+ * permitted. Online airport auto-population (REQ-AP-002) is deferred, so every
+ * lookup currently resolves to manual entry.
+ *
+ * @see docs/requirements/airport_database.md REQ-AP-003, REQ-AP-004, REQ-AP-006
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed, toRaw } from 'vue'
+import { v4 as uuidv4 } from 'uuid'
+import type {
+  AirportMode,
+  BaseSurfaceType,
+  ManualAirportEntry,
+  ManualRunwayOverrides,
+} from '../domain/airport.types'
+import { isValidSurfaceCondition } from '../domain/surface-conditions'
+import { evaluateComputeGate, type ComputeGateResult } from '../domain/compute-gate'
+import {
+  airportRepository,
+  MANUAL_AIRPORT_SCHEMA_VERSION,
+} from '../services/airport.repository'
+
+/** IndexedDB hydration lifecycle for UI feedback. */
+export type AirportLoadState = 'IDLE' | 'LOADING' | 'READY' | 'ERROR'
+
+function blankRunway(): ManualRunwayOverrides {
+  return {
+    designator: '',
+    magneticHeadingDeg: null,
+    baseSurfaceType: 'paved',
+    slopePercent: null,
+    toraM: null,
+    todaM: null,
+    asdaM: null,
+    ldaM: null,
+    surfaceConditionId: null,
+  }
+}
+
+function blankEntry(icao: string): ManualAirportEntry {
+  return {
+    id: uuidv4(),
+    icao,
+    name: '',
+    elevationFt: null,
+    runway: blankRunway(),
+    schemaVersion: MANUAL_AIRPORT_SCHEMA_VERSION,
+  }
+}
+
+// @IMP-AP-STORE-004@ (FROM: @REQ-AP-003@, @REQ-AP-004@, @REQ-AP-006@)
+export const useManualAirportStore = defineStore('manual-airport', () => {
+  // ─── State ────────────────────────────────────────────────────────────────
+
+  const mode = ref<AirportMode>('idle')
+  const entry = ref<ManualAirportEntry | null>(null)
+  const savedEntries = ref<ManualAirportEntry[]>([])
+  const loadState = ref<AirportLoadState>('IDLE')
+  const loadError = ref<string | null>(null)
+  /** The last blocked compute attempt, surfaced inline; cleared once the gate passes. */
+  const rejection = ref<ComputeGateResult | null>(null)
+
+  // ─── Getters ──────────────────────────────────────────────────────────────
+
+  /** Live gate evaluation for the current entry (REQ-AP-004). */
+  const gate = computed<ComputeGateResult | null>(() =>
+    entry.value ? evaluateComputeGate(entry.value) : null,
+  )
+  const canCompute = computed<boolean>(() => gate.value?.allowed ?? false)
+
+  // ─── Actions ──────────────────────────────────────────────────────────────
+
+  /**
+   * Look up an ICAO code. Online auto-population is deferred, so no match is
+   * ever found: the system drops into manual-entry mode with the ICAO
+   * pre-filled (REQ-AP-003).
+   */
+  function searchByIcao(icao: string): void {
+    const normalized = icao.trim().toUpperCase()
+    entry.value = blankEntry(normalized)
+    mode.value = 'manual-entry'
+    rejection.value = null
+  }
+
+  /** Override airport-level parameters (REQ-AP-006). */
+  function updateAirport(changes: Partial<Pick<ManualAirportEntry, 'icao' | 'name' | 'elevationFt'>>): void {
+    if (entry.value === null) return
+    entry.value = { ...entry.value, ...changes }
+    rejection.value = null
+  }
+
+  /**
+   * Override runway parameters (REQ-AP-006). Changing the base surface type
+   * clears a now-incompatible surface condition so an "ice on grass" style
+   * mismatch can never survive into the compute gate.
+   */
+  function updateRunway(changes: Partial<ManualRunwayOverrides>): void {
+    if (entry.value === null) return
+    const next: ManualRunwayOverrides = { ...entry.value.runway, ...changes }
+    if (!isValidSurfaceCondition(next.baseSurfaceType, next.surfaceConditionId)) {
+      next.surfaceConditionId = null
+    }
+    entry.value = { ...entry.value, runway: next }
+    rejection.value = null
+  }
+
+  /** Select the current surface condition (REQ-AP-004). Invalid ids are coerced to none. */
+  function selectSurfaceCondition(id: string | null): void {
+    if (entry.value === null) return
+    const base: BaseSurfaceType = entry.value.runway.baseSurfaceType
+    const accepted = isValidSurfaceCondition(base, id) ? id : null
+    entry.value = {
+      ...entry.value,
+      runway: { ...entry.value.runway, surfaceConditionId: accepted },
+    }
+    rejection.value = null
+  }
+
+  /**
+   * Attempt to proceed to performance computation. Returns the gate result and,
+   * when blocked, records it as an inline rejection (REQ-AP-004, H-009).
+   */
+  function requestCompute(): ComputeGateResult {
+    const result = gate.value ?? evaluateComputeGate(blankEntry(''))
+    rejection.value = result.allowed ? null : result
+    return result
+  }
+
+  function clearRejection(): void {
+    rejection.value = null
+  }
+
+  /** Persist the current entry's overrides to IndexedDB (REQ-AP-006). */
+  async function saveEntry(): Promise<void> {
+    if (entry.value === null) return
+    // IndexedDB structured-clone cannot serialise a Vue reactive proxy, so
+    // persist (and cache) a plain deep snapshot of the entry instead.
+    const snapshot: ManualAirportEntry = structuredClone(toRaw(entry.value))
+    await airportRepository.update(snapshot)
+    const idx = savedEntries.value.findIndex((e) => e.id === snapshot.id)
+    if (idx === -1) savedEntries.value.push(snapshot)
+    else savedEntries.value[idx] = snapshot
+  }
+
+  /** Hydrate persisted entries from IndexedDB. */
+  async function loadAll(): Promise<void> {
+    loadState.value = 'LOADING'
+    loadError.value = null
+    try {
+      savedEntries.value = await airportRepository.findAll()
+      loadState.value = 'READY'
+    } catch (err) {
+      loadState.value = 'ERROR'
+      loadError.value =
+        err instanceof Error ? err.message : 'Failed to load manual airports from storage.'
+    }
+  }
+
+  /** Discard the current entry and return to the idle search state. */
+  function reset(): void {
+    entry.value = null
+    mode.value = 'idle'
+    rejection.value = null
+  }
+
+  return {
+    // State
+    mode,
+    entry,
+    savedEntries,
+    loadState,
+    loadError,
+    rejection,
+    // Getters
+    gate,
+    canCompute,
+    // Actions
+    searchByIcao,
+    updateAirport,
+    updateRunway,
+    selectSurfaceCondition,
+    requestCompute,
+    clearRejection,
+    saveEntry,
+    loadAll,
+    reset,
+  }
+})

--- a/frontend/src/modules/airport/views/ManualAirportEntryView.vue
+++ b/frontend/src/modules/airport/views/ManualAirportEntryView.vue
@@ -1,0 +1,249 @@
+<template>
+  <section class="manual-airport-view">
+    <header class="manual-airport-header">
+      <h1>Airport</h1>
+      <p class="intro">
+        Enter an ICAO code. Unlisted strips drop into manual entry, where you provide and override
+        runway data yourself.
+      </p>
+    </header>
+
+    <form class="icao-search" @submit.prevent="onSearch">
+      <label for="icao-search-input">ICAO code</label>
+      <div class="icao-search-row">
+        <input
+          id="icao-search-input"
+          v-model="icaoQuery"
+          type="text"
+          maxlength="8"
+          autocomplete="off"
+          placeholder="e.g. ZZZZ"
+        />
+        <button type="submit" class="btn-primary" :disabled="icaoQuery.trim() === ''">Search</button>
+      </div>
+    </form>
+
+    <div v-if="store.mode === 'manual-entry' && store.entry" class="manual-entry">
+      <p class="manual-entry-banner" role="status">
+        “{{ store.entry.icao }}” was not found in any database — entering manually. The resulting
+        data is pilot-provided and unverified.
+      </p>
+
+      <fieldset class="field-block">
+        <legend>Airport</legend>
+        <div class="field-group">
+          <label for="airport-name">Name</label>
+          <input
+            id="airport-name"
+            type="text"
+            :value="store.entry.name"
+            @input="store.updateAirport({ name: ($event.target as HTMLInputElement).value })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="airport-elevation">Field elevation (ft)</label>
+          <DecimalInput
+            id="airport-elevation"
+            :model-value="store.entry.elevationFt"
+            :allow-null="true"
+            placeholder="e.g. 350"
+            @update:model-value="store.updateAirport({ elevationFt: $event })"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset class="field-block">
+        <legend>Runway</legend>
+        <div class="field-group">
+          <label for="runway-designator">Designator</label>
+          <input
+            id="runway-designator"
+            type="text"
+            maxlength="3"
+            :value="store.entry.runway.designator"
+            @input="store.updateRunway({ designator: ($event.target as HTMLInputElement).value })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="runway-heading">Magnetic heading (°M)</label>
+          <DecimalInput
+            id="runway-heading"
+            :model-value="store.entry.runway.magneticHeadingDeg"
+            :allow-null="true"
+            :min="0"
+            :max="360"
+            placeholder="e.g. 270"
+            @update:model-value="store.updateRunway({ magneticHeadingDeg: $event })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="runway-surface-type">Base surface type</label>
+          <select
+            id="runway-surface-type"
+            :value="store.entry.runway.baseSurfaceType"
+            @change="
+              store.updateRunway({
+                baseSurfaceType: ($event.target as HTMLSelectElement).value as BaseSurfaceType,
+              })
+            "
+          >
+            <option value="paved">Paved (asphalt / concrete)</option>
+            <option value="grass">Grass / unpaved</option>
+          </select>
+        </div>
+        <div class="field-group">
+          <label for="runway-tora">TORA (m)</label>
+          <DecimalInput
+            id="runway-tora"
+            :model-value="store.entry.runway.toraM"
+            :allow-null="true"
+            :min="0"
+            placeholder="e.g. 600"
+            @update:model-value="store.updateRunway({ toraM: $event })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="runway-toda">TODA (m)</label>
+          <DecimalInput
+            id="runway-toda"
+            :model-value="store.entry.runway.todaM"
+            :allow-null="true"
+            :min="0"
+            @update:model-value="store.updateRunway({ todaM: $event })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="runway-asda">ASDA (m)</label>
+          <DecimalInput
+            id="runway-asda"
+            :model-value="store.entry.runway.asdaM"
+            :allow-null="true"
+            :min="0"
+            @update:model-value="store.updateRunway({ asdaM: $event })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="runway-lda">LDA (m)</label>
+          <DecimalInput
+            id="runway-lda"
+            :model-value="store.entry.runway.ldaM"
+            :allow-null="true"
+            :min="0"
+            @update:model-value="store.updateRunway({ ldaM: $event })"
+          />
+        </div>
+        <div class="field-group">
+          <label for="runway-slope">Slope (%)</label>
+          <DecimalInput
+            id="runway-slope"
+            :model-value="store.entry.runway.slopePercent"
+            :allow-null="true"
+            @update:model-value="store.updateRunway({ slopePercent: $event })"
+          />
+        </div>
+        <SurfaceConditionSelect
+          select-id="runway-surface-condition"
+          :base="store.entry.runway.baseSurfaceType"
+          :model-value="store.entry.runway.surfaceConditionId"
+          @update:model-value="store.selectSurfaceCondition($event)"
+        />
+      </fieldset>
+
+      <p v-if="store.rejection" class="compute-rejection" role="alert">
+        {{ store.rejection.message }}
+      </p>
+      <p v-else-if="store.canCompute" class="compute-ready" role="status">
+        Runway data complete — ready to compute performance.
+      </p>
+
+      <div class="actions">
+        <button type="button" class="btn-secondary" @click="onSave">Save runway</button>
+        <button type="button" class="btn-primary" @click="store.requestCompute()">
+          Compute performance
+        </button>
+      </div>
+      <p v-if="saved" class="save-confirmation" role="status">Runway data saved.</p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+// @IMP-AP-VIEW-002@ (FROM: @REQ-AP-003@, @REQ-AP-004@, @REQ-AP-006@)
+import { ref } from 'vue'
+import DecimalInput from '@/shared/components/DecimalInput.vue'
+import type { BaseSurfaceType } from '../domain/airport.types'
+import { useManualAirportStore } from '../stores/manual-airport.store'
+import SurfaceConditionSelect from '../components/SurfaceConditionSelect.vue'
+
+const store = useManualAirportStore()
+const icaoQuery = ref('')
+const saved = ref(false)
+
+function onSearch(): void {
+  if (icaoQuery.value.trim() === '') return
+  store.searchByIcao(icaoQuery.value)
+  saved.value = false
+}
+
+async function onSave(): Promise<void> {
+  await store.saveEntry()
+  saved.value = true
+}
+</script>
+
+<style scoped>
+.manual-airport-view {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.icao-search-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.field-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.manual-entry-banner {
+  background: #fef3c7;
+  border-left: 4px solid #d97706;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+}
+
+.compute-rejection {
+  background: #fee2e2;
+  border-left: 4px solid #b91c1c;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+  color: #7f1d1d;
+}
+
+.compute-ready,
+.save-confirmation {
+  color: #065f46;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+</style>

--- a/frontend/src/modules/airport/views/__tests__/ManualAirportEntryView.spec.ts
+++ b/frontend/src/modules/airport/views/__tests__/ManualAirportEntryView.spec.ts
@@ -1,0 +1,97 @@
+// @UT-AP-VIEW-002@ (FROM: @IMP-AP-VIEW-002@)
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import ManualAirportEntryView from '../ManualAirportEntryView.vue'
+import { useManualAirportStore } from '../../stores/manual-airport.store'
+
+vi.mock('../../services/airport.repository', () => ({
+  MANUAL_AIRPORT_SCHEMA_VERSION: 1,
+  airportRepository: {
+    update: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    findAll: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+  },
+}))
+
+import { airportRepository } from '../../services/airport.repository'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+async function searchUnknownAirport() {
+  const wrapper = mount(ManualAirportEntryView)
+  await wrapper.find('#icao-search-input').setValue('zzzz')
+  await wrapper.find('form.icao-search').trigger('submit')
+  return wrapper
+}
+
+describe('ManualAirportEntryView', () => {
+  it('hides the manual-entry form until a search is run', () => {
+    const wrapper = mount(ManualAirportEntryView)
+    expect(wrapper.find('.manual-entry').exists()).toBe(false)
+  })
+
+  it('switches to manual entry with the ICAO echoed when no airport is found (REQ-AP-003)', async () => {
+    const wrapper = await searchUnknownAirport()
+    expect(wrapper.find('.manual-entry').exists()).toBe(true)
+    expect(wrapper.find('.manual-entry-banner').text()).toContain('ZZZZ')
+  })
+
+  it('blocks compute and shows an inline rejection without a surface condition (REQ-AP-004)', async () => {
+    const wrapper = await searchUnknownAirport()
+    const store = useManualAirportStore()
+    store.updateRunway({ toraM: 600 })
+    await wrapper.vm.$nextTick()
+    await wrapper.find('.actions .btn-primary').trigger('click')
+    const rejection = wrapper.find('.compute-rejection')
+    expect(rejection.exists()).toBe(true)
+    expect(rejection.text()).toMatch(/surface condition/i)
+  })
+
+  it('clears the block and signals ready once a surface condition is selected', async () => {
+    const wrapper = await searchUnknownAirport()
+    const store = useManualAirportStore()
+    store.updateRunway({ toraM: 600 })
+    await wrapper.find('#runway-surface-condition').setValue('paved-dry')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.compute-rejection').exists()).toBe(false)
+    expect(wrapper.find('.compute-ready').exists()).toBe(true)
+  })
+
+  it('binds every editable override field back to the store (REQ-AP-006)', async () => {
+    const wrapper = await searchUnknownAirport()
+    const store = useManualAirportStore()
+    await wrapper.find('#airport-name').setValue('Family Strip')
+    await wrapper.find('#airport-elevation').setValue('350')
+    await wrapper.find('#runway-designator').setValue('27')
+    await wrapper.find('#runway-heading').setValue('270')
+    await wrapper.find('#runway-surface-type').setValue('grass')
+    await wrapper.find('#runway-tora').setValue('600')
+    await wrapper.find('#runway-toda').setValue('640')
+    await wrapper.find('#runway-asda').setValue('620')
+    await wrapper.find('#runway-lda').setValue('580')
+    await wrapper.find('#runway-slope').setValue('1.5')
+    expect(store.entry?.name).toBe('Family Strip')
+    expect(store.entry?.elevationFt).toBe(350)
+    expect(store.entry?.runway.designator).toBe('27')
+    expect(store.entry?.runway.magneticHeadingDeg).toBe(270)
+    expect(store.entry?.runway.baseSurfaceType).toBe('grass')
+    expect(store.entry?.runway.toraM).toBe(600)
+    expect(store.entry?.runway.todaM).toBe(640)
+    expect(store.entry?.runway.asdaM).toBe(620)
+    expect(store.entry?.runway.ldaM).toBe(580)
+    expect(store.entry?.runway.slopePercent).toBe(1.5)
+  })
+
+  it('persists overrides when Save is pressed (REQ-AP-006)', async () => {
+    const wrapper = await searchUnknownAirport()
+    const store = useManualAirportStore()
+    store.updateRunway({ toraM: 600 })
+    await wrapper.find('.actions .btn-secondary').trigger('click')
+    await flushPromises()
+    expect(airportRepository.update).toHaveBeenCalledOnce()
+    expect(wrapper.find('.save-confirmation').exists()).toBe(true)
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -42,6 +42,12 @@ const router = createRouter({
       name: 'fleet-edit',
       component: () => import('@/modules/aircraft/views/AircraftProfileEditorView.vue'),
     },
+    // @IMP-UI-ROUTE-006@ (FROM: @REQ-AP-003@)
+    {
+      path: '/airport',
+      name: 'airport',
+      component: () => import('@/modules/airport/views/ManualAirportEntryView.vue'),
+    },
     // @IMP-UI-ROUTE-004@ (FROM: @REQ-SYS-014@, @REQ-SYS-015@)
     {
       path: '/privacy',

--- a/frontend/tests/e2e/features/phase-c-performance-safety/manual-airport-entry.feature
+++ b/frontend/tests/e2e/features/phase-c-performance-safety/manual-airport-entry.feature
@@ -1,0 +1,34 @@
+Feature: Manual airport entry for an unlisted airfield
+  As a pilot flying into an unregistered grass strip
+  I want to enter the runway by hand and confirm its surface condition
+  So that performance is computed from data I have verified myself
+
+  Background:
+    Given the pilot opens the airport page
+
+  # @E2E-C-001@ (FROM: @UJ-C-002@)
+  @UJ-C-002 @phase-C @e2e @module-ap @E2E-C-001
+  Scenario: An unknown ICAO offers manual airport entry
+    When the pilot searches for the unlisted airport "ZZZZ"
+    Then manual airport entry is offered for "ZZZZ"
+
+  # @E2E-C-002@ (FROM: @UJ-C-002@)
+  @UJ-C-002 @phase-C @e2e @module-ap @E2E-C-002
+  Scenario: Performance is refused until the surface condition is chosen
+    Given the pilot has entered a manual runway 600 m long
+    When the pilot tries to compute performance without a surface condition
+    Then performance computation is refused pending a surface condition
+
+  # @E2E-C-003@ (FROM: @UJ-C-002@)
+  @UJ-C-002 @phase-C @e2e @module-ap @E2E-C-003
+  Scenario: Choosing the surface condition unlocks the computation
+    Given the pilot has entered a manual runway 600 m long
+    When the pilot selects the runway surface condition "Dry"
+    Then performance computation is ready to proceed
+
+  # @E2E-C-004@ (FROM: @UJ-C-002@)
+  @UJ-C-002 @phase-C @e2e @module-ap @E2E-C-004
+  Scenario: Manual runway overrides are saved
+    Given the pilot has entered a manual runway 600 m long
+    When the pilot saves the manual runway
+    Then the runway data is confirmed saved

--- a/frontend/tests/e2e/steps/manual-airport-entry.steps.ts
+++ b/frontend/tests/e2e/steps/manual-airport-entry.steps.ts
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test'
+import { createBdd } from 'playwright-bdd'
+
+const { Given, When, Then } = createBdd()
+
+Given('the pilot opens the airport page', async ({ page }) => {
+  await page.goto('/airport')
+  await expect(page.locator('#icao-search-input')).toBeVisible()
+})
+
+When('the pilot searches for the unlisted airport {string}', async ({ page }, icao: string) => {
+  await page.locator('#icao-search-input').fill(icao)
+  await page.locator('form.icao-search button[type="submit"]').click()
+})
+
+Then('manual airport entry is offered for {string}', async ({ page }, icao: string) => {
+  await expect(page.locator('.manual-entry')).toBeVisible()
+  await expect(page.locator('.manual-entry-banner')).toContainText(icao)
+})
+
+Given('the pilot has entered a manual runway {int} m long', async ({ page }, length: number) => {
+  await page.locator('#icao-search-input').fill('ZZZZ')
+  await page.locator('form.icao-search button[type="submit"]').click()
+  await expect(page.locator('.manual-entry')).toBeVisible()
+  await page.locator('#runway-tora').fill(String(length))
+})
+
+When('the pilot tries to compute performance without a surface condition', async ({ page }) => {
+  await page.locator('.actions button.btn-primary').click()
+})
+
+Then('performance computation is refused pending a surface condition', async ({ page }) => {
+  const rejection = page.locator('.compute-rejection')
+  await expect(rejection).toBeVisible()
+  await expect(rejection).toContainText(/surface condition/i)
+})
+
+When('the pilot selects the runway surface condition {string}', async ({ page }, label: string) => {
+  await page.locator('#runway-surface-condition').selectOption({ label })
+})
+
+Then('performance computation is ready to proceed', async ({ page }) => {
+  await expect(page.locator('.compute-ready')).toBeVisible()
+})
+
+When('the pilot saves the manual runway', async ({ page }) => {
+  await page.locator('.actions button.btn-secondary').click()
+})
+
+Then('the runway data is confirmed saved', async ({ page }) => {
+  await expect(page.locator('.save-confirmation')).toBeVisible()
+})

--- a/trace/e2e/c.yaml
+++ b/trace/e2e/c.yaml
@@ -1,0 +1,28 @@
+C (auto)
+  E2E-C-001
+    title: Unknown ICAO offers manual airport entry
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/manual-airport-entry.feature
+    uj:
+      - UJ-C-002
+
+  E2E-C-002
+    title: Performance refused until the surface condition is chosen
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/manual-airport-entry.feature
+    uj:
+      - UJ-C-002
+
+  E2E-C-003
+    title: Choosing the surface condition unlocks the computation
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/manual-airport-entry.feature
+    uj:
+      - UJ-C-002
+
+  E2E-C-004
+    title: Manual runway overrides are saved
+    files:
+      - frontend/tests/e2e/features/phase-c-performance-safety/manual-airport-entry.feature
+    uj:
+      - UJ-C-002

--- a/trace/implementation/ap.yaml
+++ b/trace/implementation/ap.yaml
@@ -1,0 +1,46 @@
+AP (auto)
+  IMP-AP-VIEW-001
+    title: SurfaceConditionSelect — context-aware surface-condition selector
+    files:
+      - frontend/src/modules/airport/components/SurfaceConditionSelect.vue
+    req:
+      - REQ-AP-004
+
+  IMP-AP-STORE-002
+    title: evaluateComputeGate — blocks performance until a surface condition is selected
+    files:
+      - frontend/src/modules/airport/domain/compute-gate.ts
+    req:
+      - REQ-AP-004
+
+  IMP-AP-STORE-001
+    title: Surface-condition catalogue — predefined lists per base surface type
+    files:
+      - frontend/src/modules/airport/domain/surface-conditions.ts
+    req:
+      - REQ-AP-004
+
+  IMP-AP-STORE-003
+    title: Airport Repository — IndexedDB persistence for manual airport entries
+    files:
+      - frontend/src/modules/airport/services/airport.repository.ts
+    req:
+      - REQ-AP-006
+
+  IMP-AP-STORE-004
+    title: Manual Airport Store — manual-entry mode, overrides, compute gate, persistence
+    files:
+      - frontend/src/modules/airport/stores/manual-airport.store.ts
+    req:
+      - REQ-AP-003
+      - REQ-AP-004
+      - REQ-AP-006
+
+  IMP-AP-VIEW-002
+    title: ManualAirportEntryView — ICAO search, editable overrides, surface gate, save
+    files:
+      - frontend/src/modules/airport/views/ManualAirportEntryView.vue
+    req:
+      - REQ-AP-003
+      - REQ-AP-004
+      - REQ-AP-006

--- a/trace/implementation/ui.yaml
+++ b/trace/implementation/ui.yaml
@@ -156,6 +156,13 @@ UI (auto)
       - DES-ARCH-011
       - DES-ARCH-012
 
+  IMP-UI-ROUTE-006
+    title: Airport route — /airport manual airport-entry view
+    files:
+      - frontend/src/router/index.ts
+    req:
+      - REQ-AP-003
+
 UI — Contribution hub (#395)
   IMP-UI-SHARED-009
     title: Contribution environment helper — auto-detected environment string for the defect form

--- a/trace/integration_test/ap.yaml
+++ b/trace/integration_test/ap.yaml
@@ -1,0 +1,14 @@
+AP (auto)
+  IT-AP-STORE-001
+    title: Airport Repository — IndexedDB CRUD round-trip with fake-indexeddb
+    files:
+      - frontend/src/modules/airport/services/__tests__/airport.repository.int.spec.ts
+    impl:
+      - IMP-AP-STORE-003
+
+  IT-AP-STORE-002
+    title: Manual Airport Store ↔ repository — overrides persist and rehydrate
+    files:
+      - frontend/src/modules/airport/stores/__tests__/manual-airport.store.int.spec.ts
+    impl:
+      - IMP-AP-STORE-004

--- a/trace/unit_test/ap.yaml
+++ b/trace/unit_test/ap.yaml
@@ -1,0 +1,35 @@
+AP (auto)
+  UT-AP-VIEW-001
+    title: SurfaceConditionSelect — renders context-aware lists and emits selection
+    files:
+      - frontend/src/modules/airport/components/__tests__/SurfaceConditionSelect.spec.ts
+    impl:
+      - IMP-AP-VIEW-001
+
+  UT-AP-STORE-002
+    title: evaluateComputeGate — surface-condition and runway-length blockers
+    files:
+      - frontend/src/modules/airport/domain/__tests__/compute-gate.spec.ts
+    impl:
+      - IMP-AP-STORE-002
+
+  UT-AP-STORE-001
+    title: Surface-condition catalogue — list, validity, and label resolution
+    files:
+      - frontend/src/modules/airport/domain/__tests__/surface-conditions.spec.ts
+    impl:
+      - IMP-AP-STORE-001
+
+  UT-AP-STORE-003
+    title: Manual Airport Store — mode, overrides, gate, persistence lifecycle
+    files:
+      - frontend/src/modules/airport/stores/__tests__/manual-airport.store.spec.ts
+    impl:
+      - IMP-AP-STORE-004
+
+  UT-AP-VIEW-002
+    title: ManualAirportEntryView — search, gate rejection, override binding, save
+    files:
+      - frontend/src/modules/airport/views/__tests__/ManualAirportEntryView.spec.ts
+    impl:
+      - IMP-AP-VIEW-002


### PR DESCRIPTION
### Summary

Manual airport-entry module (P2, `frontend/src/modules/airport/`) for unlisted/unknown airfields:

- **Manual-entry fallback** when an ICAO is not found — online auto-population (REQ-AP-002) is deferred, so every lookup resolves to manual entry (REQ-AP-003).
- **Context-aware surface-condition catalogue** (Paved vs Grass/Unpaved lists, per REQ-AP-004) plus a **mandatory pre-compute gate** that blocks performance computation until a surface condition is selected. The gate is fail-safe — it blocks rather than defaulting a friction class (mitigates **H-009**: surface-factor errors).
- **Editable airport/runway overrides** (designator, magnetic heading, base surface, slope, TORA/TODA/ASDA/LDA, field elevation) persisted to IndexedDB and rehydrated on reload (REQ-AP-006).
- Pure domain logic + Pinia store + SFCs + `/airport` route. No P1/`src/core/` change; no Zod in P2 (plain structural validation at the persistence boundary).

This is the only sub-task of feature #302, so the feature is delivered in full here.

### Related Issues

Closes #312
Closes #302

### Issue State Management (Post-Merge)

- [x] If merging to `develop`: Issues auto-closed by `Closes #` keyword; verify Issue Label is `fixed` & Project Status is `Done`

### Affected Items

- **Requirements Implemented/Affected:** `REQ-AP-003`, `REQ-AP-004` (H-009), `REQ-AP-006` → all set to `Implemented`

### Documentation Updates

- [x] **Requirements:** Updated `REQ-AP-003/004/006` status → `Implemented` in `docs/requirements/airport_database.md`
- [x] **Architecture:** `N/A` (Reason: no new P1 interface/surface; P2 module within existing module pattern, no ADR-worthy change)
- [x] **Risk Management:** `N/A` (Reason: H-009 already registered & `Mitigated`; this PR delivers part of its mitigation via REQ-AP-004 — no hazard-register change required)
- [x] **Journeys:** Updated `UJ-C-002` upstream to cite `REQ-AP-004` in `docs/journeys/03_performance_safety.md`
- [x] **Code Docs:** `N/A` (Reason: CHANGELOG reserved for the release process per the implement-issue workflow)

### Safety Considerations

- [x] Checked Safety Traceability Matrix.
- [x] No new hazards introduced.
- [x] Existing mitigations preserved.
- [x] P1 isolation maintained (no new P2/P3 imports in core modules — this PR does not touch `src/core/`).

### Quality & Testing Checklist

- [x] **Target Branch:** This PR correctly targets `develop`.
- [x] **Unit Tests:** Added/updated and passing locally (full suite **1745 passed**; 43 new airport specs covering catalogue, gate, store, components, view).
- [x] **Integration Tests:** Passing (**96 passed**; IndexedDB CRUD + store↔repository persist/rehydrate round-trip).
- [x] **Manual Testing:** UJ-C-002 E2E **4/4 scenarios pass in chromium** against the real dev server; `pnpm build` succeeds.
- [x] **DoD:** All Definition of Done items from #312 and #302 are met and attested `[x]` on both issues.
- [x] **Review:** Performed a self-review of code and documentation.
- [x] **ADR:** `N/A` — no P1 interface change; no architectural decision introduced.

### Verification (local pipeline)

`pnpm lint` ✓ (oxlint + eslint + structural trace gate + markdownlint) · `pnpm --filter frontend type-check` ✓ · `pnpm test:unit` ✓ (1745) · `pnpm test:integration` ✓ (96) · `pnpm build` ✓ · UJ-C-002 E2E ✓ (chromium 4/4).

### What remains

- **Project board not updated in this run:** the `claude[bot]` token has no Projects v2 access (`gh project list` → `totalCount: 0`), so the *In Progress* → *In Verification* column moves could not be performed here. The ready-gate workflow / a maintainer handles board status. Everything else for #312 and #302 is complete.
